### PR TITLE
i18n foundation + initial French (String Catalog)

### DIFF
--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -508,6 +508,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				fr,
 				Base,
 			);
 			mainGroup = CE57B01F2D52C7BB00929AF3;

--- a/OpenSuperWhisper/Localizable.xcstrings
+++ b/OpenSuperWhisper/Localizable.xcstrings
@@ -1,0 +1,84 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "Add Word" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ajouter un mot" } } }
+    },
+    "Advanced" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Avancé" } } }
+    },
+    "Cancel" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Annuler" } } }
+    },
+    "Check for Updates" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher des mises à jour" } } }
+    },
+    "Check for Updates…" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher des mises à jour…" } } }
+    },
+    "Couldn't check for updates. Check your connection and try again." : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Impossible de vérifier les mises à jour. Vérifiez votre connexion et réessayez." } } }
+    },
+    "Done" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Terminé" } } }
+    },
+    "Download" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Télécharger" } } }
+    },
+    "General" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Général" } } }
+    },
+    "History" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Historique" } } }
+    },
+    "Language" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Langue" } } }
+    },
+    "Later" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Plus tard" } } }
+    },
+    "Loading release notes…" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Chargement des notes de version…" } } }
+    },
+    "Loading Parakeet Model..." : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Chargement du modèle Parakeet…" } } }
+    },
+    "Loading Whisper Model..." : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Chargement du modèle Whisper…" } } }
+    },
+    "Microphone" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Microphone" } } }
+    },
+    "Model" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Modèle" } } }
+    },
+    "No microphones available" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucun microphone disponible" } } }
+    },
+    "Open Folder" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Ouvrir le dossier" } } }
+    },
+    "Quit" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Quitter" } } }
+    },
+    "Transcription" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Transcription" } } }
+    },
+    "Updates" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Mises à jour" } } }
+    },
+    "Version" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Version" } } }
+    },
+    "What's New" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Nouveautés" } } }
+    },
+    "You're on the latest version." : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Vous avez déjà la dernière version." } } }
+    },
+    "You're up to date" : {
+      "localizations" : { "fr" : { "stringUnit" : { "state" : "translated", "value" : "Vous êtes à jour" } } }
+    }
+  }
+}

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -191,7 +191,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         
         menu.addItem(NSMenuItem(title: "OpenSuperWhisper", action: #selector(openApp), keyEquivalent: "o"))
         
-        let transcriptionLanguageItem = NSMenuItem(title: "Language", action: nil, keyEquivalent: "")
+        let transcriptionLanguageItem = NSMenuItem(title: NSLocalizedString("Language", comment: ""), action: nil, keyEquivalent: "")
         languageSubmenu = NSMenu()
         
         // Add language options
@@ -217,14 +217,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         
         menu.addItem(NSMenuItem.separator())
         
-        let microphoneMenu = NSMenuItem(title: "Microphone", action: nil, keyEquivalent: "")
+        let microphoneMenu = NSMenuItem(title: NSLocalizedString("Microphone", comment: ""), action: nil, keyEquivalent: "")
         let submenu = NSMenu()
         
         let microphones = microphoneService.availableMicrophones
         let currentMic = microphoneService.currentMicrophone
         
         if microphones.isEmpty {
-            let noDeviceItem = NSMenuItem(title: "No microphones available", action: nil, keyEquivalent: "")
+            let noDeviceItem = NSMenuItem(title: NSLocalizedString("No microphones available", comment: ""), action: nil, keyEquivalent: "")
             noDeviceItem.isEnabled = false
             submenu.addItem(noDeviceItem)
         } else {
@@ -273,12 +273,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         
         menu.addItem(NSMenuItem.separator())
 
-        let updateItem = NSMenuItem(title: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        let updateItem = NSMenuItem(title: NSLocalizedString("Check for Updates…", comment: ""), action: #selector(checkForUpdates), keyEquivalent: "")
         updateItem.target = self
         menu.addItem(updateItem)
 
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q"))
+        menu.addItem(NSMenuItem(title: NSLocalizedString("Quit", comment: ""), action: #selector(quitApp), keyEquivalent: "q"))
 
         statusItem?.menu = menu
     }


### PR DESCRIPTION
## What
Lays the **internationalization** groundwork and ships an initial **French** translation.

- Adds a `Localizable.xcstrings` String Catalog and the `fr` region.
- SwiftUI `Text`/`Label`/`Button` localize automatically via the catalog; the AppKit **menu-bar** titles are wrapped in `NSLocalizedString`.
- Translated the most visible strings (menu bar, Settings tabs, Updates view, common buttons). The catalog makes adding the remaining strings incremental.

## Testing
- ✅ Builds; the catalog compiles to `fr.lproj/Localizable.strings` in the bundle (verified).
- Try it: `open OpenSuperWhisper.app --args -AppleLanguages "(fr)"` → menu + Settings tabs in French.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
