### PR TITLE
feat: history enrichment — source context, real duration, rerun-with-model (from #21)

### DIFF
--- a/OpenSuperWhisper/AppContextModelRules.swift
+++ b/OpenSuperWhisper/AppContextModelRules.swift
@@ -1,0 +1,74 @@
+import AppKit
+import Foundation
+
+/// The app the user is currently targeting — refreshed at record-start and when
+/// the menu-bar picker opens — so binding a model maps to the right app.
+/// Runtime-only.
+final class RecordingContext {
+    static let shared = RecordingContext()
+    private(set) var appName: String?
+    private(set) var bundleID: String?
+    /// URL host for supported browsers (e.g. "docs.google.com") — enables
+    /// per-site rules. nil for non-browsers or when the URL is unavailable.
+    private(set) var host: String?
+    /// Full active-tab URL for supported browsers (for transcript metadata).
+    private(set) var fullURL: String?
+    /// Focused window title at capture time (for transcript metadata).
+    private(set) var windowTitle: String?
+    private init() {}
+
+    func update(appName: String?, bundleID: String?, host: String? = nil,
+                fullURL: String? = nil, windowTitle: String? = nil) {
+        self.appName = appName
+        self.bundleID = bundleID
+        self.host = host
+        self.fullURL = fullURL
+        self.windowTitle = windowTitle
+    }
+
+    /// A label for the most specific bindable scope: the site host if we have
+    /// one, otherwise the app name.
+    var scopeLabel: String? { host ?? appName }
+
+    /// Capture the current frontmost app (browser site + URL + window title) as
+    /// the active context. Opening a status-bar menu doesn't steal focus, so this
+    /// is the app the cursor is in. If our own app is frontmost, keep the previous
+    /// context.
+    func captureFrontmost() {
+        guard let front = NSWorkspace.shared.frontmostApplication,
+              let bundle = front.bundleIdentifier,
+              bundle != Bundle.main.bundleIdentifier
+        else { return }
+        let url = SourceCapture.browserURL(bundleID: bundle)
+        let host = SourceCapture.host(of: url)
+        let title = SourceCapture.focusedWindowTitle()
+        update(appName: front.localizedName, bundleID: bundle, host: host,
+               fullURL: url, windowTitle: title)
+    }
+
+    // One-time model override. "Just This Time" makes the *next* recording in an
+    // app use the picked model instead of the app's rule, then reverts —
+    // otherwise the rule re-applies at record-start and clobbers the one-off.
+    private var oneTimeBundleID: String?
+    private var oneTimeModel: DictationModelOption?
+
+    func setOneTimeModel(_ model: DictationModelOption, for bundleID: String) {
+        oneTimeBundleID = bundleID
+        oneTimeModel = model
+    }
+
+    func clearOneTimeModel(for bundleID: String) {
+        if oneTimeBundleID == bundleID {
+            oneTimeBundleID = nil
+            oneTimeModel = nil
+        }
+    }
+
+    /// Return and clear a pending one-time model for this app, if any.
+    func consumeOneTimeModel(for bundleID: String) -> DictationModelOption? {
+        guard oneTimeBundleID == bundleID, let model = oneTimeModel else { return nil }
+        oneTimeBundleID = nil
+        oneTimeModel = nil
+        return model
+    }
+}

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -136,7 +136,7 @@ class ContentViewModel: ObservableObject {
         startFreshLoad(query: query)
     }
     
-    func handleProgressUpdate(id: UUID, transcription: String?, progress: Float, status: RecordingStatus, isRegeneration: Bool?) {
+    func handleProgressUpdate(id: UUID, transcription: String?, progress: Float, status: RecordingStatus, isRegeneration: Bool?, modelUsed: String? = nil, wasFallback: Bool? = nil) {
         if let index = recordings.firstIndex(where: { $0.id == id }) {
             if let transcription = transcription {
                 recordings[index].transcription = transcription
@@ -145,6 +145,12 @@ class ContentViewModel: ObservableObject {
             recordings[index].status = status
             if let isRegeneration = isRegeneration {
                 recordings[index].isRegeneration = isRegeneration
+            }
+            if let modelUsed {
+                recordings[index].modelUsed = modelUsed
+            }
+            if let wasFallback {
+                recordings[index].wasFallback = wasFallback
             }
         }
     }
@@ -176,6 +182,10 @@ class ContentViewModel: ObservableObject {
     }
 
     func startRecording() {
+        // Capture where the dictation is happening (frontmost app + browser site)
+        // for the transcript's source metadata.
+        RecordingContext.shared.captureFrontmost()
+
         if microphoneService.isActiveMicrophoneRequiresConnection() {
             state = .connecting
             stopBlinking()
@@ -234,8 +244,16 @@ class ContentViewModel: ObservableObject {
                         // Move the temporary recording to final location
                         try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
 
+                        // Source context captured at record-start.
+                        let ctx = RecordingContext.shared
+
                         // Save the recording to store
                         await MainActor.run {
+                            // The model that actually produced the text (the local fallback,
+                            // not the configured remote model, when the server was unreachable).
+                            let modelUsed = TranscriptionService.shared.lastUsedModel?.displayName
+                                ?? ModelCatalog.activeOption()?.displayName
+                            let wasFallback = TranscriptionService.shared.lastUsedFallback
                             let newRecording = Recording(
                                 id: recordingId,
                                 timestamp: timestamp,
@@ -244,7 +262,12 @@ class ContentViewModel: ObservableObject {
                                 duration: self.recordingDuration,
                                 status: .completed,
                                 progress: 1.0,
-                                sourceFileURL: nil
+                                sourceFileURL: nil,
+                                sourceAppName: ctx.appName,
+                                sourceWindowTitle: ctx.windowTitle,
+                                sourceURL: ctx.fullURL,
+                                modelUsed: modelUsed,
+                                wasFallback: wasFallback
                             )
                             self.recordingStore.addRecording(newRecording)
 
@@ -479,9 +502,9 @@ struct ContentView: View {
                                         onDelete: {
                                             viewModel.deleteRecording(recording)
                                         },
-                                        onRegenerate: {
+                                        onRegenerate: { model in
                                             Task {
-                                                await TranscriptionQueue.shared.requeueRecording(recording)
+                                                await TranscriptionQueue.shared.requeueRecording(recording, model: model)
                                             }
                                         }
                                     )
@@ -677,13 +700,17 @@ struct ContentView: View {
             
             let transcription = userInfo["transcription"] as? String
             let isRegeneration = userInfo["isRegeneration"] as? Bool
-            
+            let modelUsed = userInfo["modelUsed"] as? String
+            let wasFallback = userInfo["wasFallback"] as? Bool
+
             viewModel.handleProgressUpdate(
                 id: id,
                 transcription: transcription,
                 progress: progress,
                 status: status,
-                isRegeneration: isRegeneration
+                isRegeneration: isRegeneration,
+                modelUsed: modelUsed,
+                wasFallback: wasFallback
             )
         }
         .onReceive(NotificationCenter.default.publisher(for: RecordingStore.recordingsDidUpdateNotification)) { _ in
@@ -795,8 +822,22 @@ struct RecordingRow: View {
     let recording: Recording
     let searchQuery: String
     let onDelete: () -> Void
-    let onRegenerate: () -> Void
+    /// nil → rerun with the current model; otherwise rerun once with that model. (F3)
+    let onRegenerate: (DictationModelOption?) -> Void
     @StateObject private var audioRecorder = AudioRecorder.shared
+
+    /// Models offered in the rerun dropdown — everything usable right now across engines.
+    private var rerunModels: [DictationModelOption] {
+        ModelCatalog.allAvailable()
+    }
+
+    /// Where the dictation happened (target app · site), for the row's second line.
+    /// The model used is rendered separately, right-aligned — see the row body.
+    private var sourceLabel: String? {
+        let site = SourceCapture.host(of: recording.sourceURL) ?? recording.sourceWindowTitle
+        let context = [recording.sourceAppName, site].compactMap { $0 }.joined(separator: " · ")
+        return context.isEmpty ? nil : context
+    }
     @State private var showTranscription = false
     @State private var isHovered = false
     @Environment(\.colorScheme) private var colorScheme
@@ -934,21 +975,55 @@ struct RecordingRow: View {
                 .padding(.vertical, 8)
 
             HStack(alignment: .center, spacing: 8) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(recording.timestamp, style: .date)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-
-                    HStack(spacing: 4) {
-                        Text(recording.timestamp, style: .time)
-                        Text("·")
-                        Text(TextUtil.formatDuration(recording.duration))
-                        Text("·")
-                        Text("^[\(TextUtil.wordCount(recording.transcription)) word](inflect: true)")
+                VStack(alignment: .leading, spacing: 3) {
+                    // Row 1: date (left) · time / duration / words (right).
+                    HStack(spacing: 8) {
+                        Text(recording.timestamp, style: .date)
+                            .font(.subheadline)
+                        Spacer(minLength: 8)
+                        HStack(spacing: 4) {
+                            Text(recording.timestamp, style: .time)
+                            Text("·")
+                            Text(TextUtil.formatDuration(recording.duration))
+                            Text("·")
+                            Text("^[\(TextUtil.wordCount(recording.transcription)) word](inflect: true)")
+                        }
+                        .font(.caption)
                     }
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+
+                    // Row 2: source app / site (left) · model used (right, cpu glyph).
+                    // Omitted when there's no metadata (older recordings, file imports).
+                    if sourceLabel != nil || recording.modelUsed != nil {
+                        HStack(spacing: 8) {
+                            if let sourceLabel {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "macwindow")
+                                    Text(sourceLabel)
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                }
+                            }
+                            Spacer(minLength: 8)
+                            if let model = recording.modelUsed {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "cpu")
+                                    Text(model)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                }
+                                // Orange only when this transcription came from the remote
+                                // engine's local fallback (server was unreachable), so a
+                                // surprising result is easy to spot back in the history.
+                                .foregroundColor(recording.wasFallback ? .orange : .secondary)
+                                .help(recording.wasFallback
+                                      ? "Local fallback — the remote server was unreachable"
+                                      : "")
+                            }
+                        }
+                        .font(.caption2)
+                    }
                 }
+                .foregroundColor(.secondary)
                 
                 if isRegenerating {
                     Spacer()
@@ -1021,15 +1096,37 @@ struct RecordingRow: View {
                     }
 
                     if (recording.status == .completed || recording.status == .failed) && isHovered {
-                        Button(action: {
-                            onRegenerate()
-                        }) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 18))
-                                .foregroundColor(.secondary)
+                        // Two controls: the icon reruns with the current model; the visible
+                        // chevron opens a picker that reruns once with a specific model without
+                        // changing the default. The chevron is the discoverable affordance. (F3)
+                        HStack(spacing: 1) {
+                            Button(action: { onRegenerate(nil) }) {
+                                Image(systemName: "arrow.clockwise")
+                                    .font(.system(size: 18))
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Regenerate (current model)")
+
+                            Menu {
+                                Button("Current model") { onRegenerate(nil) }
+                                if !rerunModels.isEmpty {
+                                    Divider()
+                                    ForEach(rerunModels.indices, id: \.self) { i in
+                                        Button(rerunModels[i].displayName) { onRegenerate(rerunModels[i]) }
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "chevron.down")
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundColor(.secondary)
+                            }
+                            .menuStyle(.button)
+                            .menuIndicator(.hidden)
+                            .buttonStyle(.plain)
+                            .fixedSize()
+                            .help("Regenerate with a specific model")
                         }
-                        .buttonStyle(.plain)
-                        .help("Regenerate transcription")
                         .transition(.opacity)
                     }
 

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Cocoa
 import Combine
 import SwiftUI
@@ -115,6 +116,12 @@ class IndicatorViewModel: ObservableObject {
             return
         }
 
+        // Capture where the dictation is happening (frontmost app, browser site/URL,
+        // window title) for the transcript's source metadata. This runs
+        // AppleScript/Accessibility synchronously on the main thread; it's quick,
+        // but see the note in RecordingContext.captureFrontmost.
+        RecordingContext.shared.captureFrontmost()
+
         // Show recording immediately and optimistically. Whether the mic needs a
         // connection is decided off the main thread inside `recorder.startRecording()`
         // (it touches AVFoundation/CoreAudio, which can stall); the recorder then
@@ -148,6 +155,13 @@ class IndicatorViewModel: ObservableObject {
 
     static var shouldUseLiveStreaming: Bool {
         AppPreferences.shared.liveTranscriptionEnabled && AppPreferences.shared.selectedEngine == "fluidaudio"
+    }
+
+    /// Real duration of a saved audio file, in seconds (0 if it can't be read).
+    nonisolated static func audioDuration(of url: URL) async -> TimeInterval {
+        guard let seconds = try? await AVURLAsset(url: url).load(.duration) else { return 0 }
+        let value = CMTimeGetSeconds(seconds)
+        return value.isFinite ? value : 0
     }
 
     func startDecoding() {
@@ -215,19 +229,10 @@ class IndicatorViewModel: ObservableObject {
                         try recorder.moveTemporaryRecording(from: tempURL, to: finalURL)
                         hookAudioPath = finalURL.path
 
-                        // Save the recording to store
-                        await MainActor.run {
-                            self.recordingStore.addRecording(Recording(
-                                id: recordingId,
-                                timestamp: timestamp,
-                                fileName: fileName,
-                                transcription: text,
-                                duration: 0,
-                                status: .completed,
-                                progress: 1.0,
-                                sourceFileURL: nil
-                            ))
-                        }
+                        await self.storeRecording(
+                            id: recordingId, timestamp: timestamp, fileName: fileName,
+                            finalURL: finalURL, transcription: text,
+                            status: .completed, progress: 1.0)
                     } else {
                         // Delete the temporary recording immediately
                         try? FileManager.default.removeItem(at: tempURL)
@@ -263,18 +268,10 @@ class IndicatorViewModel: ObservableObject {
                     // and can be re-run with the regenerate (↻) button. Otherwise discard.
                     if AppPreferences.shared.saveTranscriptionHistory,
                        let saved = self.persistFailedRecording(tempURL: tempURL) {
-                        await MainActor.run {
-                            self.recordingStore.addRecording(Recording(
-                                id: saved.id,
-                                timestamp: saved.timestamp,
-                                fileName: saved.fileName,
-                                transcription: "Transcription failed — click ↻ to try again.",
-                                duration: 0,
-                                status: .failed,
-                                progress: 0,
-                                sourceFileURL: nil
-                            ))
-                        }
+                        await self.storeRecording(
+                            id: saved.id, timestamp: saved.timestamp, fileName: saved.fileName,
+                            finalURL: saved.url, transcription: "Transcription failed — click ↻ to try again.",
+                            status: .failed, progress: 0)
                     } else {
                         try? FileManager.default.removeItem(at: tempURL)
                     }
@@ -296,6 +293,36 @@ class IndicatorViewModel: ObservableObject {
         }
     }
     
+    /// Insert a recording (already at its final URL) into the store with the measured
+    /// audio duration and the captured source context (app / window / URL / model used).
+    /// Shared by the success and failure paths so their metadata wiring can't drift.
+    private func storeRecording(id: UUID, timestamp: Date, fileName: String, finalURL: URL,
+                                transcription: String, status: RecordingStatus, progress: Float) async {
+        let realDuration = await Self.audioDuration(of: finalURL)
+        let ctx = RecordingContext.shared
+        // The model that actually produced the text (which is the local fallback, not
+        // the configured remote model, when the server was unreachable).
+        let modelUsed = transcriptionService.lastUsedModel?.displayName ?? ModelCatalog.activeOption()?.displayName
+        let wasFallback = transcriptionService.lastUsedFallback
+        await MainActor.run {
+            self.recordingStore.addRecording(Recording(
+                id: id,
+                timestamp: timestamp,
+                fileName: fileName,
+                transcription: transcription,
+                duration: realDuration,
+                status: status,
+                progress: progress,
+                sourceFileURL: nil,
+                sourceAppName: ctx.appName,
+                sourceWindowTitle: ctx.windowTitle,
+                sourceURL: ctx.fullURL,
+                modelUsed: modelUsed,
+                wasFallback: wasFallback
+            ))
+        }
+    }
+
     /// Move a temp recording to its permanent location after a FAILED transcription
     /// so the audio survives and can be re-run from the history list. Returns the
     /// saved identity, or nil if the file move failed (then the temp is discarded).

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -18,11 +18,23 @@ struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equ
     var status: RecordingStatus
     var progress: Float
     var sourceFileURL: String?
-    
+    // Where the dictation happened (captured at record-start). All optional with
+    // nil defaults so existing Recording(...) call sites (file imports, etc.) and
+    // older recordings keep working.
+    var sourceAppName: String? = nil
+    var sourceWindowTitle: String? = nil
+    var sourceURL: String? = nil
+    /// Display name of the model used for this transcription (e.g. "whisper-large-v3").
+    var modelUsed: String? = nil
+    /// True when this transcription came from the remote engine's local fallback (the
+    /// server was unreachable). The history row tints the model label to flag it.
+    var wasFallback: Bool = false
+
     var isRegeneration: Bool = false
-    
+
     enum CodingKeys: String, CodingKey {
         case id, timestamp, fileName, transcription, duration, status, progress, sourceFileURL
+        case sourceAppName, sourceWindowTitle, sourceURL, modelUsed, wasFallback
     }
 
     static func == (lhs: Recording, rhs: Recording) -> Bool {
@@ -65,6 +77,11 @@ struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equ
         static let status = Column(CodingKeys.status)
         static let progress = Column(CodingKeys.progress)
         static let sourceFileURL = Column(CodingKeys.sourceFileURL)
+        static let sourceAppName = Column(CodingKeys.sourceAppName)
+        static let sourceWindowTitle = Column(CodingKeys.sourceWindowTitle)
+        static let sourceURL = Column(CodingKeys.sourceURL)
+        static let modelUsed = Column(CodingKeys.modelUsed)
+        static let wasFallback = Column(CodingKeys.wasFallback)
     }
 }
 
@@ -128,7 +145,38 @@ class RecordingStore: ObservableObject {
                 }
             }
         }
-        
+
+        // Appended AFTER my-monkeys' latest migration (v2_add_status). Both columns are
+        // nullable text, so old rows simply get NULL. Guarded by a column-existence check
+        // so re-running is a no-op.
+        migrator.registerMigration("v3_add_source_context") { db in
+            let columnNames = try db.columns(in: Recording.databaseTableName).map { $0.name }
+            for column in ["sourceAppName", "sourceWindowTitle", "sourceURL"]
+            where !columnNames.contains(column) {
+                try db.alter(table: Recording.databaseTableName) { t in
+                    t.add(column: column, .text)
+                }
+            }
+        }
+
+        migrator.registerMigration("v4_add_model_used") { db in
+            let columnNames = try db.columns(in: Recording.databaseTableName).map { $0.name }
+            if !columnNames.contains("modelUsed") {
+                try db.alter(table: Recording.databaseTableName) { t in
+                    t.add(column: "modelUsed", .text)
+                }
+            }
+        }
+
+        migrator.registerMigration("v5_add_was_fallback") { db in
+            let columnNames = try db.columns(in: Recording.databaseTableName).map { $0.name }
+            if !columnNames.contains("wasFallback") {
+                try db.alter(table: Recording.databaseTableName) { t in
+                    t.add(column: "wasFallback", .boolean).notNull().defaults(to: false)
+                }
+            }
+        }
+
         try migrator.migrate(dbQueue)
     }
     
@@ -238,16 +286,23 @@ class RecordingStore: ObservableObject {
     
     static let recordingProgressDidUpdateNotification = Notification.Name("RecordingStore.recordingProgressDidUpdate")
     
-    func updateRecordingProgressOnlySync(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil) async {
+    func updateRecordingProgressOnlySync(_ id: UUID, transcription: String, progress: Float, status: RecordingStatus, isRegeneration: Bool? = nil, modelUsed: String? = nil, wasFallback: Bool? = nil) async {
         do {
             _ = try await dbQueue.write { db -> Int in
-                try Recording
+                var assignments = [
+                    Recording.Columns.transcription.set(to: transcription),
+                    Recording.Columns.progress.set(to: progress),
+                    Recording.Columns.status.set(to: status.rawValue)
+                ]
+                if let modelUsed {
+                    assignments.append(Recording.Columns.modelUsed.set(to: modelUsed))
+                }
+                if let wasFallback {
+                    assignments.append(Recording.Columns.wasFallback.set(to: wasFallback))
+                }
+                return try Recording
                     .filter(Recording.Columns.id == id)
-                    .updateAll(db, [
-                        Recording.Columns.transcription.set(to: transcription),
-                        Recording.Columns.progress.set(to: progress),
-                        Recording.Columns.status.set(to: status.rawValue)
-                    ])
+                    .updateAll(db, assignments)
             }
             if let index = recordings.firstIndex(where: { $0.id == id }) {
                 var updated = recordings[index]
@@ -257,9 +312,15 @@ class RecordingStore: ObservableObject {
                 if let isRegeneration = isRegeneration {
                     updated.isRegeneration = isRegeneration
                 }
+                if let modelUsed {
+                    updated.modelUsed = modelUsed
+                }
+                if let wasFallback {
+                    updated.wasFallback = wasFallback
+                }
                 recordings[index] = updated
             }
-            
+
             var userInfo: [String: Any] = [
                 "id": id,
                 "transcription": transcription,
@@ -269,7 +330,13 @@ class RecordingStore: ObservableObject {
             if let isRegeneration = isRegeneration {
                 userInfo["isRegeneration"] = isRegeneration
             }
-            
+            if let modelUsed {
+                userInfo["modelUsed"] = modelUsed
+            }
+            if let wasFallback {
+                userInfo["wasFallback"] = wasFallback
+            }
+
             await MainActor.run {
                 NotificationCenter.default.post(name: Self.recordingProgressDidUpdateNotification, object: nil, userInfo: userInfo)
             }

--- a/OpenSuperWhisper/OpenSuperWhisper-Info.plist
+++ b/OpenSuperWhisper/OpenSuperWhisper-Info.plist
@@ -24,7 +24,7 @@
 	<key>NSAccessibilityUsageDescription</key>
 	<string>OpenSuperWhisper needs accessibility access to provide system-wide functionality.</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>OpenSuperWhisper needs accessibility access to provide system-wide functionality.</string>
+	<string>OpenSuperWhisper reads the active browser tab's URL to record where a dictation happened and to apply per-site model rules.</string>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/my-monkeys/OpenSuperWhisper/master/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/OpenSuperWhisper/TranscriptionQueue.swift
+++ b/OpenSuperWhisper/TranscriptionQueue.swift
@@ -16,6 +16,9 @@ class TranscriptionQueue: ObservableObject {
     private var currentTranscriptionTask: Task<Void, Never>?
     private var cancelledRecordingIds: Set<UUID> = []
     private var progressCancellable: AnyCancellable?
+    // One-off model for a specific rerun (keyed by recording id). Applied for
+    // that transcription only, then the system default is restored. (F3)
+    private var modelOverrides: [UUID: DictationModelOption] = [:]
 
     private init() {
         self.transcriptionService = TranscriptionService.shared
@@ -143,7 +146,10 @@ class TranscriptionQueue: ObservableObject {
         }
     }
 
-    func requeueRecording(_ recording: Recording) async {
+    func requeueRecording(_ recording: Recording, model: DictationModelOption? = nil) async {
+        if let model {
+            modelOverrides[recording.id] = model
+        }
         let sourceURL: URL? = await Task.detached(priority: .userInitiated) {
             if let existingSource = recording.sourceFileURL,
                !existingSource.isEmpty,
@@ -245,6 +251,11 @@ class TranscriptionQueue: ObservableObject {
             )
         }
 
+        // Apply a one-off model for this rerun (from the rerun dropdown), then restore
+        // the system default once it finishes — the rerun-side analog of "Just This Time".
+        let restoreOverride = applyModelOverride(for: recording.id)
+        defer { restoreOverride() }
+
         currentTranscriptionTask = Task {
             do {
                 if isRecordingCancelled(recording.id) {
@@ -277,12 +288,20 @@ class TranscriptionQueue: ObservableObject {
                     }
                 }.value
 
+                // The model that actually produced the text — the local fallback, not the
+                // configured/override model, when a remote rerun fell back to local.
+                let (modelUsed, wasFallback) = await MainActor.run {
+                    (TranscriptionService.shared.lastUsedModel?.displayName,
+                     TranscriptionService.shared.lastUsedFallback)
+                }
                 await recordingStore.updateRecordingProgressOnlySync(
                     recording.id,
                     transcription: text,
                     progress: 1.0,
                     status: .completed,
-                    isRegeneration: false
+                    isRegeneration: false,
+                    modelUsed: modelUsed,
+                    wasFallback: wasFallback
                 )
 
             } catch {
@@ -303,4 +322,31 @@ class TranscriptionQueue: ObservableObject {
         clearCancellation(recording.id)
     }
 
+    /// Temporarily switch to a recording's one-off override model and return a
+    /// closure restoring the previous settings + engine. No override → no-op.
+    private func applyModelOverride(for recordingID: UUID) -> () -> Void {
+        guard let option = modelOverrides.removeValue(forKey: recordingID) else { return {} }
+        let prefs = AppPreferences.shared
+        let previousEngine = prefs.selectedEngine
+        let previousWhisper = prefs.selectedWhisperModelPath
+        let previousFluid = prefs.fluidAudioModelVersion
+        let previousRemote = prefs.remoteServerModel
+
+        prefs.selectedEngine = option.engine
+        switch option.engine {
+        case "whisper": prefs.selectedWhisperModelPath = option.identifier
+        case "fluidaudio": prefs.fluidAudioModelVersion = option.identifier
+        case "remote": prefs.remoteServerModel = option.identifier
+        default: break
+        }
+        transcriptionService.reloadEngine()
+
+        return {
+            prefs.selectedEngine = previousEngine
+            prefs.selectedWhisperModelPath = previousWhisper
+            prefs.fluidAudioModelVersion = previousFluid
+            prefs.remoteServerModel = previousRemote
+            self.transcriptionService.reloadEngine()
+        }
+    }
 }

--- a/OpenSuperWhisper/Utils/FocusUtils.swift
+++ b/OpenSuperWhisper/Utils/FocusUtils.swift
@@ -20,8 +20,8 @@ class FocusUtils {
     /// browser/Electron app) blocks the calling thread — and since the global
     /// hotkey tap runs on the main run loop, that freezes the whole app and the
     /// recording shortcut (#freeze). Half a second is far longer than a healthy
-    /// AX reply and short enough to fall back gracefully.
-    private static let axMessagingTimeout: Float = 0.5
+    /// AX reply and short enough to fall back gracefully. Shared with SourceCapture.
+    static let axMessagingTimeout: Float = 0.5
 
     static func getCurrentCursorPosition() -> NSPoint {
         return NSEvent.mouseLocation

--- a/OpenSuperWhisper/Utils/SourceCapture.swift
+++ b/OpenSuperWhisper/Utils/SourceCapture.swift
@@ -1,0 +1,65 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+/// Best-effort capture of "where" a dictation happened, beyond the app name: the
+/// focused window's title (Accessibility) and, for supported browsers, the active
+/// tab's URL (AppleScript — triggers a one-time automation permission per app).
+enum SourceCapture {
+    /// Title of the system-wide focused window (e.g. a browser tab or document).
+    static func focusedWindowTitle() -> String? {
+        // These AX calls are synchronous IPC to the frontmost app and run on the
+        // main thread at record-start / menu-open; a wedged target would freeze the
+        // recording hotkey without a timeout (#freeze). Bound every request, exactly
+        // as FocusUtils does.
+        let system = AXUIElementCreateSystemWide()
+        AXUIElementSetMessagingTimeout(system, FocusUtils.axMessagingTimeout)
+        var windowRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            system, kAXFocusedWindowAttribute as CFString, &windowRef
+        ) == .success, let windowRef else { return nil }
+
+        let window = windowRef as! AXUIElement
+        AXUIElementSetMessagingTimeout(window, FocusUtils.axMessagingTimeout)
+        var titleRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            window, kAXTitleAttribute as CFString, &titleRef
+        ) == .success else { return nil }
+
+        let title = titleRef as? String
+        return (title?.isEmpty == false) ? title : nil
+    }
+
+    /// AppleScript to read the active tab/document URL, keyed by bundle id.
+    private static let browserScripts: [String: String] = [
+        "com.google.Chrome": "tell application \"Google Chrome\" to return URL of active tab of front window",
+        "com.google.Chrome.beta": "tell application \"Google Chrome Beta\" to return URL of active tab of front window",
+        "com.brave.Browser": "tell application \"Brave Browser\" to return URL of active tab of front window",
+        "com.microsoft.edgemac": "tell application \"Microsoft Edge\" to return URL of active tab of front window",
+        "com.vivaldi.Vivaldi": "tell application \"Vivaldi\" to return URL of active tab of front window",
+        "company.thebrowser.Browser": "tell application \"Arc\" to return URL of active tab of front window",
+        "com.apple.Safari": "tell application \"Safari\" to return URL of front document",
+    ]
+
+    /// Active-tab URL for a known browser bundle id, or nil (not a browser, no
+    /// window, or automation permission denied). Synchronous — call on the main
+    /// thread (NSAppleScript requirement).
+    static func browserURL(bundleID: String) -> String? {
+        guard let source = browserScripts[bundleID],
+              let script = NSAppleScript(source: source) else { return nil }
+        var error: NSDictionary?
+        let result = script.executeAndReturnError(&error)
+        guard error == nil else { return nil }
+        let url = result.stringValue
+        return (url?.isEmpty == false) ? url : nil
+    }
+
+    /// Host of a URL string, "www." stripped — e.g. "github.com". For display and
+    /// (later) per-site rules.
+    static func host(of urlString: String?) -> String? {
+        guard let urlString,
+              let host = URLComponents(string: urlString)?.host,
+              !host.isEmpty else { return nil }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+}

--- a/OpenSuperWhisperTests/SourceCaptureHostTests.swift
+++ b/OpenSuperWhisperTests/SourceCaptureHostTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// `SourceCapture.host(of:)` extracts a bare hostname from a browser URL for the
+/// per-site model rules and the history "source" line — stripping a leading
+/// `www.` so a rule keyed on `github.com` still matches `www.github.com`. This
+/// guards the parsing edge cases (nil / empty / non-URL / no host) so a malformed
+/// URL never crashes or yields a bogus site key.
+final class SourceCaptureHostTests: XCTestCase {
+
+    func testExtractsHost() {
+        XCTAssertEqual(SourceCapture.host(of: "https://docs.google.com/document/d/abc"), "docs.google.com")
+        XCTAssertEqual(SourceCapture.host(of: "http://litellm.docker.lan:4000/v1"), "litellm.docker.lan")
+    }
+
+    func testStripsLeadingWWW() {
+        XCTAssertEqual(SourceCapture.host(of: "https://www.github.com/user/repo"), "github.com")
+    }
+
+    func testDoesNotStripWWWWhenPartOfLabel() {
+        // "www2" is not the "www." prefix — leave it intact.
+        XCTAssertEqual(SourceCapture.host(of: "https://www2.example.com"), "www2.example.com")
+    }
+
+    func testReturnsNilForNilEmptyOrNonURL() {
+        XCTAssertNil(SourceCapture.host(of: nil))
+        XCTAssertNil(SourceCapture.host(of: ""))
+        XCTAssertNil(SourceCapture.host(of: "justtext"))
+        XCTAssertNil(SourceCapture.host(of: "/relative/path"))
+    }
+}


### PR DESCRIPTION
Third slice of #21, carved by the maintainers (menu item **8**) — code by @EvanSchalton, credited via commit co-authorship.

- Source app / window title / browser URL + model per recording (GRDB migrations v3/v4/v5, guarded); orange chip when the local fallback produced the text.
- 2×2 metadata layout on history rows; regenerate becomes a menu with one-off model override (transient, restore-on-error).
- Real audio duration measured from the file (fixes the stored `duration: 0`).
- `RecordingContext` (capture-only) lands here; the per-app/per-site rules arrive with the App Context slice.

Suite: **173 tests green locally**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzqCgLqxHEtcEFLsSKxD5V