### PR TITLE
fix: kill indicator window layout-recursion crash for good (#19)

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -398,8 +398,20 @@ struct RecordingIndicator: View {
     }
 }
 
+/// Reports the indicator bubble's laid-out size (before the entrance render transforms) so the
+/// window manager can size the panel itself — see the note on `.onPreferenceChange` below.
+private struct IndicatorContentSizeKey: PreferenceKey {
+    static let defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}
+
 struct IndicatorWindow: View {
     @ObservedObject var viewModel: IndicatorViewModel
+    /// Called whenever the bubble's intrinsic size changes. The manager resizes the hosting
+    /// window to match, *non-animated* (see `.onPreferenceChange` below for why).
+    var onContentResize: (CGSize) -> Void = { _ in }
     @ObservedObject private var streaming = StreamingTranscriptionController.shared
     @ObservedObject private var notch = NotchTuning.shared
     @Environment(\.colorScheme) private var colorScheme
@@ -542,21 +554,29 @@ struct IndicatorWindow: View {
             }
         }
         .clipShape(rect)
+        // Measure the bubble here, *before* the entrance transforms below, so the reported size is
+        // the real layout size (scaleEffect/offset are render-only and don't affect this).
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: IndicatorContentSizeKey.self, value: proxy.size)
+            }
+        )
         .environment(\.colorScheme, isNotchMode ? .dark : colorScheme)
         // Notch drops in from the top edge; the others rise from below.
         .scaleEffect(viewModel.isVisible ? 1 : (isNotchMode ? 0.85 : 0.5), anchor: isNotchMode ? .top : .center)
         .offset(y: viewModel.isVisible ? 0 : (isNotchMode ? -20 : 20))
         .opacity(viewModel.isVisible ? 1 : 0)
-        // Entrance only: scale/offset/opacity are render transforms that don't change the
-        // view's layout size, so they're safe to animate.
         .animation(.spring(response: 0.35, dampingFraction: 0.72), value: viewModel.isVisible)
-        // NOTE: Do NOT add implicit animations on values that change the bubble's *size*
-        // (bubbleWidth, the streaming caption text, height, etc.). This window is hosted with
-        // `sizingOptions = .preferredContentSize`, so it resizes to fit this content. Animating
-        // the size makes SwiftUI drive an animated window resize (NSHostingView
-        // .updateAnimatedWindowSize), which on macOS 26 re-enters layout synchronously and
-        // recurses until the main-thread stack overflows (crash: "Thread stack size exceeded
-        // due to excessive recursion"). Let size changes snap in a single layout pass instead.
+        // The hosting window is sized by the manager from this preference (NOT by SwiftUI's
+        // `.preferredContentSize` auto-resize). That auto-resize runs *animated* whenever any
+        // SwiftUI animation transaction is active during a layout pass (NSHostingView
+        // .updateAnimatedWindowSize), and on macOS 26 the animated resize re-enters layout and
+        // recurses until the main-thread stack overflows — the crash in #11/#15/#19. Driving the
+        // size ourselves, non-animated, makes that recursion impossible, so the entrance spring
+        // and the blinking dot above are free to animate without risk.
+        .onPreferenceChange(IndicatorContentSizeKey.self) { size in
+            onContentResize(size)
+        }
         .onAppear {
             viewModel.isVisible = true
         }

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -48,9 +48,16 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             self.window = panel
         }
         
-        // Host with a controller that resizes the window to fit the SwiftUI content.
-        let hostingController = NSHostingController(rootView: IndicatorWindow(viewModel: newViewModel))
-        hostingController.sizingOptions = [.preferredContentSize]
+        // Host the SwiftUI content and size the window to it *ourselves* (see `resizeToContent`).
+        // We deliberately do NOT use `sizingOptions = [.preferredContentSize]`: that auto-resize
+        // runs animated on macOS 26 (NSHostingView.updateAnimatedWindowSize) and recurses into
+        // layout until the main-thread stack overflows — the #11/#15/#19 crash.
+        let hostingController = NSHostingController(
+            rootView: IndicatorWindow(viewModel: newViewModel) { [weak self] size in
+                self?.resizeToContent(size)
+            }
+        )
+        hostingController.sizingOptions = []
         window?.contentViewController = hostingController
 
         // Position window - use the screen containing the point, or main screen as fallback
