### PR TITLE
fix: stop window-resize stack overflow from SwiftUI/AppKit layout recursion (#11)

### DIFF
--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -42,7 +42,16 @@ struct OpenSuperWhisperApp: App {
         }
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 450, height: 650)
-        .windowResizability(.contentMinSize)
+        // NOTE: do NOT use .windowResizability(.contentMinSize) here. It makes
+        // SwiftUI's NSHostingView drive the window size from its content
+        // (updateAnimatedWindowSize), which fights the imperative AppKit geometry
+        // we set in AppDelegate (min/maxSize lock width to 450 and bound height
+        // 400–900, plus windowWillResize). The two authorities never agree on a
+        // fixed point, so windowDidLayout → updateAnimatedWindowSize → layout
+        // recurses until the stack overflows (EXC_BAD_ACCESS on resize, #11).
+        // .automatic leaves window sizing to AppKit, which already fully expresses
+        // the desired geometry.
+        .windowResizability(.automatic)
         .commands {
             CommandGroup(replacing: .newItem) {}
             CommandGroup(replacing: .appSettings) {


### PR DESCRIPTION
## Summary

Fixes #11 — the `EXC_BAD_ACCESS (SIGSEGV)` stack-overflow crash on window resize caused by unbounded SwiftUI/AppKit layout recursion (`windowDidLayout → updateAnimatedWindowSize → layout → …`).

## Root cause

The main `WindowGroup` declared `.windowResizability(.contentMinSize)`, which makes SwiftUI's `NSHostingView` drive the window's size from its content (`updateAnimatedWindowSize`). At the same time, `AppDelegate` **imperatively** governs that very same window's geometry:

- `windowWillResize(_:to:)` pins the width to `450`
- `window.minSize` / `window.maxSize` bound it to `450×400` … `450×900`

So there are two sizing authorities for one window. Every size SwiftUI applies from the content gets overridden by the AppKit constraints/delegate, which triggers another layout pass, which re-enters `updateAnimatedWindowSize`. The two never converge on a fixed point, so on window resize the cycle recurses until the main thread exhausts its stack.

This matches the reported crash exactly (verified against a real `.ips` from build 26 / macOS 26):

```
EXC_BAD_ACCESS (SIGSEGV) — "Thread stack size exceeded due to excessive recursion"
… NSPerformVisuallyAtomicChange
→ NSHostingView.windowDidLayout()
→ NSHostingView.updateAnimatedWindowSize(_:)
```

## Fix

Switch the main window to `.windowResizability(.automatic)`, leaving window sizing to AppKit alone. The imperative constraints already fully express the intended geometry (fixed `450` width, resizable `400–900` height), so dropping SwiftUI's content-driven sizing removes the competing authority and breaks the recursion — with no change to how the window actually behaves for users.

The Settings window also uses `.contentMinSize`, but it has **no** competing AppKit delegate/constraints (no `windowWillResize`, no imperative `min`/`maxSize`), so it isn't subject to this cycle and is intentionally left unchanged.

```diff
 .windowStyle(.hiddenTitleBar)
 .defaultSize(width: 450, height: 650)
-.windowResizability(.contentMinSize)
+.windowResizability(.automatic)
```

## Testing / verification

- Confirmed the diagnosis against an actual crash report (build 26, macOS 26): top-of-stack and recursion loop match #11 frame-for-frame.
- `swiftc -parse` on the edited file is clean.
- Full `./run.sh build` runs in CI (`.github/workflows/build.yml`) on a runner with full Xcode; I couldn't run the Xcode build on my machine (Command Line Tools only). **Marking this a draft until CI is green** / a maintainer confirms the resize no longer crashes.

This is a one-line scene-configuration change with no behavioral change to the window's bounds, so manual repro is: resize the main window repeatedly (the action that previously triggered the crash) and confirm it stays stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
