### PR TITLE
fix(indicator): break layout-recursion stack-overflow at recording-stop (#11)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,26 @@ jobs:
       - name: Make run.sh executable
         run: chmod +x ./run.sh
       - name: Build with run.sh
-        run: ./run.sh build 
+        run: ./run.sh build
+      # Run the regression suite. Reuses the build's `build/` derivedData and
+      # `SourcePackages/` clone (NOT a fresh resolve) so the FluidAudio
+      # swiftLanguageVersions patch applied by run.sh stays in effect — a fresh
+      # derivedData re-resolves an unpatched FluidAudio, tripping Swift-6
+      # data-race errors and breaking the test target's link. Flags mirror
+      # run.sh's xcodebuild invocation; `-test-without-building` is avoided
+      # because run.sh only builds the app scheme, not the OpenSuperWhisperTests
+      # bundle, so `test` builds the (small) test target against the cached deps.
+      - name: Test OpenSuperWhisperTests (reuse build's derivedData + SourcePackages)
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -scheme OpenSuperWhisper \
+            -configuration Debug \
+            -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath build \
+            -clonedSourcePackagesDirPath SourcePackages \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            -skipUnavailableActions \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcpretty --simple --color

--- a/OpenSuperWhisper/Engines/StreamingTranscriptionController.swift
+++ b/OpenSuperWhisper/Engines/StreamingTranscriptionController.swift
@@ -26,6 +26,16 @@ final class StreamingTranscriptionController: ObservableObject {
 
     private init() {}
 
+    /// TEST-ONLY injection point for the live-caption text. Drives the same `@Published`
+    /// properties the real streaming callback writes (see the `onUpdate` path), so the hosted
+    /// `IndicatorWindow` re-evaluates `bubbleWidth` and the hosting controller re-probes
+    /// `preferredContentSize` exactly as a live session would — without a microphone. Reachable
+    /// only via `@testable import` (it is `internal`, not `public`); no production caller uses it.
+    func _testInjectCaption(confirmed: String, volatile: String = "") {
+        confirmedText = confirmed
+        volatileText = volatile
+    }
+
     /// Starts streaming. Throws if models/mic can't be set up — callers should fall back to the
     /// file-based flow. `boostTerms` (the custom dictionary's terms) bias recognition when present.
     func start(boostTerms: [String]) async throws {

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -17,9 +17,16 @@ class IndicatorWindowManager: IndicatorViewDelegate {
     private var anchorFromTop = false
     private var anchorTopY: CGFloat = 0
     private var resizeObserver: NSObjectProtocol?
+    // True while a deferred reposition is pending (set before the async dispatch, cleared in its
+    // defer). NOT "currently repositioning" — it marks that one reposition is already scheduled
+    // for the next runloop, so a nested didResizeNotification during the same burst is a no-op.
     // Recursion-guard backstop (Option C): bounds reposition to one in-flight pass even if
-    // layout scheduling shifts (macOS 26/Tahoe). Nested reposition calls become no-ops.
-    private var isRepositioning = false
+    // layout scheduling shifts (macOS 26/Tahoe).
+    private var isRepositionPending = false
+    // One-shot: if the guard above ever drops a nested call, log it ONCE. A trip means a
+    // residual layout loop is being coalesced on this macOS build — the only in-the-field
+    // signal that Option C is doing work (the async dispatch alone wasn't enough).
+    private var hasLoggedRepositionPendingTrip = false
 
     private init() {}
     
@@ -127,13 +134,23 @@ class IndicatorWindowManager: IndicatorViewDelegate {
     /// Coalesces re-anchoring to the next runloop turn so `setFrameOrigin` never executes
     /// inside the layout pass that posted `didResizeNotification`. A burst of resizes (e.g. the
     /// stop-time settle storm) collapses to a single deferred `reposition` once layout settles,
-    /// and `isRepositioning` bounds reposition to one in-flight pass — no synchronous re-entry.
+    /// and `isRepositionPending` bounds reposition to one in-flight pass — no synchronous re-entry.
     private func scheduleReposition(window: NSWindow, screen: NSScreen) {
-        guard !isRepositioning else { return } // already a deferred reposition pending
-        isRepositioning = true
+        guard !isRepositionPending else {
+            // A nested reposition arrived while one was already pending — the guard dropped it.
+            // Log once so a residual layout loop (a sign the async dispatch alone isn't fully
+            // breaking re-entry on this macOS build) is observable in unified logging:
+            //   log show --predicate 'subsystem == "fr.my-monkey.opensuperwhisper"' --last 30m
+            if !hasLoggedRepositionPendingTrip {
+                hasLoggedRepositionPendingTrip = true
+                Diag.log.fault("Indicator reposition recursion-guard tripped — nested layout re-entry coalesced (#11)")
+            }
+            return
+        }
+        isRepositionPending = true
         DispatchQueue.main.async { [weak self, weak window] in
             guard let self else { return }
-            defer { self.isRepositioning = false }
+            defer { self.isRepositionPending = false }
             // Re-derive the screen inside the deferred turn — the window may have moved screens
             // since the notification fired. Falls back to the firing-time screen, then main.
             guard let window, let resolvedScreen = window.screen ?? screen ?? NSScreen.main else { return }

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -17,6 +17,9 @@ class IndicatorWindowManager: IndicatorViewDelegate {
     private var anchorFromTop = false
     private var anchorTopY: CGFloat = 0
     private var resizeObserver: NSObjectProtocol?
+    // Recursion-guard backstop (Option C): bounds reposition to one in-flight pass even if
+    // layout scheduling shifts (macOS 26/Tahoe). Nested reposition calls become no-ops.
+    private var isRepositioning = false
 
     private init() {}
     
@@ -87,14 +90,19 @@ class IndicatorWindowManager: IndicatorViewDelegate {
 
             reposition(window: window, screen: screen)
 
-            // Keep the bottom edge anchored as the content (and window) grows upward.
-            if resizeObserver == nil {
-                resizeObserver = NotificationCenter.default.addObserver(
-                    forName: NSWindow.didResizeNotification, object: window, queue: .main
-                ) { [weak self, weak window] _ in
-                    guard let self, let window, let screen = window.screen ?? NSScreen.main else { return }
-                    self.reposition(window: window, screen: screen)
-                }
+            // Re-anchor the bottom/top edge as the content (and window) resizes.
+            // Added fresh on every show() and removed in hide() (see teardown) so the
+            // observer's lifecycle is symmetric with the window's visibility — it never
+            // lingers across show/hide cycles. A lingering observer firing reposition()
+            // during the stop-time settle storm is part of the #11 crash chain.
+            resizeObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didResizeNotification, object: window, queue: .main
+            ) { [weak self, weak window] _ in
+                guard let self, let window, let screen = window.screen ?? NSScreen.main else { return }
+                // Re-anchor asynchronously so setFrameOrigin never runs inside the in-flight
+                // layout pass that posted this didResizeNotification — synchronous frame
+                // mutation mid-layout is the #11 re-entrancy that overflowed the stack.
+                self.scheduleReposition(window: window, screen: screen)
             }
         }
 
@@ -114,6 +122,23 @@ class IndicatorWindowManager: IndicatorViewDelegate {
 
         window?.orderFront(nil)
         return newViewModel
+    }
+
+    /// Coalesces re-anchoring to the next runloop turn so `setFrameOrigin` never executes
+    /// inside the layout pass that posted `didResizeNotification`. A burst of resizes (e.g. the
+    /// stop-time settle storm) collapses to a single deferred `reposition` once layout settles,
+    /// and `isRepositioning` bounds reposition to one in-flight pass — no synchronous re-entry.
+    private func scheduleReposition(window: NSWindow, screen: NSScreen) {
+        guard !isRepositioning else { return } // already a deferred reposition pending
+        isRepositioning = true
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self else { return }
+            defer { self.isRepositioning = false }
+            // Re-derive the screen inside the deferred turn — the window may have moved screens
+            // since the notification fired. Falls back to the firing-time screen, then main.
+            guard let window, let resolvedScreen = window.screen ?? screen ?? NSScreen.main else { return }
+            self.reposition(window: window, screen: resolvedScreen)
+        }
     }
 
     private func reposition(window: NSWindow, screen: NSScreen) {
@@ -152,17 +177,27 @@ class IndicatorWindowManager: IndicatorViewDelegate {
 
     func hide() {
         KeyboardShortcuts.disable(.escape)
-        
+
+        // Tear down the resize observer BEFORE the hide animation so the stop-time
+        // settle storm (isVisible spring + scaleEffect/opacity + bubbleWidth collapse)
+        // can't drive any further reposition() calls. The window is already anchored;
+        // the hide-out animation fades/scales in place and does not re-anchor.
+        // (#11: a never-removed observer was the cross-cycle half of the crash chain.)
+        if let resizeObserver {
+            NotificationCenter.default.removeObserver(resizeObserver)
+            self.resizeObserver = nil
+        }
+
         Task {
             guard let viewModel = self.viewModel else { return }
-            
+
             await viewModel.hideWithAnimation()
             viewModel.cleanup()
-            
+
             self.window?.contentView = nil
             self.window?.orderOut(nil)
             self.viewModel = nil
-            
+
             NotificationCenter.default.post(name: .indicatorWindowDidHide, object: nil)
         }
     }

--- a/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
+++ b/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
@@ -14,7 +14,7 @@ import XCTest
 ///   (1) observer add/remove symmetry — added fresh on `show()`, removed in `hide()`;
 ///   (2) `scheduleReposition` dispatches `reposition` to the next runloop turn so
 ///       `setFrameOrigin` never runs inside the layout pass that posted the notification;
-///   (3) `isRepositioning` recursion-guard coalesces a nested burst.
+///   (3) `isRepositionPending` recursion-guard coalesces a nested burst.
 ///
 /// These tests assert the OBSERVABLE contracts of that fix, not the private flags:
 ///   - observer removed on hide() → no reposition after teardown
@@ -114,7 +114,7 @@ final class IndicatorLayoutRecursionTests: XCTestCase {
         drainMainRunloop(seconds: 0.1) // let the initial show() reposition settle
         let baseline = FrameOriginCounter.shared.count
 
-        // Burst of resizes while visible — scheduleReposition's isRepositioning guard
+        // Burst of resizes while visible — scheduleReposition's isRepositionPending guard
         // coalesces these to a SINGLE deferred reposition.
         for _ in 0..<6 {
             NotificationCenter.default.post(

--- a/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
+++ b/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// Regression tests for the Indicator layout-recursion stack-overflow (#11).
+///
+/// The crash was an unbounded SwiftUI/AppKit layout feedback loop on the
+/// recording-stop transition: `NSHostingController` `sizingOptions=[.preferredContentSize]`
+/// drives `NSHostingView.updateAnimatedWindowSize` on every SwiftUI size change, and a
+/// `didResizeNotification` observer called `reposition()→setFrameOrigin()` synchronously
+/// inside the in-flight layout pass, re-entering `updateAnimatedWindowSize` unboundedly
+/// (~6,795 levels → 56 MB guard page → SIGSEGV).
+///
+/// The fix (commit on `IndicatorWindowManager.swift`):
+///   (1) observer add/remove symmetry — added fresh on `show()`, removed in `hide()`;
+///   (2) `scheduleReposition` dispatches `reposition` to the next runloop turn so
+///       `setFrameOrigin` never runs inside the layout pass that posted the notification;
+///   (3) `isRepositioning` recursion-guard coalesces a nested burst.
+///
+/// These tests assert the OBSERVABLE contracts of that fix, not the private flags:
+///   - observer removed on hide() → no reposition after teardown
+///   - setFrameOrigin deferred out of the layout pass (no synchronous re-entry)
+///   - no runaway layout on the stop transition (count-budget + wall-clock timeout)
+///   - pill-growth preserved (window still resizes to fit growing content)
+///
+/// The observable seam is `NSWindow.setFrameOrigin(_:)`, counted via a swizzle. A
+/// counter that increments from within a `didResizeNotification` observer's synchronous
+/// call frame proves re-entry; a counter that only increments on a later runloop turn
+/// proves the deferral.
+///
+/// `./run.sh build` is a hard prereq — the test target links the app target which links
+/// the native dylibs (autocorrect / onnxruntime / libwhisper). Build artifacts must be
+/// present before this target compiles/links.
+///
+/// `@MainActor`: `IndicatorWindowManager` and `IndicatorViewModel` are main-actor-isolated,
+/// so all `show()`/`hide()`/`window`/`viewModel` access must run on the main actor. XCTest
+/// runs `@MainActor` test classes' methods on the main actor, which is also where the AppKit
+/// windowing + `DispatchQueue.main.async` deferred reposition fire — so the runloop draining
+/// below actually pumps the same queue the fix dispatches to.
+@MainActor
+final class IndicatorLayoutRecursionTests: XCTestCase {
+
+    private var swizzleToken: NSObjectProtocol?
+    /// Increments on every `NSWindow.setFrameOrigin(_:)` call, tagged with whether the
+    /// call happened on the main runloop's current pass vs a deferred turn.
+    private var setFrameOriginCount = 0
+
+    override func setUp() {
+        super.setUp()
+        setFrameOriginCount = 0
+        FrameOriginCounter.installIfNeeded()
+        FrameOriginCounter.shared.reset()
+    }
+
+    override func tearDown() {
+        // Ensure no indicator window lingers between tests (singleton state isolation).
+        IndicatorWindowManager.shared.stopForce()
+        // Drain any deferred scheduleReposition dispatched during the test.
+        drainMainRunloop(seconds: 0.2)
+        super.tearDown()
+    }
+
+    // MARK: - P0: observer removed on hide()
+
+    /// After show() → hide() (+ draining the async Task), posting a didResizeNotification
+    /// to the indicator window must NOT cause any further setFrameOrigin call. This proves
+    /// the observer is removed in hide() and does not linger across cycles (the
+    /// cross-cycle half of the #11 crash chain).
+    ///
+    /// Counter-test-by-revert (source-only revert of fix commit `eed859c`):
+    ///   this test FAILS pre-fix (observer never removed → reposition still fires after
+    ///   hide). Coupled to the regression. See also testSetFrameOriginDeferredOutOfLayoutPass
+    ///   and testObserverActiveWhileShown_SingleCoalescedReposition, which fail pre-fix too.
+    func testObserverRemovedOnHide_NoFurtherReposition() {
+        let manager = IndicatorWindowManager.shared
+        let vm = manager.show(nearPoint: nil)
+        XCTAssertNotNil(manager.window, "show() must install a window")
+
+        // Tear down synchronously where possible: hide() enqueues a Task, so drive the
+        // VM through the delegate path and drain.
+        vm.cleanup()
+        manager.hide()
+        drainMainRunloop(seconds: 0.3) // let hide()'s Task complete + any deferred reposition settle
+
+        let baseline = FrameOriginCounter.shared.count
+
+        // Simulate the stop-time settle storm: post a burst of resizes to the window.
+        // If the observer were still installed, scheduleReposition → reposition →
+        // setFrameOrigin would fire on the next runloop turn.
+        if let window = manager.window {
+            for _ in 0..<5 {
+                NotificationCenter.default.post(
+                    name: NSWindow.didResizeNotification, object: window)
+            }
+        }
+        drainMainRunloop(seconds: 0.3) // give any deferred dispatch room to fire
+
+        let delta = FrameOriginCounter.shared.count - baseline
+        XCTAssertEqual(delta, 0,
+            "Observer must be removed on hide(); a didResizeNotification after teardown "
+            + "must not trigger setFrameOrigin (got \(delta) call(s)).")
+    }
+
+    /// The observer IS active while shown: a resize while the indicator is visible must
+    /// still re-anchor (exactly one deferred setFrameOrigin, coalesced from a burst).
+    /// This is the positive-path counter-test to testObserverRemovedOnHide — it proves
+    /// the delta=0 above is because the observer is gone, not because counting is broken.
+    func testObserverActiveWhileShown_SingleCoalescedReposition() {
+        let manager = IndicatorWindowManager.shared
+        _ = manager.show(nearPoint: nil)
+        guard let window = manager.window else {
+            XCTFail("show() must install a window"); return
+        }
+
+        drainMainRunloop(seconds: 0.1) // let the initial show() reposition settle
+        let baseline = FrameOriginCounter.shared.count
+
+        // Burst of resizes while visible — scheduleReposition's isRepositioning guard
+        // coalesces these to a SINGLE deferred reposition.
+        for _ in 0..<6 {
+            NotificationCenter.default.post(
+                name: NSWindow.didResizeNotification, object: window)
+        }
+        drainMainRunloop(seconds: 0.3)
+
+        let delta = FrameOriginCounter.shared.count - baseline
+        // The coalescing guard bounds a burst to one in-flight pass. We don't assert an
+        // exact count (initial layout may add one), but it must be SMALL — a pre-fix
+        // synchronous loop would have re-entered unboundedly and crashed/exploded.
+        XCTAssertLessThanOrEqual(delta, 2,
+            "A resize burst while shown must coalesce to a small bounded number of "
+            + "reposition calls (got \(delta)); the pre-fix loop recursed unboundedly.")
+        XCTAssertGreaterThanOrEqual(delta, 1,
+            "Observer must still re-anchor while shown (got \(delta)); if 0, the "
+            + "observer-removed test above is green for the wrong reason.")
+    }
+
+    // MARK: - P0: setFrameOrigin deferred out of the layout pass (no synchronous re-entry)
+
+    /// The #11 re-entrancy was `setFrameOrigin` called synchronously inside the layout
+    /// pass that posted `didResizeNotification`. The fix dispatches reposition to the
+    /// next runloop turn. Assert: when a didResizeNotification fires, the resulting
+    /// setFrameOrigin does NOT happen within the same synchronous call frame — it happens
+    /// on a later runloop iteration.
+    func testSetFrameOriginDeferredOutOfLayoutPass() {
+        let manager = IndicatorWindowManager.shared
+        _ = manager.show(nearPoint: nil)
+        guard let window = manager.window else {
+            XCTFail("show() must install a window"); return
+        }
+        drainMainRunloop(seconds: 0.1)
+
+        // Within the synchronous handling of the notification, setFrameOrigin must NOT
+        // be called. We detect this by recording whether the count changed during the
+        // post() call itself.
+        let before = FrameOriginCounter.shared.count
+        NotificationCenter.default.post(
+            name: NSWindow.didResizeNotification, object: window)
+        let synchronousDelta = FrameOriginCounter.shared.count - before
+
+        XCTAssertEqual(synchronousDelta, 0,
+            "setFrameOrigin must NOT run synchronously inside the didResizeNotification "
+            + "handler (got \(synchronousDelta) synchronous call(s)); the fix defers it. "
+            + "Synchronous frame mutation mid-layout is the #11 re-entrancy.")
+
+        // And it DOES happen once we drain the deferred dispatch — proving the deferral,
+        // not a no-op.
+        drainMainRunloop(seconds: 0.3)
+        let deferredDelta = FrameOriginCounter.shared.count - before
+        XCTAssertGreaterThanOrEqual(deferredDelta, 1,
+            "After draining the runloop, the deferred reposition must have run "
+            + "(got \(deferredDelta) total); if 0, reposition was dropped entirely.")
+    }
+
+    // MARK: - P0: no runaway layout on the recording-stop transition (count-budget + timeout)
+
+    /// Drives the literal crash path — caption growth then the recording-stop transition —
+    /// and asserts no runaway layout: setFrameOrigin count stays under a small budget and
+    /// the whole sequence completes within a wall-clock timeout. Pre-fix this path
+    /// overflowed the stack at ~6,795 recursion levels; any sane budget is a clean signal.
+    ///
+    /// No microphone / permissions: caption growth is simulated by publishing streaming
+    /// text, and the stop transition by flipping the view-model state.
+    ///
+    /// RESIDUAL — documented honestly (counter-test-by-revert, source-only revert of
+    /// `eed859c`): this test PASSES both pre-fix and post-fix on this dev machine's macOS,
+    /// because AppKit self-damps the synchronous re-entry to a bounded number of passes
+    /// here. The unbounded runaway only manifests under macOS 26/Tahoe's altered layout
+    /// timing (issue #11's trigger), which cannot be reproduced in this CI environment.
+    /// So this test is a defense-in-depth belt — it would fire only if re-entry became
+    /// unbounded on THIS OS too — NOT the primary regression anchor. The primary anchors
+    /// are testObserverRemovedOnHide_NoFurtherReposition and
+    /// testSetFrameOriginDeferredOutOfLayoutPass, which DO fail pre-fix. The macOS-26
+    /// runaway itself is covered by the manual Tahoe smoke (per the plan's test matrix).
+    func testNoRunawayLayoutOnRecordingStopTransition() {
+        let manager = IndicatorWindowManager.shared
+        let vm = manager.show(nearPoint: nil)
+
+        // Simulate caption growth (the live-transcription path that grows bubbleWidth).
+        let streaming = StreamingTranscriptionController.shared
+        vm.state = .recording
+        for i in 0..<8 {
+            streaming._testInjectCaption(confirmed: String(repeating: "word ", count: (i + 1) * 3))
+            drainMainRunloop(seconds: 0.05)
+        }
+
+        let baseline = FrameOriginCounter.shared.count
+
+        // The stop-time settle storm: hide() flips isVisible spring + scaleEffect/opacity
+        // + bubbleWidth collapse — three concurrent animated geometry changes that pre-fix
+        // re-entered updateAnimatedWindowSize unboundedly. Wrap in a wall-clock timeout.
+        let stopDeadline = Date(timeIntervalSinceNow: 5.0)
+        manager.hide()
+
+        // Pump the runloop until the hide Task + deferred repositions settle, or timeout.
+        while Date() < stopDeadline {
+            drainMainRunloop(seconds: 0.1)
+            // Once the window is torn down (viewModel nilled), the storm is over.
+            if manager.viewModel == nil && manager.window?.isVisible == false {
+                break
+            }
+        }
+
+        let totalDelta = FrameOriginCounter.shared.count - baseline
+
+        // COUNT BUDGET: pre-fix recursion was ~6,795 deep. A bounded budget of 50 is a
+        // 100x+ safety margin over any legitimate settle repositioning; if the loop were
+        // still present we'd see thousands (or a process crash).
+        XCTAssertLessThan(totalDelta, 50,
+            "Recording-stop transition must not drive a runaway number of setFrameOrigin "
+            + "calls (got \(totalDelta)); the pre-fix loop recursed ~6,795 times. "
+            + "A count under 50 proves the re-entrancy is broken.")
+
+        // WALL-CLOCK TIMEOUT: if we exited because the deadline passed (not because the
+        // window tore down), the sequence did not settle — a near-infinite loop symptom.
+        let settled = (manager.viewModel == nil)
+        XCTAssertTrue(settled,
+            "Recording-stop transition must settle (window torn down) within the timeout; "
+            + "if it didn't, a layout loop is still running.")
+    }
+
+    // MARK: - P1: pill-growth preserved (window still resizes to fit growing content)
+
+    /// `sizingOptions = [.preferredContentSize]` is RETAINED by the fix so the live-caption
+    /// pill still grows. Assert that growing the hosted content changes the window's
+    /// content size — i.e., auto-sizing was not removed wholesale.
+    ///
+    /// Counter-test-by-revert (source-only revert of `eed859c`): this test PASSES both
+    /// pre-fix and post-fix — CORRECTLY, because the fix deliberately retains
+    /// `.preferredContentSize` (growth is identical either way). This is a regression
+    /// guard for a behavior the fix must NOT break, not a guard for the bug itself.
+    func testPillGrowthPreserved_WindowResizesToFitContent() {
+        let manager = IndicatorWindowManager.shared
+        let vm = manager.show(nearPoint: nil)
+        guard let window = manager.window else {
+            XCTFail("show() must install a window"); return
+        }
+        vm.state = .recording
+        drainMainRunloop(seconds: 0.2)
+
+        let sizeBefore = window.contentView?.frame.size
+            ?? NSSize(width: 0, height: 0)
+
+        // Grow the caption substantially.
+        let streaming = StreamingTranscriptionController.shared
+        streaming._testInjectCaption(confirmed: String(repeating: "a growing caption ", count: 30))
+        // Give the hosting controller's preferredContentSize + the deferred reposition
+        // time to flow through.
+        drainMainRunloop(seconds: 0.4)
+
+        let sizeAfter = window.contentView?.frame.size
+            ?? NSSize(width: 0, height: 0)
+
+        // Width is the load-bearing growth dimension for the live caption (bubbleWidth).
+        // We assert width OR height grew — the pill grows to fit its content. The exact
+        // axis depends on layout, but a strictly-equal/zero-growth result would mean
+        // auto-sizing was broken.
+        let grew = (sizeAfter.width > sizeBefore.width + 1)
+            || (sizeAfter.height > sizeBefore.height + 1)
+        XCTAssertTrue(grew,
+            "Pill-growth must be preserved: growing the hosted caption content must grow "
+            + "the window content size. Before=\(sizeBefore), After=\(sizeAfter). "
+            + "If neither axis grew, the fix broke auto-sizing.")
+    }
+
+    // MARK: - Helpers
+
+    /// Pumps the main runloop so deferred `DispatchQueue.main.async` blocks
+    /// (scheduleReposition) and hide()'s `Task` get a chance to execute.
+    private func drainMainRunloop(seconds: TimeInterval) {
+        let deadline = Date(timeIntervalSinceNow: seconds)
+        while Date() < deadline {
+            RunLoop.current.run(
+                mode: .default,
+                before: Date(timeIntervalSinceNow: min(0.05, seconds)))
+        }
+    }
+}
+
+// MARK: - FrameOriginCounter (swizzle on NSWindow.setFrameOrigin)
+
+/// Counts `NSWindow.setFrameOrigin(_:)` invocations process-wide via a one-shot
+/// `dispatch_once`-style swizzle. This is the observable seam for "setFrameOrigin never
+/// runs inside the in-flight layout pass": a synchronous call inside a didResizeNotification
+/// handler increments the counter in the same call frame; a deferred call increments it on
+/// a later runloop turn.
+///
+/// Swizzling `setFrameOrigin` (not `updateAnimatedWindowSize`) is deliberate: setFrameOrigin
+/// is OUR reposition's terminal call and is a public AppKit API safe to swizzle, whereas
+/// `updateAnimatedWindowSize` is private SwiftUI and the fix specifically keeps it working
+/// (pill-growth depends on it). We assert on the observable consequence (frame origin
+/// mutation timing), not on SwiftUI internals.
+final class FrameOriginCounter {
+    static let shared = FrameOriginCounter()
+    private(set) var count = 0
+
+    private static var installed = false
+    private static let installLock = NSLock()
+
+    static func installIfNeeded() {
+        installLock.lock(); defer { installLock.unlock() }
+        guard !installed else { return }
+        installed = true
+
+        let cls: AnyClass = NSWindow.self
+        let original = class_getInstanceMethod(cls, #selector(NSWindow.setFrameOrigin(_:)))
+        let swizzled = class_getInstanceMethod(cls, #selector(NSWindow.osw_setFrameOrigin(_:)))
+        guard let original, let swizzled else { return }
+        method_exchangeImplementations(original, swizzled)
+    }
+
+    func reset() { count = 0 }
+    fileprivate func tick() { count += 1 }
+}
+
+private extension NSWindow {
+    @objc func osw_setFrameOrigin(_ point: NSPoint) {
+        FrameOriginCounter.shared.tick()
+        // Call the original (implementations are exchanged, so this is the original).
+        self.osw_setFrameOrigin(point)
+    }
+}

--- a/patches/fluidaudio-swift5-mode.patch
+++ b/patches/fluidaudio-swift5-mode.patch
@@ -1,0 +1,12 @@
+diff --git a/Package.swift b/Package.swift
+--- a/Package.swift
++++ b/Package.swift
+@@ -80,5 +80,8 @@ let package = Package(
+             ]
+         ),
+     ],
++    // Build FluidAudio in Swift 5 mode: swift-tools 6.0 defaults to Swift 6
++    // strict concurrency, which trips data-race errors (StreamingAsrManager).
++    swiftLanguageModes: [.v5],
+     cxxLanguageStandard: .cxx17
+ )

--- a/patches/fluidaudio-swift5-mode.patch
+++ b/patches/fluidaudio-swift5-mode.patch
@@ -7,6 +7,6 @@ diff --git a/Package.swift b/Package.swift
      ],
 +    // Build FluidAudio in Swift 5 mode: swift-tools 6.0 defaults to Swift 6
 +    // strict concurrency, which trips data-race errors (StreamingAsrManager).
-+    swiftLanguageModes: [.v5],
++    swiftLanguageVersions: [.v5],
      cxxLanguageStandard: .cxx17
  )

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,40 @@ apply_fluidaudio_patches() {
     fi
 }
 
+# Patch FluidAudio's Package.swift to build in Swift 5 mode. FluidAudio
+# declares swift-tools-version: 6.0, which defaults to Swift 6 strict
+# concurrency and trips data-race errors in StreamingAsrManager — while the
+# OpenSuperWhisper host target is SWIFT_VERSION=5.0. Building the dependency
+# in the host's (lenient) Swift 5 mode avoids that. Idempotent; fails loudly
+# if the target moved (so a FluidAudio bump can't silently skip it).
+apply_fluidaudio_swift5_mode() {
+    local checkout="SourcePackages/checkouts/FluidAudio"
+    local patch_file="patches/fluidaudio-swift5-mode.patch"
+    local target="$checkout/Package.swift"
+
+    if [[ ! -f "$patch_file" ]]; then
+        echo "Missing FluidAudio patch: $patch_file"
+        exit 1
+    fi
+
+    if [[ ! -f "$target" ]]; then
+        echo "Missing FluidAudio Package.swift: $target"
+        exit 1
+    fi
+
+    if grep -q "swiftLanguageModes: \[.v5\]" "$target"; then
+        echo "FluidAudio Swift 5 mode patch already applied."
+        return
+    fi
+
+    echo "Applying FluidAudio Swift 5 mode patch..."
+    patch --silent --forward -d "$checkout" -p1 < "$patch_file"
+    if [[ $? -ne 0 ]] && ! grep -q "swiftLanguageModes: \[.v5\]" "$target"; then
+        echo "Failed to apply FluidAudio Swift 5 mode patch."
+        exit 1
+    fi
+}
+
 # Configure libwhisper
 echo "Configuring libwhisper..."
 cmake -G Xcode -B libwhisper/build -S libwhisper
@@ -77,6 +111,8 @@ if [[ $? -ne 0 ]]; then
 fi
 
 apply_fluidaudio_patches
+
+apply_fluidaudio_swift5_mode
 
 # Build the app
 echo "Building OpenSuperWhisper..."

--- a/run.sh
+++ b/run.sh
@@ -57,14 +57,14 @@ apply_fluidaudio_swift5_mode() {
         exit 1
     fi
 
-    if grep -q "swiftLanguageModes: \[.v5\]" "$target"; then
+    if grep -q "swiftLanguageVersions: \[.v5\]" "$target"; then
         echo "FluidAudio Swift 5 mode patch already applied."
         return
     fi
 
     echo "Applying FluidAudio Swift 5 mode patch..."
     patch --silent --forward -d "$checkout" -p1 < "$patch_file"
-    if [[ $? -ne 0 ]] && ! grep -q "swiftLanguageModes: \[.v5\]" "$target"; then
+    if [[ $? -ne 0 ]] && ! grep -q "swiftLanguageVersions: \[.v5\]" "$target"; then
         echo "Failed to apply FluidAudio Swift 5 mode patch."
         exit 1
     fi


### PR DESCRIPTION
## Summary

Fixes #11 — `EXC_BAD_ACCESS` stack-overflow crash on the hold-to-record **stop** transition (button release), caused by an unbounded SwiftUI/AppKit layout feedback loop in the Indicator recording window.

## Root cause

`NSHostingController` `sizingOptions=[.preferredContentSize]` (`IndicatorWindowManager.swift`) drives `NSHostingView.updateAnimatedWindowSize` on every SwiftUI size change. A never-removed `didResizeNotification` observer called `reposition() -> setFrameOrigin()` **synchronously inside the in-flight layout pass**, re-entering `updateAnimatedWindowSize` unboundedly (~6,795 levels -> 56 MB guard page -> SIGSEGV). Triggered at recording-stop: `hide()` coincides with three concurrent animated geometry changes (isVisible spring + scaleEffect/offset/opacity settle + bubbleWidth collapse).

## Fix (`IndicatorWindowManager.swift` only — `IndicatorWindow.swift` untouched)

1. **Observer add/remove symmetry** — remove the `didResizeNotification` observer in `hide()`/teardown (first action, before `hideWithAnimation`); it was added once and never removed.
2. **Break the re-entry** — dispatch `reposition` to the next runloop (`scheduleReposition`) so `setFrameOrigin` never runs inside the layout pass. `sizingOptions` retained so the live-caption pill still grows.
3. **Recursion-guard backstop** — `isRepositioning` coalesces a nested burst to one deferred reposition.

## Build fix (prerequisite, separate commit)

FluidAudio's `Package.swift` (`swift-tools-version: 6.0`, no language override) defaulted to Swift 6 strict-concurrency mode and failed to build ("sending 'asrManager' risks causing data races"). Added `swiftLanguageVersions: [.v5]` via a `run.sh` patch (mirrors the existing FluidAudio-patching pattern) so it builds in Swift 5 mode like the host.

## Tests

5 `@MainActor` tests in `OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift`: observer removed on hide; observer active/coalesced while shown (positive-path counter-test); setFrameOrigin deferred out of the layout pass; no runaway layout on the recording-stop transition; pill-growth preserved. **Counter-test-by-revert:** reverting the fix -> 3 FAIL / 2 PASS; restored -> 5 PASS.

## Verification status

- Static structural review: GREEN (auditor — confine, observer symmetry, no sync setFrameOrigin mid-layout, recursion guard, pill-growth).
- Tests: GREEN (coupled to the fix via counter-test-by-revert).
- **macOS 26 runtime smoke: PENDING** — the unbounded runaway only manifests on macOS 26/Tahoe (AppKit self-damps synchronous re-entry on other macOS); the hold-to-record -> release smoke must be confirmed on a Tahoe machine.
