### PR TITLE
Configurable recording-indicator position (#125)

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -99,7 +99,19 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         let y = max(screenFrame.minY, min(anchorBottomY, screenFrame.maxY - window.frame.height))
         window.setFrameOrigin(NSPoint(x: x, y: y))
     }
-    
+
+    /// Briefly shows the indicator at the configured position (without recording) so the user
+    /// can see where it will appear. Used by the position picker's "Preview" button.
+    func preview() {
+        guard viewModel == nil else { return } // don't interfere with a live recording
+        let vm = show(nearPoint: FocusUtils.getCurrentCursorPosition())
+        vm.state = .recording
+        vm.isBlinking = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) { [weak self] in
+            self?.hide()
+        }
+    }
+
     func stopRecording() {
         viewModel?.startDecoding()
     }

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -55,12 +55,24 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         if let window = window, let screen = targetScreen {
             let screenFrame = screen.frame
 
-            if let point = point {
-                anchorBottomY = point.y + 20 // sit just above the caret
-                anchorCenterX = point.x
-            } else {
-                anchorBottomY = screenFrame.maxY - 260 // a stable band near the top
+            switch AppPreferences.shared.indicatorPosition {
+            case "top":
                 anchorCenterX = screenFrame.midX
+                anchorBottomY = screenFrame.maxY - 140
+            case "center":
+                anchorCenterX = screenFrame.midX
+                anchorBottomY = screenFrame.midY
+            case "bottom":
+                anchorCenterX = screenFrame.midX
+                anchorBottomY = screenFrame.minY + 120
+            default: // "cursor": sit just above the caret, falling back to a band near the top
+                if let point = point {
+                    anchorBottomY = point.y + 20
+                    anchorCenterX = point.x
+                } else {
+                    anchorBottomY = screenFrame.maxY - 260
+                    anchorCenterX = screenFrame.midX
+                }
             }
 
             reposition(window: window, screen: screen)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -147,6 +147,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var indicatorPosition: String {
+        didSet {
+            AppPreferences.shared.indicatorPosition = indicatorPosition
+        }
+    }
+
     @Published var liveTranscriptionEnabled: Bool {
         didSet {
             AppPreferences.shared.liveTranscriptionEnabled = liveTranscriptionEnabled
@@ -332,6 +338,7 @@ class SettingsViewModel: ObservableObject {
         self.debugMode = prefs.debugMode
         self.playSoundOnRecordStart = prefs.playSoundOnRecordStart
         self.startHidden = prefs.startHidden
+        self.indicatorPosition = prefs.indicatorPosition
         self.liveTranscriptionEnabled = prefs.liveTranscriptionEnabled
         self.useAsianAutocorrect = prefs.useAsianAutocorrect
         self.modifierOnlyHotkey = ModifierKey(rawValue: prefs.modifierOnlyHotkey) ?? .none
@@ -1782,8 +1789,23 @@ struct SettingsView: View {
                     Text("Recording Behavior")
                         .font(.headline)
                         .foregroundColor(.primary)
-                    
+
                     VStack(alignment: .leading, spacing: 12) {
+                        SettingRow(
+                            title: "Indicator position",
+                            caption: "Where the recording indicator appears.",
+                            info: "Near cursor (default) shows it just above your text caret. Top, Center or Bottom pin it to the middle of the screen instead."
+                        ) {
+                            Picker("", selection: $viewModel.indicatorPosition) {
+                                Text("Near cursor").tag("cursor")
+                                Text("Top").tag("top")
+                                Text("Center").tag("center")
+                                Text("Bottom").tag("bottom")
+                            }
+                            .labelsHidden()
+                            .frame(width: 140)
+                        }
+
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("Hold to Record")

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1796,14 +1796,21 @@ struct SettingsView: View {
                             caption: "Where the recording indicator appears.",
                             info: "Near cursor (default) shows it just above your text caret. Top, Center or Bottom pin it to the middle of the screen instead."
                         ) {
-                            Picker("", selection: $viewModel.indicatorPosition) {
-                                Text("Near cursor").tag("cursor")
-                                Text("Top").tag("top")
-                                Text("Center").tag("center")
-                                Text("Bottom").tag("bottom")
+                            HStack(spacing: 8) {
+                                Picker("", selection: $viewModel.indicatorPosition) {
+                                    Text("Near cursor").tag("cursor")
+                                    Text("Top").tag("top")
+                                    Text("Center").tag("center")
+                                    Text("Bottom").tag("bottom")
+                                }
+                                .labelsHidden()
+                                .frame(width: 140)
+                                Button("Preview") {
+                                    IndicatorWindowManager.shared.preview()
+                                }
+                                .controlSize(.small)
+                                .help("Briefly show the indicator at this position")
                             }
-                            .labelsHidden()
-                            .frame(width: 140)
                         }
 
                         HStack {

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -153,6 +153,10 @@ final class AppPreferences {
     @UserDefault(key: "postRecordHookCommand", defaultValue: "")
     var postRecordHookCommand: String
 
+    /// Where the recording indicator appears: "cursor" (default), "top", "center", "bottom".
+    @UserDefault(key: "indicatorPosition", defaultValue: "cursor")
+    var indicatorPosition: String
+
     /// Strip filler words (um, uh, …) from the transcription before saving/inserting. Opt-in.
     @UserDefault(key: "removeFillerWords", defaultValue: false)
     var removeFillerWords: Bool


### PR DESCRIPTION
## What
Adds a **configurable position for the recording indicator** — the second half of #125 (the first half, *Start in the Menu Bar*, shipped in v0.2.2).

A new **Indicator position** setting under **General → Recording Behavior**:
- **Near cursor** (default) — the existing behaviour, just above the text caret.
- **Top / Center / Bottom** — pinned to the middle of the active screen.

## How
- New `indicatorPosition` preference (default `"cursor"`).
- `IndicatorWindowManager` chooses the anchor from the preference; the window still auto-sizes and grows from that anchor.
- Picker in Settings.

## Testing
- ✅ Builds clean.
- ⏳ Visual smoke pending (each position on screen) — I couldn't self-verify the on-screen placement here; please check the four options when you get a chance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
