### PR TITLE
fix: media pause/resume, failed-recording preservation, indicator hardening (from #21)

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -257,6 +257,27 @@ class IndicatorViewModel: ObservableObject {
                     return
                 } catch {
                     print("Error transcribing audio: \(error)")
+                    // Don't lose the audio on failure (e.g. an intermittent remote 405 /
+                    // network blip after a long dictation). When history is on, keep the
+                    // recording with a .failed status + retry message so it shows in the log
+                    // and can be re-run with the regenerate (↻) button. Otherwise discard.
+                    if AppPreferences.shared.saveTranscriptionHistory,
+                       let saved = self.persistFailedRecording(tempURL: tempURL) {
+                        await MainActor.run {
+                            self.recordingStore.addRecording(Recording(
+                                id: saved.id,
+                                timestamp: saved.timestamp,
+                                fileName: saved.fileName,
+                                transcription: "Transcription failed — click ↻ to try again.",
+                                duration: 0,
+                                status: .failed,
+                                progress: 0,
+                                sourceFileURL: nil
+                            ))
+                        }
+                    } else {
+                        try? FileManager.default.removeItem(at: tempURL)
+                    }
                     await MainActor.run {
                         self.showError("Transcription failed: \(error.localizedDescription)")
                     }
@@ -275,6 +296,32 @@ class IndicatorViewModel: ObservableObject {
         }
     }
     
+    /// Move a temp recording to its permanent location after a FAILED transcription
+    /// so the audio survives and can be re-run from the history list. Returns the
+    /// saved identity, or nil if the file move failed (then the temp is discarded).
+    private func persistFailedRecording(tempURL: URL) -> (id: UUID, timestamp: Date, fileName: String, url: URL)? {
+        let timestamp = Date()
+        let fileName = "\(Int(timestamp.timeIntervalSince1970)).wav"
+        let id = UUID()
+        let finalURL = Recording(
+            id: id,
+            timestamp: timestamp,
+            fileName: fileName,
+            transcription: "",
+            duration: 0,
+            status: .failed,
+            progress: 0,
+            sourceFileURL: nil
+        ).url
+        do {
+            try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
+            return (id, timestamp, fileName, finalURL)
+        } catch {
+            print("Failed to persist failed recording: \(error)")
+            return nil
+        }
+    }
+
     /// Returns `true` when auto-paste ran but no editable field was focused,
     /// so the caller can surface a "copied — press ⌘V" notice. When no target
     /// is found, typing is skipped and the text is left on the clipboard.
@@ -453,8 +500,6 @@ struct IndicatorWindow: View {
                     Text("Connecting...")
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                
             case .recording:
                 if streaming.confirmedText.isEmpty && streaming.volatileText.isEmpty {
                     // Before any text arrives, just the dot + label, vertically centered.
@@ -482,16 +527,16 @@ struct IndicatorWindow: View {
                 }
 
             case .decoding:
+                // Keep the same height as the recording state (the spinner's intrinsic
+                // height is capped) so the bubble doesn't jump taller when transcribing.
                 HStack(spacing: 8) {
                     ProgressView()
-                        .scaleEffect(0.7)
-                        .frame(width: 24)
-                    
+                        .controlSize(.small)
+                        .frame(width: 24, height: 16)
+
                     Text("Transcribing...")
                         .font(.system(size: 13, weight: .semibold))
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                
             case .busy:
                 HStack(spacing: 8) {
                     Image(systemName: "hourglass")
@@ -502,8 +547,6 @@ struct IndicatorWindow: View {
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.orange)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                
             case .error(let message):
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -514,8 +557,6 @@ struct IndicatorWindow: View {
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.red)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
             case .info(let message):
                 HStack(spacing: 8) {
                     Image(systemName: "doc.on.clipboard")
@@ -526,8 +567,6 @@ struct IndicatorWindow: View {
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.primary)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
             case .idle:
                 EmptyView()
             }

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -50,7 +50,11 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             panel.hasShadow = false
             panel.ignoresMouseEvents = true
             panel.hidesOnDeactivate = false
-            
+            // Belt-and-suspenders: the window is sized manually + non-animated via
+            // `resizeToContent` (#19), and this also stops AppKit from animating the frame on
+            // its own. Size changes should snap, never animate (macOS 26 recursion guard).
+            panel.animationBehavior = .none
+
             self.window = panel
         }
         

--- a/OpenSuperWhisper/MediaPlaybackController.swift
+++ b/OpenSuperWhisper/MediaPlaybackController.swift
@@ -2,44 +2,138 @@ import Foundation
 
 /// Pauses/resumes system media playback via the private MediaRemote framework.
 ///
-/// macOS lets a normal app *send* play/pause commands but not reliably *read* the Now
-/// Playing state from inside the process, so we can't tell whether something was actually
-/// playing. We therefore always pause on record and always resume on stop. The trade-off:
-/// if media was already paused when you start recording, it will resume on stop — accepted.
+/// The pause is always sent **unconditionally** — a synchronous "is something playing?" probe at
+/// record-start reads false, because starting `AVAudioRecorder` transiently clears the system Now
+/// Playing flag (#126), so a probe there wrongly skips the pause (browser tabs like YouTube never
+/// paused). A pause command is a harmless no-op when nothing plays, so this is safe and reliable.
+///
+/// The resume is where it gets subtle: we want to resume only what was actually playing, so an
+/// idle/already-paused source isn't *woken* when recording stops. That requires reading the
+/// now-playing state — but **MediaRemote gates now-playing reads on a real (team) code signature.**
+/// Verified empirically: Apple's signed `swift` toolchain reads `IsPlaying=true`/`rate=1` for a
+/// playing Chrome tab, while an ad-hoc/unsigned build (or subprocess) reads nothing back. So:
+///
+///   • Signed builds (reads work): poll the playback state while not recording, snapshot it at
+///     pause, and resume only if it was playing. Idle media is left alone.
+///   • Unsigned/ad-hoc builds (reads fail): we can't tell what was playing, so leave playback
+///     paused (the user presses play to resume). We deliberately do NOT always-resume here: macOS
+///     keeps stale/closed media as the now-playing owner, so always-resuming would frequently wake
+///     things the user didn't know were "playing".
+///
+/// Which path is active is detected at runtime (`canRead`), so a properly signed release upgrades
+/// to the precise behavior automatically with no code change. MediaRemote's now-playing is a single
+/// system-wide owner, so this acts on the active player; it can't restore several sources at once.
 final class MediaPlaybackController {
     static let shared = MediaPlaybackController()
 
-    /// Whether we sent a pause this cycle, so `resumeMedia` only acts after `pauseMedia`.
+    /// Whether we armed a resume this cycle (something was playing when we paused, or we can't tell).
     private(set) var didPauseMedia = false
+
+    /// Cached "is the Now Playing app playing?" (from the playback rate), refreshed while not
+    /// recording so it reflects the state from *before* a recording disrupts the flag. Only
+    /// meaningful when `canRead` is true.
+    private var isNowPlaying = false
+
+    /// Whether this process can actually read now-playing state (see the type doc — gated on a real
+    /// code signature). Set true the first time a now-playing info dict comes back. While false we
+    /// can't detect playback, so resume falls back to always-on (#126).
+    private var canRead = false
+    private var readAttempts = 0
 
     private static let kMRPlay: UInt32 = 0
     private static let kMRPause: UInt32 = 1
+    private static let pollInterval: TimeInterval = 1.5
+    /// Give reads a few tries; if none succeed this build can't read now-playing (unsigned) — stop
+    /// polling and settle into the always-resume fallback rather than polling forever.
+    private static let maxReadAttempts = 5
 
     private let sendCommand: (@convention(c) (UInt32, UnsafeRawPointer?) -> Bool)?
+    /// MRMediaRemoteGetNowPlayingInfo(queue, completion(infoDict?)). The dict is nil when this
+    /// process can't read now-playing, which doubles as the capability signal.
+    private let getInfo: (@convention(c) (DispatchQueue, @escaping @convention(block) (CFDictionary?) -> Void) -> Void)?
+    private var pollTimer: Timer?
 
     private init() {
-        guard
-            let bundle = CFBundleCreate(
-                kCFAllocatorDefault,
-                NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")
-            ),
-            let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteSendCommand" as CFString)
-        else {
+        let bundle = CFBundleCreate(
+            kCFAllocatorDefault,
+            NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")
+        )
+        if let bundle,
+           let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteSendCommand" as CFString) {
+            sendCommand = unsafeBitCast(ptr, to: (@convention(c) (UInt32, UnsafeRawPointer?) -> Bool).self)
+        } else {
             sendCommand = nil
-            return
         }
-        sendCommand = unsafeBitCast(ptr, to: (@convention(c) (UInt32, UnsafeRawPointer?) -> Bool).self)
+        if let bundle,
+           let ptr = CFBundleGetFunctionPointerForName(bundle, "MRMediaRemoteGetNowPlayingInfo" as CFString) {
+            getInfo = unsafeBitCast(
+                ptr, to: (@convention(c) (DispatchQueue, @escaping @convention(block) (CFDictionary?) -> Void) -> Void).self)
+        } else {
+            getInfo = nil
+        }
+
+        // Prime the now-playing connection — reads don't work in signed builds without registering.
+        if let bundle,
+           let regPtr = CFBundleGetFunctionPointerForName(
+            bundle, "MRMediaRemoteRegisterForNowPlayingNotifications" as CFString) {
+            typealias RegisterFn = @convention(c) (DispatchQueue) -> Void
+            unsafeBitCast(regPtr, to: RegisterFn.self)(DispatchQueue.main)
+        }
+
+        startPolling()
     }
 
-    /// Sends an explicit pause (a harmless no-op when nothing is playing).
+    /// Poll the playing state while not recording (fires in `.common` mode so it keeps ticking
+    /// during menu tracking / window resizing).
+    private func startPolling() {
+        guard getInfo != nil, pollTimer == nil else { return }
+        refreshNowPlaying()
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            self?.refreshNowPlaying()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+    }
+
+    private func stopPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+
+    private func refreshNowPlaying() {
+        // If reads never succeed, this build can't see now-playing — stop polling and rely on the
+        // always-resume fallback.
+        if !canRead {
+            readAttempts += 1
+            if readAttempts > Self.maxReadAttempts { stopPolling(); return }
+        }
+        getInfo?(DispatchQueue.main) { [weak self] info in
+            guard let self, let dict = info as? [String: Any] else { return }
+            self.canRead = true
+            let rate = (dict["kMRMediaRemoteNowPlayingInfoPlaybackRate"] as? NSNumber)?.doubleValue ?? 0
+            self.isNowPlaying = rate > 0
+        }
+    }
+
+    /// Pause playback (unconditional = reliable), arming a resume only if something was actually
+    /// playing when we paused (or unconditionally when we can't read state), and freezing the cache
+    /// while the recording runs.
     func pauseMedia() {
-        guard let sendCommand = sendCommand else { return }
-        didPauseMedia = sendCommand(Self.kMRPause, nil)
+        guard let sendCommand else { return }
+        // Can read → resume only what was playing. Can't read (unsigned) → leave it paused: macOS
+        // keeps stale/closed media (e.g. the last YouTube video) as the now-playing owner, so
+        // always-resuming would frequently wake things the user didn't know were "playing".
+        let wasPlaying = canRead ? isNowPlaying : false
+        stopPolling()
+        _ = sendCommand(Self.kMRPause, nil)
+        didPauseMedia = wasPlaying
     }
 
-    /// Sends play, but only if we previously paused this cycle.
+    /// Resume playback, but only if we paused something this cycle; then re-arm the poll (only if
+    /// reads work — otherwise we've settled into the fallback and there's nothing to poll).
     func resumeMedia() {
-        guard didPauseMedia, let sendCommand = sendCommand else { return }
+        defer { if canRead { startPolling() } }
+        guard didPauseMedia, let sendCommand else { return }
         _ = sendCommand(Self.kMRPlay, nil)
         didPauseMedia = false
     }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2355,7 +2355,7 @@ struct SettingsView: View {
                         SettingRow(
                             title: "Pause media during recording",
                             caption: "Pause other apps' playback while recording, then resume.",
-                            info: "macOS doesn't let the app detect what was playing, so if media was already paused it may start playing when you stop — if that bothers you, use the volume option below instead."
+                            info: "Pauses the system's active player while recording, then resumes what was playing. If the app can't detect what was playing (unsigned builds), it leaves playback paused — press play to resume. Acts on the system's active player, so it can't independently restore several sources at once."
                         ) {
                             Toggle("", isOn: $viewModel.pauseMediaOnRecord)
                                 .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))


### PR DESCRIPTION
First slice of #21, carved by the maintainers (menu items **1**, **3** and **4**) — code by @EvanSchalton, commit authorship preserved.

- **Reliable media pause/resume** — pause sent unconditionally (record-start probes are unreliable: `AVAudioRecorder` transiently clears Now Playing); resume is adaptive — signed builds resume only what was actually playing, unsigned builds leave playback paused rather than waking stale media.
- **Failed-recording preservation** — a failed hotkey transcription keeps the audio (`.failed` + retry placeholder in history, re-runnable via ↻) instead of discarding it. *Adapted from #21: the source-context/model metadata parts land with the history PR (menu item 8).*
- **Indicator residual hardening** — `panel.animationBehavior = .none` (belt-and-suspenders on the #19/#20 recursion fix), width-feedback frames removed from the state views, decoding spinner height capped.

Verified: full unit-test suite green locally (incl. `IndicatorLayoutRecursionTests`).

Remaining slices tracked in #21: Remote engine + fallback (5/6, with lazy loading 2), history enrichment (8), App Context + stores (7/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzqCgLqxHEtcEFLsSKxD5V