### PR TITLE
Updates tab: check for updates + What's New

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -852,6 +852,13 @@ struct SettingsView: View {
                     Label("Advanced", systemImage: "gear")
                 }
                 .tag(4)
+
+            // Updates / What's New
+            UpdatesView()
+                .tabItem {
+                    Label("Updates", systemImage: "sparkles")
+                }
+                .tag(5)
             }
         .padding()
         .frame(width: 550)

--- a/OpenSuperWhisper/UpdatesView.swift
+++ b/OpenSuperWhisper/UpdatesView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The "Updates" settings tab: shows the current version, a manual update check, and the
+/// release-note history pulled from GitHub Releases.
+struct UpdatesView: View {
+    @State private var releases: [GitHubRelease] = []
+    @State private var isChecking = false
+    @State private var availableUpdate: GitHubRelease?
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                versionCard
+                whatsNewSection
+            }
+            .padding()
+        }
+        .task { await loadReleases() }
+    }
+
+    private var versionCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Version")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            HStack(spacing: 10) {
+                Text("OpenSuperWhisper \(UpdateChecker.currentVersion)")
+                    .font(.subheadline)
+
+                Spacer()
+
+                Button(action: { Task { await checkForUpdates() } }) {
+                    if isChecking {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Check for Updates")
+                    }
+                }
+                .disabled(isChecking)
+            }
+
+            if let update = availableUpdate {
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.down.circle.fill").foregroundColor(.green)
+                    Text("Update available: \(update.tagName)")
+                        .font(.subheadline)
+                    Button("Download") { NSWorkspace.shared.open(update.htmlURL) }
+                        .controlSize(.small)
+                }
+            } else if let statusMessage {
+                Label(statusMessage, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundColor(.green)
+            }
+
+            if let errorMessage {
+                Text(errorMessage).font(.caption).foregroundColor(.red)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    private var whatsNewSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("What's New")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            if releases.isEmpty {
+                Text("Loading release notes…")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                ForEach(releases) { release in
+                    releaseRow(release)
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    private func releaseRow(_ release: GitHubRelease) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(release.displayName).font(.subheadline).bold()
+                Spacer()
+                if let date = release.publishedAt {
+                    Text(date, style: .date).font(.caption).foregroundColor(.secondary)
+                }
+            }
+            if let body = release.body, !body.isEmpty {
+                Text(renderedNotes(body))
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Divider()
+        }
+    }
+
+    /// Render the markdown release notes, keeping line breaks (inline markdown only).
+    /// Header markers ("## ") are stripped since SwiftUI's inline markdown shows them literally.
+    private func renderedNotes(_ markdown: String) -> AttributedString {
+        let cleaned = markdown.replacingOccurrences(
+            of: "(?m)^#{1,6}[ \\t]+", with: "", options: .regularExpression)
+        return (try? AttributedString(
+            markdown: cleaned,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(cleaned)
+    }
+
+    private func loadReleases() async {
+        guard releases.isEmpty else { return }
+        releases = (try? await UpdateChecker.fetchReleases()) ?? []
+    }
+
+    private func checkForUpdates() async {
+        isChecking = true
+        errorMessage = nil
+        statusMessage = nil
+        availableUpdate = nil
+        defer { isChecking = false }
+        do {
+            let fetched = try await UpdateChecker.fetchReleases()
+            releases = fetched
+            if let update = UpdateChecker.availableUpdate(in: fetched) {
+                availableUpdate = update
+            } else {
+                statusMessage = "You're on the latest version."
+            }
+        } catch {
+            errorMessage = "Couldn't check for updates. Check your connection and try again."
+        }
+    }
+}

--- a/OpenSuperWhisper/Utils/UpdateChecker.swift
+++ b/OpenSuperWhisper/Utils/UpdateChecker.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A published GitHub release of the app.
+struct GitHubRelease: Decodable, Identifiable {
+    let tagName: String
+    let name: String?
+    let body: String?
+    let htmlURL: URL
+    let publishedAt: Date?
+    let prerelease: Bool
+
+    var id: String { tagName }
+    var displayName: String { (name?.isEmpty == false ? name : nil) ?? tagName }
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case name, body, prerelease
+        case htmlURL = "html_url"
+        case publishedAt = "published_at"
+    }
+}
+
+/// Checks for app updates and lists release notes via the public GitHub Releases API
+/// (no auth, no Sparkle). The actual download is a link to the release page.
+enum UpdateChecker {
+    static let repo = "my-monkeys/OpenSuperWhisper"
+    static let releasesURL = URL(string: "https://github.com/\(repo)/releases")!
+
+    static var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    static func fetchReleases() async throws -> [GitHubRelease] {
+        let url = URL(string: "https://api.github.com/repos/\(repo)/releases?per_page=30")!
+        var request = URLRequest(url: url, timeoutInterval: 15)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([GitHubRelease].self, from: data)
+            .filter { !$0.prerelease }
+    }
+
+    /// The newest stable release strictly newer than the running version, if any.
+    static func availableUpdate(in releases: [GitHubRelease]) -> GitHubRelease? {
+        releases.first { isVersion($0.tagName, newerThan: currentVersion) }
+    }
+
+    /// Numeric, component-wise semver-ish comparison ("v0.2.10" > "0.2.9").
+    static func isVersion(_ tag: String, newerThan current: String) -> Bool {
+        let a = components(tag), b = components(current)
+        for i in 0..<max(a.count, b.count) {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    private static func components(_ version: String) -> [Int] {
+        let trimmed = version.hasPrefix("v") ? String(version.dropFirst()) : version
+        return trimmed.split(separator: ".").map { Int($0.prefix(while: \.isNumber)) ?? 0 }
+    }
+}


### PR DESCRIPTION
## What
Adds an **"Updates" settings tab** that covers two roadmap items:
- **Check for updates** — shows the current version with a "Check for Updates" button that compares the latest GitHub release tag to the running version ("You're on the latest version" / "Update available: vX.Y.Z" + Download link).
- **What's New / patch notes** — a scrollable list of release notes pulled from the repo's releases.

## How
- `UpdateChecker` + `GitHubRelease` hit the **public GitHub Releases API** — no auth, no Sparkle, no extra dependency. The "download" is just a link to the release page (full auto-update via Sparkle is a separate, later step that needs notarization).
- `UpdatesView` is the tab; release notes are rendered as markdown (header markers stripped).

## Testing
- ✅ Builds clean.
- ✅ Verified via screenshots: the tab renders, "Check for Updates" reports up-to-date on 0.2.5, and the What's New notes render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
