### PR TITLE
Distribution prep: notarized-release script + Homebrew cask + playbook

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Build → sign (Developer ID, hardened runtime) → DMG → notarize → staple.
+# Produces dist/OpenSuperWhisper-<VERSION>.dmg, ready to attach to a GitHub release.
+#
+# Required env:
+#   DEVELOPER_ID    e.g. "Developer ID Application: Maxim Costa (TEAMID)"
+#   NOTARY_PROFILE  notarytool keychain profile (see docs/DISTRIBUTION.md)
+#   VERSION         e.g. 0.3.0
+# Optional:
+#   SCHEME (default OpenSuperWhisper), APP_NAME (default OpenSuperWhisper)
+#
+# NOTE: this is the starting-point pipeline. It must be validated once a real Developer ID
+# certificate exists — in particular the bundled dylibs (libwhisper / libomp /
+# libautocorrect_swift) must each be Developer-ID-signed for notarization to pass.
+set -euo pipefail
+
+: "${DEVELOPER_ID:?set DEVELOPER_ID (Developer ID Application identity)}"
+: "${NOTARY_PROFILE:?set NOTARY_PROFILE (notarytool keychain profile)}"
+: "${VERSION:?set VERSION}"
+SCHEME="${SCHEME:-OpenSuperWhisper}"
+APP_NAME="${APP_NAME:-OpenSuperWhisper}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+DIST="$ROOT/dist"
+BUILD="$ROOT/build-release"
+rm -rf "$DIST" "$BUILD"
+mkdir -p "$DIST"
+
+echo "==> Building native dependencies (libwhisper, autocorrect, libomp)…"
+./run.sh build
+
+echo "==> Building Release with Xcode…"
+xcodebuild -scheme "$SCHEME" -configuration Release -derivedDataPath "$BUILD" \
+  -destination 'generic/platform=macOS' \
+  CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="$DEVELOPER_ID" \
+  OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime" \
+  build
+
+APP="$BUILD/Build/Products/Release/$APP_NAME.app"
+[ -d "$APP" ] || { echo "App not found at $APP" >&2; exit 1; }
+
+echo "==> Signing bundled dylibs + app (hardened runtime)…"
+find "$APP/Contents" -name "*.dylib" -print0 | while IFS= read -r -d '' lib; do
+  codesign --force --timestamp --options runtime --sign "$DEVELOPER_ID" "$lib"
+done
+codesign --force --deep --timestamp --options runtime --sign "$DEVELOPER_ID" "$APP"
+codesign --verify --strict --verbose=2 "$APP"
+
+echo "==> Packaging DMG…"
+DMG="$DIST/$APP_NAME-$VERSION.dmg"
+STAGE="$(mktemp -d)"
+cp -R "$APP" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+hdiutil create -volname "$APP_NAME" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
+rm -rf "$STAGE"
+codesign --force --timestamp --sign "$DEVELOPER_ID" "$DMG"
+
+echo "==> Notarizing (uploads to Apple and waits)…"
+xcrun notarytool submit "$DMG" --keychain-profile "$NOTARY_PROFILE" --wait
+
+echo "==> Stapling…"
+xcrun stapler staple "$DMG"
+xcrun stapler validate "$DMG"
+
+echo "==> Done."
+shasum -a 256 "$DMG"

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,78 @@
+# Distribution — notarized release + Homebrew
+
+This is the playbook to ship a **notarized** OpenSuperWhisper build, publish it as a GitHub
+release artifact, and install it via Homebrew. The app is **not** App-Store distributed, so it
+must be signed with a **Developer ID Application** certificate and notarized by Apple, otherwise
+Gatekeeper blocks it.
+
+## ⚠️ Decisions needed first (Maxim)
+
+The repo is still on the upstream identity. Before the first real release, decide:
+
+1. **Apple team for distribution.** The project's `DEVELOPMENT_TEAM` is `8LLDD7HWZK` (Starmel's,
+   inherited from the fork). Pick one of *your* teams to own the Developer ID cert + notarization.
+2. **Bundle identifier.** Currently `ru.starmel.OpenSuperWhisper`. Keep it, or move to a
+   My-Monkey one (e.g. `fr.my-monkey.opensuperwhisper`). Changing it resets existing users'
+   preferences/permissions, so decide early.
+
+Once decided, set `DEVELOPMENT_TEAM` + `PRODUCT_BUNDLE_IDENTIFIER` in the Xcode project.
+
+## One-time Apple setup
+
+1. **Developer ID Application certificate**
+   - Keychain Access → Certificate Assistant → *Request a Certificate from a Certificate
+     Authority* → save the CSR to disk.
+   - https://developer.apple.com/account/resources/certificates/list → **+** → *Developer ID
+     Application* (on the chosen team) → upload the CSR → download the `.cer` → double-click to
+     install it into the **login** keychain.
+   - Verify: `security find-identity -v -p codesigning` should now list a
+     `Developer ID Application: … (<TEAMID>)` identity.
+
+2. **Notarization credentials** (App Store Connect API key — preferred for CI)
+   - https://appstoreconnect.apple.com/access/integrations/api → **+** → role *Developer* →
+     download the `.p8` (once only) and note the **Key ID** + **Issuer ID**.
+   - Store a reusable notarytool profile:
+     ```sh
+     xcrun notarytool store-credentials osw-notary \
+       --key /path/to/AuthKey_XXXX.p8 --key-id <KEY_ID> --issuer <ISSUER_ID>
+     ```
+   - (Alternative: an app-specific password from https://account.apple.com → Sign-In & Security.)
+
+## Cutting a release
+
+```sh
+# from the repo root
+DEVELOPER_ID="Developer ID Application: Maxim Costa (<TEAMID>)" \
+NOTARY_PROFILE="osw-notary" \
+VERSION="0.3.0" \
+./Scripts/release.sh
+```
+
+`Scripts/release.sh` builds Release, signs with the Developer ID + hardened runtime, packages a
+DMG, notarizes it, staples the ticket, and leaves `dist/OpenSuperWhisper-<version>.dmg` ready to
+attach to the GitHub release:
+
+```sh
+gh release create <version> --repo my-monkeys/OpenSuperWhisper \
+  dist/OpenSuperWhisper-<version>.dmg --title "v<version> — …" --notes-file notes.md
+```
+
+## Homebrew cask
+
+`packaging/Casks/opensuperwhisper.rb` is the cask. After a release:
+
+1. Update `version` and `sha256` (`shasum -a 256 dist/OpenSuperWhisper-<version>.dmg`).
+2. Host it in a tap repo, e.g. `my-monkeys/homebrew-tap`, then:
+   ```sh
+   brew tap my-monkeys/tap
+   brew install --cask opensuperwhisper
+   ```
+
+## Auto-update (Sparkle) — later
+
+For in-app auto-update (beyond the existing "Check for Updates" tab), add **Sparkle**:
+- Add the `Sparkle` SPM package; set `SUFeedURL` (an `appcast.xml` hosted on the releases) and a
+  generated EdDSA public key (`SUPublicEDKey`) in Info.plist.
+- Sign each release with Sparkle's `sign_update`, append the item to `appcast.xml`.
+- Updates only install cleanly when the app is Developer-ID-signed + notarized (above), which is
+  why this comes after the notarization setup.

--- a/packaging/Casks/opensuperwhisper.rb
+++ b/packaging/Casks/opensuperwhisper.rb
@@ -1,0 +1,27 @@
+# Homebrew cask for OpenSuperWhisper.
+#
+# Template — fill in `version` and `sha256` after each notarized release
+# (`shasum -a 256 dist/OpenSuperWhisper-<version>.dmg`), then host this file in a tap
+# (e.g. my-monkeys/homebrew-tap). See docs/DISTRIBUTION.md.
+cask "opensuperwhisper" do
+  version "0.0.0"
+  sha256 "REPLACE_WITH_DMG_SHA256"
+
+  url "https://github.com/my-monkeys/OpenSuperWhisper/releases/download/#{version}/OpenSuperWhisper-#{version}.dmg",
+      verified: "github.com/my-monkeys/OpenSuperWhisper/"
+  name "OpenSuperWhisper"
+  desc "macOS dictation with local Whisper/Parakeet transcription"
+  homepage "https://github.com/my-monkeys/OpenSuperWhisper"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :sonoma"
+
+  app "OpenSuperWhisper.app"
+
+  zap trash: [
+    "~/Library/Application Support/ru.starmel.OpenSuperWhisper",
+    "~/Library/Preferences/ru.starmel.OpenSuperWhisper.plist",
+    "~/Library/Caches/ru.starmel.OpenSuperWhisper",
+    "~/Library/Application Support/FluidAudio",
+  ]
+end


### PR DESCRIPTION
## What
Prep for **notarized distribution + Homebrew** (no Apple-account changes in this PR):
- **docs/DISTRIBUTION.md** — the playbook, including the two decisions only you can make:
  1. which of your Apple teams owns the **Developer ID Application** cert (project is currently on Starmel's team `8LLDD7HWZK`);
  2. keep the `ru.starmel.OpenSuperWhisper` bundle id or move to a My-Monkey one.
- **Scripts/release.sh** — build → Developer-ID sign (hardened runtime) → DMG → notarize → staple.
- **packaging/Casks/opensuperwhisper.rb** — Homebrew cask template.

## Why it stops here
You don't have a **Developer ID Application** certificate yet (only Apple Development / Apple Distribution), and creating it requires choosing a team + bundle id — your calls, and irreversible on your account, so I didn't create it autonomously. Once you decide, it's a ~10-minute setup (in the doc) and the script + cask are ready. Sparkle auto-update comes after that.

## Testing
- ✅ `bash -n` / `ruby -c` syntax-checked. The pipeline itself needs a real Developer ID cert to run end-to-end (noted in the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
