### PR TITLE
Sparkle in-place auto-update

### DIFF
--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		840156D42D79EDBA00FB5FFE /* libggml-cpu.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156CB2D79ED9900FB5FFE /* libggml-cpu.a */; };
 		840156D52D79EDBA00FB5FFE /* libggml-metal.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 840156CD2D79ED9900FB5FFE /* libggml-metal.a */; };
 		CE0EAD6E2D56ACA80067FDEE /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = CE0EAD6D2D56ACA80067FDEE /* GRDB */; };
+		5BA9E0DA0000000000000A03 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 5BA9E0DA0000000000000A02 /* Sparkle */; };
 		CE84DF6E2D55777800C54EA6 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF6D2D55777800C54EA6 /* libc++.tbd */; };
 		CE84DF712D55778000C54EA6 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF6F2D55778000C54EA6 /* Metal.framework */; };
 		CE84DF722D55778000C54EA6 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE84DF702D55778000C54EA6 /* MetalKit.framework */; };
@@ -220,6 +221,7 @@
 				840156D12D79EDA900FB5FFE /* libggml.a in Frameworks */,
 				CE84E17D2D56550B00C54EA6 /* KeyboardShortcuts in Frameworks */,
 				CEAC00032D82F00200000000 /* libautocorrect_swift.dylib in Frameworks */,
+				5BA9E0DA0000000000000A03 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,6 +431,7 @@
 				CE84E17C2D56550B00C54EA6 /* KeyboardShortcuts */,
 				CE0EAD6D2D56ACA80067FDEE /* GRDB */,
 				CE84E17E2D56550B00C54EA7 /* FluidAudio */,
+				5BA9E0DA0000000000000A02 /* Sparkle */,
 			);
 			productName = OpenSuperWhisper;
 			productReference = CE57B0282D52C7BB00929AF3 /* OpenSuperWhisper.app */;
@@ -516,6 +519,7 @@
 				CE84E17B2D56550B00C54EA6 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
 				CE0EAD6C2D56ACA80067FDEE /* XCRemoteSwiftPackageReference "GRDB.swift" */,
 				CE84E17D2D56550B00C54EA7 /* XCRemoteSwiftPackageReference "FluidAudio" */,
+				5BA9E0DA0000000000000A01 /* XCRemoteSwiftPackageReference "Sparkle" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = CE57B0292D52C7BB00929AF3 /* Products */;
@@ -1050,6 +1054,14 @@
 				minimumVersion = 0.7.9;
 			};
 		};
+		5BA9E0DA0000000000000A01 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1067,6 +1079,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CE84E17D2D56550B00C54EA7 /* XCRemoteSwiftPackageReference "FluidAudio" */;
 			productName = FluidAudio;
+		};
+		5BA9E0DA0000000000000A02 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5BA9E0DA0000000000000A01 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenSuperWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b52b70f493c6c228eeb95f6561d91dd41131a6d3eba456cfebe020d41814380",
+  "originHash" : "497507a3520c08aaf12e552e774044d4ee9485607a0f83d9893347bc7c121b52",
   "pins" : [
     {
       "identity" : "fluidaudio",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "045cf174010beb335fa1d2567d18c057b8787165",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {

--- a/OpenSuperWhisper/OpenSuperWhisper-Info.plist
+++ b/OpenSuperWhisper/OpenSuperWhisper-Info.plist
@@ -25,5 +25,11 @@
 	<string>OpenSuperWhisper needs accessibility access to provide system-wide functionality.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>OpenSuperWhisper needs accessibility access to provide system-wide functionality.</string>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/my-monkeys/OpenSuperWhisper/master/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>ECQpCBVVumUKoBjgcDPSlmllYiWlSAUFGh5WycBhCA0=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
 </dict>
 </plist>

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -285,30 +285,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     @objc private func checkForUpdates() {
         NSApp.activate(ignoringOtherApps: true)
-        Task { @MainActor in
-            let alert = NSAlert()
-            do {
-                let releases = try await UpdateChecker.fetchReleases()
-                if let update = UpdateChecker.availableUpdate(in: releases) {
-                    alert.messageText = "Update available: \(update.tagName)"
-                    alert.informativeText = "You're on \(UpdateChecker.currentVersion). Open the release page to download it?"
-                    alert.addButton(withTitle: "Download")
-                    alert.addButton(withTitle: "Later")
-                    if alert.runModal() == .alertFirstButtonReturn {
-                        NSWorkspace.shared.open(update.htmlURL)
-                    }
-                } else {
-                    alert.messageText = "You're up to date"
-                    alert.informativeText = "OpenSuperWhisper \(UpdateChecker.currentVersion) is the latest version."
-                    alert.addButton(withTitle: "OK")
-                    alert.runModal()
-                }
-            } catch {
-                alert.messageText = "Couldn't check for updates"
-                alert.informativeText = "Check your connection and try again."
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
-            }
+        MainActor.assumeIsolated {
+            SparkleUpdater.shared.checkForUpdates()
         }
     }
     

--- a/OpenSuperWhisper/Utils/SparkleUpdater.swift
+++ b/OpenSuperWhisper/Utils/SparkleUpdater.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Sparkle
+
+/// Thin wrapper around Sparkle's standard updater. Sparkle reads `SUFeedURL` and `SUPublicEDKey`
+/// from Info.plist, fetches the appcast, and performs verified in-place download + install.
+@MainActor
+final class SparkleUpdater {
+    static let shared = SparkleUpdater()
+
+    private let controller: SPUStandardUpdaterController
+
+    private init() {
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    /// Manual check — shows Sparkle's UI (up-to-date, or the update prompt).
+    func checkForUpdates() {
+        controller.checkForUpdates(nil)
+    }
+}

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>OpenSuperWhisper</title>
+    <description>Updates for OpenSuperWhisper</description>
+    <language>en</language>
+    <item>
+      <title>0.3.0</title>
+      <link>https://github.com/my-monkeys/OpenSuperWhisper/releases/tag/v0.3.0</link>
+      <sparkle:version>15</sparkle:version>
+      <sparkle:shortVersionString>0.3.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <pubDate>Sun, 22 Jun 2026 00:00:00 +0000</pubDate>
+      <enclosure
+        url="https://github.com/my-monkeys/OpenSuperWhisper/releases/download/v0.3.0/OpenSuperWhisper-0.3.0.dmg"
+        sparkle:edSignature="u7vZ4Mfuyv/9XJTzdCjMiGVeEp8cd/74WliDxkZKsqWjyJAQfaIgD3JBHr80Ijir1vBBal7KiWnuuEtl3zD0Bw=="
+        length="11105326"
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,8 +46,27 @@ brew install --cask my-monkeys/tap/opensuperwhisper
 > Use the full `my-monkeys/tap/` path — the bare `opensuperwhisper` resolves to the original
 > (unmaintained) cask in homebrew-cask, not this fork.
 
-## Auto-update (Sparkle) — not yet wired
+## Auto-update (Sparkle)
 
-The in-app "Check for Updates" (Settings → Updates, and the menu-bar item) compares the running
-version against the latest GitHub release and links to it. Full in-place auto-update via Sparkle
-would build on the Developer-ID signing above; not implemented yet.
+The app embeds **Sparkle**. The menu-bar **"Check for Updates…"** runs Sparkle's verified
+in-place download + install; the Settings → Updates tab still shows the GitHub release-note history.
+
+- Feed: `SUFeedURL` in Info.plist → `appcast.xml` at the repo root (served via
+  `https://raw.githubusercontent.com/my-monkeys/OpenSuperWhisper/master/appcast.xml`).
+- Signing key: an EdDSA keypair; the **public** key is `SUPublicEDKey` in Info.plist, the **private**
+  key lives in the login keychain (generated once via Sparkle's `generate_keys`).
+
+**Per release**, after building the notarized DMG (and before/with publishing it), append an item to
+`appcast.xml`:
+
+```sh
+# sign the DMG with the EdDSA private key (from the keychain)
+/path/to/Sparkle/bin/sign_update OpenSuperWhisper-$VERSION.dmg
+#   → sparkle:edSignature="…" length="…"
+```
+
+Add an `<item>` to `appcast.xml` with the new `<sparkle:shortVersionString>`, `<sparkle:version>`
+(= `CURRENT_PROJECT_VERSION`), the release-tag `<link>`, and an `<enclosure>` whose `url` is the
+GitHub release DMG, with the `sparkle:edSignature` and `length` from `sign_update`. Commit
+`appcast.xml` to `master` so the feed updates. (The Sparkle CLI tools come from the
+[Sparkle release tarball](https://github.com/sparkle-project/Sparkle/releases).)


### PR DESCRIPTION
## What
Adds **Sparkle** for verified, in-place auto-updates.

- Embeds Sparkle (SPM) and wires the menu-bar **"Check for Updates…"** to its download + install flow.
- `SUFeedURL` → `appcast.xml` (served from the repo via raw.githubusercontent), signed with an **EdDSA** key (public key in Info.plist, private key in the keychain).
- The Settings → Updates tab keeps the GitHub release-note history.
- `docs/RELEASING.md` documents the per-release appcast step (`sign_update` + add an `<item>`).

## Notes
- The appcast is already live at master; the **next** notarized release will be the first Sparkle-enabled build that can self-update.
- The EdDSA private key lives in @MaximCosta's login keychain — releasing from another machine needs it exported.

## Testing
- ✅ Builds; `Sparkle.framework` embeds in the bundle (verified). The appcast is valid and reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