@@ -114,6 +121,22 @@ class IndicatorWindowManager: IndicatorViewDelegate {
 
         window?.orderFront(nil)
         return newViewModel
+    }
+
+    /// Sizes the indicator window to its SwiftUI content, *non-animated*. This replaces
+    /// NSHostingView's `.preferredContentSize` auto-resize, whose animated variant recurses into
+    /// layout and overflows the main-thread stack on macOS 26 (#11/#15/#19). `setContentSize`
+    /// snaps in a single pass, so no SwiftUI animation can ever drive a window resize.
+    private func resizeToContent(_ size: CGSize) {
+        guard let window, size.width > 1, size.height > 1 else { return }
+        let newSize = NSSize(width: ceil(size.width), height: ceil(size.height))
+        let current = window.contentRect(forFrameRect: window.frame).size
+        if abs(current.width - newSize.width) > 0.5 || abs(current.height - newSize.height) > 0.5 {
+            window.setContentSize(newSize)
+        }
+        if let screen = window.screen ?? NSScreen.main {
+            reposition(window: window, screen: screen)
+        }
     }
 
     private func reposition(window: NSWindow, screen: NSScreen) {

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -5,7 +5,13 @@ import SwiftUI
 @MainActor
 class IndicatorWindowManager: IndicatorViewDelegate {
     static let shared = IndicatorWindowManager()
-    
+
+    /// The indicator window is sized manually (see `resizeToContent`) — NEVER via NSHostingView's
+    /// `.preferredContentSize` auto-resize. That auto-resize animates the window frame on macOS 26
+    /// (`NSHostingView.updateAnimatedWindowSize`) and recurses into layout until the main-thread
+    /// stack overflows (#11/#15/#19). Must stay empty; `IndicatorLayoutRecursionTests` guards it.
+    nonisolated static let hostingSizingOptions: NSHostingSizingOptions = []
+
     var window: NSWindow?
     var viewModel: IndicatorViewModel?
 
@@ -57,7 +63,7 @@ class IndicatorWindowManager: IndicatorViewDelegate {
                 self?.resizeToContent(size)
             }
         )
-        hostingController.sizingOptions = []
+        hostingController.sizingOptions = Self.hostingSizingOptions
         window?.contentViewController = hostingController
 
         // Position window - use the screen containing the point, or main screen as fallback

--- a/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
+++ b/OpenSuperWhisperTests/IndicatorLayoutRecursionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import SwiftUI
+@testable import OpenSuperWhisper
+
+/// Guards the fix for the indicator-window layout-recursion crash (#11, #15, #19).
+///
+/// On macOS 26 (Tahoe), hosting the recording indicator with
+/// `NSHostingController.sizingOptions = [.preferredContentSize]` makes NSHostingView auto-resize
+/// the window to fit its content — and that resize runs *animated* whenever any SwiftUI animation
+/// transaction is active during a layout pass (`NSHostingView.updateAnimatedWindowSize`), which
+/// re-enters layout and recurses until the main-thread stack overflows (~6,795 frames → SIGSEGV).
+///
+/// The robust fix takes window sizing off SwiftUI's animated path entirely: the window is sized
+/// manually, non-animated, via `IndicatorWindowManager.resizeToContent`, so `updateAnimatedWindowSize`
+/// can never be invoked. This test pins the one invariant that makes that true — the hosting
+/// controller must NOT be configured to auto-resize the window.
+///
+/// Counter-test: set `hostingSizingOptions` back to `[.preferredContentSize]` and these fail —
+/// i.e. they fail exactly when the crash would return. (Regression-test idea from @michael-wojcik's
+/// PR #13, adapted to the manual-sizing approach.)
+final class IndicatorLayoutRecursionTests: XCTestCase {
+
+    func testHostingDoesNotAutoResizeWindow() {
+        // `.preferredContentSize` is the option that drives the animated window resize; its presence
+        // is the crash. The window is sized by hand instead, so it must be absent.
+        XCTAssertFalse(
+            IndicatorWindowManager.hostingSizingOptions.contains(.preferredContentSize),
+            "Indicator hosting must not use .preferredContentSize — it re-arms the macOS 26 layout-recursion crash (#11/#15/#19)."
+        )
+    }
+
+    func testHostingSizingIsManual() {
+        // No sizing option at all: NSHostingView neither resizes the window nor imposes intrinsic
+        // bounds; `resizeToContent` owns the size.
+        XCTAssertTrue(
+            IndicatorWindowManager.hostingSizingOptions.isEmpty,
+            "Indicator hosting sizingOptions must be empty — the window is sized manually via resizeToContent."
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Closed #11/#15 with #16 — but the crash **came back** in **0.9.3-beta.3 (build 29)**, which already ships #16. Reported again in #19 (M4 Max, Tahoe 26.5.1), same `EXC_BAD_ACCESS` / "Thread stack size exceeded due to excessive recursion", same ~6,795-deep `NSPerformVisuallyAtomicChange` loop.

## Root cause

The recursion driver, straight from the #19 crash log (build 29):

```
NSWindow _setFrameCommon:display:fromServer:   ← window frame is being SET…
NSHostingView.updateAnimatedWindowSize(_:)     ← …ANIMATED
NSHostingView.windowDidLayout()                ← from a layout-pass notification
   ↑ +[NSAnimationContext runAnimationGroup:] wrapping NSHostingView.layout()
```

`hostingController.sizingOptions = [.preferredContentSize]` makes `NSHostingView` auto-resize the window to fit the SwiftUI content. On macOS 26, if **any** SwiftUI animation transaction is active during a layout pass, that resize runs **animated** (`updateAnimatedWindowSize`), which re-enters layout → recurses → stack overflow.

#16 removed the three size-bound `.animation()` modifiers, but the hosted view still had live animation transactions: the `isVisible` entrance spring, the `withAnimation { isVisible = false }` hide, and the blinking dot. Any of them overlapping a content-size update re-arms the loop. Removing animations one at a time is whack-a-mole.

## Fix

Take window sizing off SwiftUI's animated path entirely:

- Drop `sizingOptions = [.preferredContentSize]` (set to `[]`).
- Measure the bubble's layout size with a `PreferenceKey`.
- The manager sets the panel size itself via `setContentSize` — **never animated**.

`updateAnimatedWindowSize` can no longer be invoked, so the recursion is impossible *regardless* of how many SwiftUI animations are active. The entrance spring and blinking dot stay; the live caption pill still grows with the text (snaps in one pass, as #16 intended).

## Verification

Built and run on **macOS 26.0 (Tahoe) / Apple M2**. Full live-streaming **record → transcribe → hide** cycle — the exact flow that crashed beta.3 "immediately after the first transcription" — completes with **no crash**, no diagnostic report generated.

Fixes #19. Re-addresses #11, #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzqCgLqxHEtcEFLsSKxD5V