### PR TITLE
feat: submit focused field on trailing "press enter" voice command

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -180,8 +180,14 @@ class IndicatorViewModel: ObservableObject {
                     // Optional LLM cleanup (no-op when disabled; returns the raw text on failure).
                     text = await LLMPostProcessor.process(text)
 
+                    // Trailing "press enter" voice command (opt-in): strip it from the text and
+                    // remember to press Return after insertion, submitting the message/prompt.
+                    let (strippedText, shouldSubmit) = AppPreferences.shared.stripSubmitCommand(text)
+                    text = strippedText
+                    let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
                     var hookAudioPath: String? = nil
-                    if AppPreferences.shared.saveTranscriptionHistory {
+                    if hasText && AppPreferences.shared.saveTranscriptionHistory {
                         // Create a new Recording instance
                         let timestamp = Date()
                         let fileName = "\(Int(timestamp.timeIntervalSince1970)).wav"
@@ -219,9 +225,20 @@ class IndicatorViewModel: ObservableObject {
                         try? FileManager.default.removeItem(at: tempURL)
                     }
 
-                    let pasteTargetMissing = insertText(text)
+                    let pasteTargetMissing = hasText ? insertText(text) : false
                     print("Transcription result: \(text)")
-                    PostRecordHook.runIfEnabled(text: text, audioPath: hookAudioPath, timestamp: Date(), duration: 0)
+                    if hasText {
+                        PostRecordHook.runIfEnabled(text: text, audioPath: hookAudioPath, timestamp: Date(), duration: 0)
+                    }
+
+                    // Submit only when auto-paste actually inserted text somewhere (or the user said
+                    // just "press enter" to submit existing content). A Return with no paste target
+                    // would fire into whatever happens to be focused. The short settle delay lets the
+                    // pasted text land in the field before Return reaches it.
+                    if shouldSubmit && AppPreferences.shared.autoPasteTranscription && !pasteTargetMissing {
+                        try? await Task.sleep(nanoseconds: 120_000_000)
+                        TextInserter.pressReturn()
+                    }
                     await MainActor.run {
                         if pasteTargetMissing {
                             self.showInfo("Copied — press ⌘V to paste")

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -277,6 +277,12 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var submitOnVoiceCommand: Bool {
+        didSet {
+            AppPreferences.shared.submitOnVoiceCommand = submitOnVoiceCommand
+        }
+    }
+
     @Published var pauseMediaOnRecord: Bool {
         didSet {
             AppPreferences.shared.pauseMediaOnRecord = pauseMediaOnRecord
@@ -406,6 +412,7 @@ class SettingsViewModel: ObservableObject {
         self.autoPasteTranscription = prefs.autoPasteTranscription
         self.pasteInsteadOfTyping = prefs.pasteInsteadOfTyping
         self.notifyWhenNoPasteTarget = prefs.notifyWhenNoPasteTarget
+        self.submitOnVoiceCommand = prefs.submitOnVoiceCommand
         self.pauseMediaOnRecord = prefs.pauseMediaOnRecord
         self.reduceVolumeOnRecord = prefs.reduceVolumeOnRecord
         self.reduceVolumeLevel = prefs.reduceVolumeLevel
@@ -1580,6 +1587,20 @@ struct SettingsView: View {
                             }
                             Spacer()
                             Toggle("", isOn: $viewModel.notifyWhenNoPasteTarget)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Submit on “press enter”")
+                                    .font(.subheadline)
+                                Text("Saying “press enter” at the end removes it from the text and presses Return — submitting in Claude Code, Slack, etc.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Toggle("", isOn: $viewModel.submitOnVoiceCommand)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
                                 .labelsHidden()
                         }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -217,6 +217,29 @@ final class AppPreferences {
     @UserDefault(key: "notifyWhenNoPasteTarget", defaultValue: true)
     var notifyWhenNoPasteTarget: Bool
 
+    /// When on, a trailing "press enter" in the dictation is removed from the text and a Return
+    /// key is pressed after the text is inserted — submitting the message/prompt (Claude Code,
+    /// Slack, …). Opt-in: a stray Return can submit a form prematurely. See `stripSubmitCommand`.
+    @UserDefault(key: "submitOnVoiceCommand", defaultValue: false)
+    var submitOnVoiceCommand: Bool
+
+    /// Detects a trailing "press enter" voice command. Returns the text with the command (and any
+    /// trailing punctuation it leaves behind) removed, plus whether the command was present.
+    ///
+    /// Only matches at the very end of the dictation, so "press enter" used mid-sentence as content
+    /// ("tell him to press enter") is left untouched. The leading separator we consume is whitespace
+    /// or a comma — a preceding sentence period ("Send this. Press enter.") is kept. No-op (returns
+    /// the text unchanged with `submit: false`) unless `submitOnVoiceCommand` is on.
+    func stripSubmitCommand(_ text: String) -> (text: String, submit: Bool) {
+        guard submitOnVoiceCommand else { return (text, false) }
+        let pattern = "[\\s,]*press[\\s,]+enter[\\s\\p{P}]*$"
+        guard let range = text.range(
+            of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return (text, false)
+        }
+        return (String(text[..<range.lowerBound]), true)
+    }
+
     /// Pause currently-playing media while recording, then resume. Opt-in (default
     /// off): it uses the private MediaRemote API and changes system playback.
     @UserDefault(key: "pauseMediaOnRecord", defaultValue: false)

--- a/OpenSuperWhisper/Utils/TextInserter.swift
+++ b/OpenSuperWhisper/Utils/TextInserter.swift
@@ -73,4 +73,20 @@ enum TextInserter {
         vUp.post(tap: .cghidEventTap)
         cmdUp.post(tap: .cghidEventTap)
     }
+
+    /// Presses Return in the focused app — used by the "press enter" voice command to submit a
+    /// message or prompt after the dictated text has been inserted. Modifier flags are cleared so a
+    /// still-held hotkey can't turn it into a shortcut (⌘↩, ⇧↩, …).
+    static func pressReturn() {
+        guard let source = CGEventSource(stateID: .combinedSessionState) else { return }
+        let returnKey: CGKeyCode = 0x24 // kVK_Return
+        guard
+            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: returnKey, keyDown: true),
+            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: returnKey, keyDown: false)
+        else { return }
+        keyDown.flags = []
+        keyUp.flags = []
+        keyDown.post(tap: .cghidEventTap)
+        keyUp.post(tap: .cghidEventTap)
+    }
 }


### PR DESCRIPTION
## What

Adds an opt-in voice command: saying **"press enter"** at the end of a dictation strips the phrase from the inserted text and presses Return, submitting the message/prompt in the focused app (Claude Code, Slack, etc.).

## Why

Lets you dictate and submit hands-free — e.g. talk to Claude Code or send a Slack message without touching the keyboard.

## How it works

- **`AppPreferences.submitOnVoiceCommand`** (default **off**) gates the whole feature.
- **`AppPreferences.stripSubmitCommand(_:)`** detects `"press enter"` **only at the very end** of the dictation (case-insensitive, tolerant of trailing punctuation). Mid-sentence use as content — "tell him to press enter on the keyboard" — is left untouched. A preceding sentence period is preserved ("Reply yes. Press enter." → inserts "Reply yes.").
- **`TextInserter.pressReturn()`** posts a Return key via the same `CGEvent` → `.cghidEventTap` path already used for paste; modifier flags are cleared so a held hotkey can't turn it into ⌘↩.
- **`IndicatorWindow`** inserts the stripped text, waits a 120 ms settle delay so the paste lands first, then presses Return — but only when auto-paste actually had a target (a Return with no target would fire into whatever is focused).
- **Settings**: new "Submit on \"press enter\"" toggle in the **Clipboard & Paste** section.

## Edge cases handled

- Saying only "press enter" → inserts nothing, just submits existing field content; no empty history entry saved.
- Feature is a no-op unless both `submitOnVoiceCommand` and auto-paste are on.

## Testing

⚠️ Not yet built/run — authored in an environment without Xcode. Needs a local build + manual check, especially the **120 ms settle delay** against Slack/Electron vs. Claude Code's terminal (the one empirically uncertain piece; it's the knob to tune if Return ever lands before the text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)