### PR TITLE
fix: stop indicator window layout-recursion crash on macOS 26 (#15)

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -530,10 +530,16 @@ struct IndicatorWindow: View {
         .scaleEffect(viewModel.isVisible ? 1 : (isNotchMode ? 0.85 : 0.5), anchor: isNotchMode ? .top : .center)
         .offset(y: viewModel.isVisible ? 0 : (isNotchMode ? -20 : 20))
         .opacity(viewModel.isVisible ? 1 : 0)
+        // Entrance only: scale/offset/opacity are render transforms that don't change the
+        // view's layout size, so they're safe to animate.
         .animation(.spring(response: 0.35, dampingFraction: 0.72), value: viewModel.isVisible)
-        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: bubbleWidth)
-        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: streaming.confirmedText)
-        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: streaming.volatileText)
+        // NOTE: Do NOT add implicit animations on values that change the bubble's *size*
+        // (bubbleWidth, the streaming caption text, height, etc.). This window is hosted with
+        // `sizingOptions = .preferredContentSize`, so it resizes to fit this content. Animating
+        // the size makes SwiftUI drive an animated window resize (NSHostingView
+        // .updateAnimatedWindowSize), which on macOS 26 re-enters layout synchronously and
+        // recurses until the main-thread stack overflows (crash: "Thread stack size exceeded
+        // due to excessive recursion"). Let size changes snap in a single layout pass instead.
         .onAppear {
             viewModel.isVisible = true
         }


### PR DESCRIPTION
## Summary

Fixes the stack-overflow crash reported in #15 — `EXC_BAD_ACCESS` / `SIGSEGV`, *"Thread stack size exceeded due to excessive recursion"* — on macOS 26.

The recording indicator is hosted with `NSHostingController` `sizingOptions = .preferredContentSize`, so its `NSPanel` resizes to fit the SwiftUI content. The root view also carried implicit spring animations bound to the values that drive that size (`bubbleWidth` and the live caption's streaming text). On macOS 26, SwiftUI animates the **window** size in response (`NSHostingView.updateAnimatedWindowSize`), which re-enters layout synchronously:

```
resize → windowDidLayout → re-layout → resize → …
```

…until the main-thread stack overflows (~35k frames in the crash report). It fires on most indicator state changes, which is why it shows up most often around transcription but also on the error / info / busy states.

## Change

Drop the three size-coupled animations (`bubbleWidth`, `streaming.confirmedText`, `streaming.volatileText`). Keep the entrance animation — `scale` / `offset` / `opacity` are render-only transforms that don't change the layout size, so they can't drive a window resize. Size changes now settle in a single layout pass. A code comment documents why those animations must not come back.

**Tradeoff:** the bubble snaps to its new size instead of springing (purely cosmetic; entrance/exit still animates).

## ⚠️ Testing needed before merge

This has only been **parse-checked** (`swiftc -parse`) — I did not have a macOS 26 + Xcode environment to build or reproduce the crash. Please verify before merging:

- [ ] Builds on macOS 26
- [ ] Run several transcriptions in both `notch` and non-notch indicator positions
- [ ] Trigger an error state (e.g. no microphone) to exercise the other indicator states
- [ ] Confirm the indicator still positions correctly as the live caption grows

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
