### PR TITLE
feat: App Context — per-app/per-site model rules + menu-bar Model picker (from #21)

### DIFF
--- a/OpenSuperWhisper/AppContextModelRules.swift
+++ b/OpenSuperWhisper/AppContextModelRules.swift
@@ -1,6 +1,32 @@
 import AppKit
 import Foundation
 
+/// How context-aware model selection behaves.
+enum ContextAwareModelMode: String, CaseIterable {
+    /// Auto-switch by app, and prompt (System Default / app / once / forget) when
+    /// you change the model in the menu.
+    case ask
+    /// Auto-switch by app, but changing the model in the menu just sets the
+    /// system default — no prompt. Set up app rules in "Ask", then switch here to
+    /// stop the per-change prompts.
+    case auto
+    /// No auto-switch and no prompts.
+    case off
+
+    var label: String {
+        switch self {
+        case .ask: return "Ask on change"
+        case .auto: return "Auto · no prompt"
+        case .off: return "Off"
+        }
+    }
+
+    /// Auto-switch to an app's bound model at record-start?
+    var autoSwitches: Bool { self != .off }
+    /// Prompt for scope when the model changes in the menu?
+    var prompts: Bool { self == .ask }
+}
+
 /// The app the user is currently targeting — refreshed at record-start and when
 /// the menu-bar picker opens — so binding a model maps to the right app.
 /// Runtime-only.
@@ -70,5 +96,89 @@ final class RecordingContext {
         oneTimeBundleID = nil
         oneTimeModel = nil
         return model
+    }
+}
+
+/// Per-app default model rules: bundle id → model. Persisted as JSON in
+/// AppPreferences. Rules are created only when the user confirms the menu-bar
+/// prompt, so this holds deliberate choices — never every app touched.
+enum AppContextModelRules {
+    /// Posted after any rule is added, changed, or removed (from this tab or the
+    /// menu-bar "Model" submenu), so open UI can refresh live.
+    static let didChangeNotification = Notification.Name("AppContextModelRulesDidChange")
+
+    static func all() -> [String: DictationModelOption] {
+        let data = AppPreferences.shared.appModelRulesData
+        guard !data.isEmpty,
+              let rules = try? JSONDecoder().decode(
+                  [String: DictationModelOption].self, from: data
+              )
+        else { return [:] }
+        return rules
+    }
+
+    /// Composite key: "bundleID|host" for a per-site rule, "bundleID" for an
+    /// app-wide rule.
+    static func key(bundleID: String, host: String?) -> String {
+        if let host, !host.isEmpty { return "\(bundleID)|\(host)" }
+        return bundleID
+    }
+
+    /// Resolved rule for the current context: a site-specific rule wins, else the
+    /// app-level rule.
+    static func rule(for bundleID: String, host: String? = nil) -> DictationModelOption? {
+        let rules = all()
+        if let host, !host.isEmpty, let site = rules["\(bundleID)|\(host)"] { return site }
+        return rules[bundleID]
+    }
+
+    /// The rule stored at exactly this scope (site if a host is given, else app)
+    /// — for the "Forget" option and to know what a bind would replace.
+    static func exactRule(for bundleID: String, host: String?) -> DictationModelOption? {
+        all()[key(bundleID: bundleID, host: host)]
+    }
+
+    static func set(_ option: DictationModelOption, for bundleID: String, host: String? = nil) {
+        var rules = all()
+        rules[key(bundleID: bundleID, host: host)] = option
+        save(rules)
+    }
+
+    static func remove(bundleID: String, host: String? = nil) {
+        var rules = all()
+        rules.removeValue(forKey: key(bundleID: bundleID, host: host))
+        save(rules)
+    }
+
+    private static func save(_ rules: [String: DictationModelOption]) {
+        if let data = try? JSONEncoder().encode(rules) {
+            AppPreferences.shared.appModelRulesData = data
+            NotificationCenter.default.post(name: didChangeNotification, object: nil)
+        }
+    }
+}
+
+/// Applies context-aware model selection at record-start. Kept here so the main
+/// window and the indicator recording paths share one implementation.
+enum ContextModelSwitcher {
+    /// Switch to the model bound to the current app/site (if any), honoring a
+    /// pending one-time override. No-op when the mode doesn't auto-switch or when
+    /// the bound model is already active. Reads the live `RecordingContext`, so
+    /// call `RecordingContext.shared.captureFrontmost()` first.
+    static func applyForCurrentContext() {
+        guard AppPreferences.shared.contextAwareModelMode.autoSwitches,
+              let bundleID = RecordingContext.shared.bundleID else { return }
+        let host = RecordingContext.shared.host
+
+        // A "Just This Time" override wins for exactly the next recording.
+        if let once = RecordingContext.shared.consumeOneTimeModel(for: bundleID) {
+            if ModelCatalog.activeOption() != once { ModelCatalog.activate(once) }
+            return
+        }
+
+        guard let rule = AppContextModelRules.rule(for: bundleID, host: host) else { return }
+        if ModelCatalog.activeOption() != rule {
+            ModelCatalog.activate(rule)
+        }
     }
 }

--- a/OpenSuperWhisper/AppContextSettingsView.swift
+++ b/OpenSuperWhisper/AppContextSettingsView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Settings → App Context. One place to manage context-aware model selection:
+/// the switching mode plus a list of every app/site → model rule, with inline
+/// model pickers and add/remove controls. Rules are also created from the
+/// menu-bar "Model" submenu; this tab shows and edits the same store.
+struct AppContextSettingsView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    @State private var rules: [AppContextRuleRow] = []
+    @State private var selectedID: String?
+    /// All usable models right now, across engines — recomputed on appear and
+    /// after edits. Context-aware selection only makes sense with 2+.
+    @State private var availableModels: [DictationModelOption] = []
+
+    private var hasChoice: Bool { availableModels.count > 1 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            if hasChoice {
+                modeCard
+                rulesCard
+            } else {
+                singleModelNotice
+                Spacer(minLength: 0)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onAppear(perform: reload)
+        .onReceive(NotificationCenter.default.publisher(for: AppContextModelRules.didChangeNotification)) { _ in
+            reload()
+        }
+    }
+
+    // MARK: - Single-model notice
+
+    private var singleModelNotice: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "square.stack.3d.up.slash")
+                    .font(.title2)
+                    .foregroundColor(.secondary)
+                Text("App-Specific Models")
+                    .font(.headline)
+            }
+            Text("Context-aware model selection switches the transcription model based on the app (or website) you're dictating in — so it only helps once you have more than one model to choose from.")
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Please download or configure another model to enable app-specific model selection.")
+                .font(.callout).bold()
+                .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("Add a model under Engine & Model (download a Whisper / Parakeet / SenseVoice model, or point the Remote engine at a server).")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Mode card (moved here from Advanced)
+
+    private var modeCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 5) {
+                Text("Context-Aware Model")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                InfoButton(text: "Bind a transcription model to an app (or a website, in supported browsers) so it switches automatically when you dictate there. Add a rule below (＋), or from the menu-bar “Model” submenu while that app is focused.\n\n• Ask on change — auto-switch by app, and ask the scope (System Default / this app / just once / forget) whenever you pick a model in the menu.\n• Auto · no prompt — auto-switch by app, but picking a model just sets the system default (no prompt). Set rules up in “Ask”, then switch here.\n• Off — no auto-switch and no prompts.")
+            }
+
+            HStack {
+                Text("Mode")
+                    .font(.subheadline)
+                Spacer()
+                Picker("", selection: $viewModel.contextAwareModelMode) {
+                    ForEach(ContextAwareModelMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Rules list card
+
+    private var rulesCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("App & Site Rules")
+                .font(.headline)
+                .foregroundColor(.primary)
+
+            VStack(spacing: 0) {
+                if rules.isEmpty {
+                    Text("No rules yet. Click ＋ to add an app, or bind a model from the menu-bar “Model” submenu while an app is focused.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .padding(.horizontal, 12)
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(rules) { rule in
+                                ruleRow(rule)
+                                if rule.id != rules.last?.id { Divider() }
+                            }
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+
+                Divider()
+
+                // Add / remove bar, anchored bottom-right of the list container.
+                HStack(spacing: 2) {
+                    Spacer()
+                    Button(action: addApp) {
+                        Image(systemName: "plus").frame(width: 24, height: 20)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Add an application…")
+
+                    Button(action: removeSelected) {
+                        Image(systemName: "minus").frame(width: 24, height: 20)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(selectedID == nil)
+                    .help("Remove the selected rule")
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+            }
+            .frame(maxHeight: .infinity)
+            .background(Color(.controlBackgroundColor).opacity(0.5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(.separatorColor), lineWidth: 1)
+            )
+            .cornerRadius(8)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color(.controlBackgroundColor).opacity(0.3))
+        .cornerRadius(12)
+    }
+
+    private func ruleRow(_ rule: AppContextRuleRow) -> some View {
+        let isSelected = rule.id == selectedID
+        return HStack(spacing: 10) {
+            Group {
+                if let icon = rule.icon {
+                    Image(nsImage: icon).resizable().interpolation(.high)
+                } else {
+                    Image(systemName: "app.dashed").resizable()
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(rule.appName)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let host = rule.host {
+                    Text(host)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            Picker("", selection: Binding(
+                get: { rule.model },
+                set: { newModel in
+                    AppContextModelRules.set(newModel, for: rule.bundleID, host: rule.host)
+                    reload()
+                }
+            )) {
+                ForEach(modelOptions(including: rule.model), id: \.self) { m in
+                    Text(m.displayName).tag(m)
+                }
+            }
+            .labelsHidden()
+            .fixedSize()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isSelected ? Color.accentColor.opacity(0.18) : Color.clear)
+        .contentShape(Rectangle())
+        .onTapGesture { selectedID = rule.id }
+    }
+
+    // MARK: - Data
+
+    private func reload() {
+        availableModels = ModelCatalog.allAvailable()
+        rules = AppContextRuleRow.loadAll()
+        if let sel = selectedID, !rules.contains(where: { $0.id == sel }) {
+            selectedID = nil
+        }
+    }
+
+    /// Models offered in a row's picker: everything usable now, plus the rule's
+    /// current model if it isn't currently available (so the choice is never lost).
+    private func modelOptions(including current: DictationModelOption) -> [DictationModelOption] {
+        var options = availableModels
+        if !options.contains(current) { options.insert(current, at: 0) }
+        return options
+    }
+
+    private func addApp() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose an Application"
+        panel.prompt = "Add"
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.treatsFilePackagesAsDirectories = false
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
+
+        // Default the new rule to whatever model is currently in effect.
+        guard let defaultModel = ModelCatalog.activeOption() ?? availableModels.first else { return }
+        AppContextModelRules.set(defaultModel, for: bundleID)
+        reload()
+        selectedID = bundleID
+    }
+
+    private func removeSelected() {
+        guard let id = selectedID, let rule = rules.first(where: { $0.id == id }) else { return }
+        AppContextModelRules.remove(bundleID: rule.bundleID, host: rule.host)
+        selectedID = nil
+        reload()
+    }
+}
+
+/// One displayable app/site rule, resolved from the persisted store.
+struct AppContextRuleRow: Identifiable {
+    /// Storage key: "bundleID" (app-wide) or "bundleID|host" (per-site).
+    let id: String
+    let bundleID: String
+    let host: String?
+    let model: DictationModelOption
+    let appName: String
+    let icon: NSImage?
+
+    static func loadAll() -> [AppContextRuleRow] {
+        AppContextModelRules.all().map { key, model -> AppContextRuleRow in
+            let (bundleID, host) = parse(key)
+            let (name, icon) = appInfo(for: bundleID)
+            return AppContextRuleRow(id: key, bundleID: bundleID, host: host,
+                                     model: model, appName: name, icon: icon)
+        }
+        .sorted {
+            if $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedSame {
+                return ($0.host ?? "") < ($1.host ?? "")
+            }
+            return $0.appName.localizedCaseInsensitiveCompare($1.appName) == .orderedAscending
+        }
+    }
+
+    static func parse(_ key: String) -> (bundleID: String, host: String?) {
+        if let pipe = key.firstIndex(of: "|") {
+            return (String(key[..<pipe]), String(key[key.index(after: pipe)...]))
+        }
+        return (key, nil)
+    }
+
+    /// Resolve an installed app's display name + icon; fall back to the bundle id
+    /// (with a generic icon) when the app isn't installed any more.
+    private static func appInfo(for bundleID: String) -> (name: String, icon: NSImage?) {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+            return (bundleID, nil)
+        }
+        let name = FileManager.default.displayName(atPath: url.path)
+            .replacingOccurrences(of: ".app", with: "")
+        return (name, NSWorkspace.shared.icon(forFile: url.path))
+    }
+}

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -182,9 +182,10 @@ class ContentViewModel: ObservableObject {
     }
 
     func startRecording() {
-        // Capture where the dictation is happening (frontmost app + browser site)
-        // for the transcript's source metadata.
+        // Capture where the dictation is happening (frontmost app + browser site) and
+        // apply any context-aware model rule before the engine spins up. See F2.
         RecordingContext.shared.captureFrontmost()
+        ContextModelSwitcher.applyForCurrentContext()
 
         if microphoneService.isActiveMicrophoneRequiresConnection() {
             state = .connecting

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -117,10 +117,11 @@ class IndicatorViewModel: ObservableObject {
         }
 
         // Capture where the dictation is happening (frontmost app, browser site/URL,
-        // window title) for the transcript's source metadata. This runs
-        // AppleScript/Accessibility synchronously on the main thread; it's quick,
-        // but see the note in RecordingContext.captureFrontmost.
+        // window title) and apply any context-aware model rule before recording. This
+        // runs AppleScript/Accessibility synchronously on the main thread; it's quick,
+        // but see the note in RecordingContext.captureFrontmost. (F2/F3)
         RecordingContext.shared.captureFrontmost()
+        ContextModelSwitcher.applyForCurrentContext()
 
         // Show recording immediately and optimistically. Whether the mic needs a
         // connection is decided off the main thread inside `recorder.startRecording()`

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -105,10 +105,11 @@ class AppState: ObservableObject {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, ObservableObject {
     private var statusItem: NSStatusItem?
     private var mainWindow: NSWindow?
     private var languageSubmenu: NSMenu?
+    private var modelSubmenu: NSMenu?
     private var microphoneService = MicrophoneService.shared
     private var microphoneObserver: AnyCancellable?
     
@@ -208,7 +209,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private func updateStatusBarMenu() {
         let menu = NSMenu()
         
-        menu.addItem(NSMenuItem(title: "OpenSuperWhisper", action: #selector(openApp), keyEquivalent: "o"))
+        let openItem = NSMenuItem(title: "Open Window", action: #selector(openApp), keyEquivalent: "o")
+        openItem.target = self   // without a target macOS disables the item (it did nothing)
+        menu.addItem(openItem)
 
         let transcriptionLanguageItem = NSMenuItem(title: NSLocalizedString("Language", comment: ""), action: nil, keyEquivalent: "")
         languageSubmenu = NSMenu()
@@ -229,9 +232,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         transcriptionLanguageItem.submenu = languageSubmenu
         menu.addItem(transcriptionLanguageItem)
 
-        // Translation needs a Whisper-class engine; Parakeet/SenseVoice only transcribe in the
-        // source language (#124). Off those, gray the item out and say why instead of silently
-        // ignoring it. Remote forwards translation to the server's /audio/translations endpoint.
+        // Translation needs a Whisper-class model or a remote server; Parakeet/SenseVoice only
+        // transcribe in the source language (#124). Off those, gray the item out and say why
+        // instead of silently ignoring it.
         let engine = AppPreferences.shared.selectedEngine
         let translateSupported = EngineCapabilities.supportsTranslation(engine: engine)
         let translateItem = NSMenuItem(
@@ -243,6 +246,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         translateItem.target = self
         translateItem.state = (translateSupported && AppPreferences.shared.translateToEnglish) ? .on : .off
         menu.addItem(translateItem)
+
+        // Model picker — quick cross-engine switch. Its items are (re)built each time
+        // the submenu opens (menuNeedsUpdate) so newly-downloaded or newly-fetched
+        // remote models show up without relaunching. (F2)
+        let modelMenuItem = NSMenuItem(title: NSLocalizedString("Model", comment: ""), action: nil, keyEquivalent: "")
+        let modelMenu = NSMenu()
+        modelMenu.delegate = self
+        modelSubmenu = modelMenu
+        populateModelSubmenu()
+        modelMenuItem.submenu = modelMenu
+        menu.addItem(modelMenuItem)
 
         // Listen for language preference changes
         NotificationCenter.default.addObserver(
@@ -335,7 +349,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     @objc private func toggleTranslateToEnglish() {
-        AppPreferences.shared.translateToEnglish.toggle()
+        MainActor.assumeIsolated { TranslateStore.shared.toggle() }
         updateStatusBarMenu()
     }
     
@@ -343,6 +357,125 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         guard let device = sender.representedObject as? MicrophoneService.AudioDevice else { return }
         microphoneService.selectMicrophone(device)
         updateStatusBarMenu()
+    }
+
+    // MARK: - Model picker (F2)
+
+    // The Model submenu opening is the moment to snapshot the app the user is in,
+    // so binding a model targets the right app without requiring a recording first.
+    // Opening a status-bar menu doesn't steal focus, so the frontmost app is still
+    // the one the cursor is in.
+    func menuWillOpen(_ menu: NSMenu) {
+        RecordingContext.shared.captureFrontmost()
+    }
+
+    // Rebuild the Model submenu just before it opens, so it reflects the latest
+    // downloaded/fetched models and the current selection.
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        if menu === modelSubmenu {
+            populateModelSubmenu()
+        }
+    }
+
+    private func populateModelSubmenu() {
+        guard let submenu = modelSubmenu else { return }
+        submenu.removeAllItems()
+
+        let active = ModelCatalog.activeOption()
+        let groups: [(label: String, options: [DictationModelOption])] = [
+            ("Whisper", ModelCatalog.whisperModels()),
+            ("Parakeet", ModelCatalog.parakeetModels()),
+            ("SenseVoice", ModelCatalog.senseVoiceModels()),
+            ("Remote", ModelCatalog.remoteModels()),
+        ]
+
+        var addedAnything = false
+        for group in groups where !group.options.isEmpty {
+            if addedAnything { submenu.addItem(NSMenuItem.separator()) }
+            let header = NSMenuItem(title: group.label, action: nil, keyEquivalent: "")
+            header.isEnabled = false
+            submenu.addItem(header)
+
+            for option in group.options {
+                let item = NSMenuItem(
+                    title: option.displayName,
+                    action: #selector(selectModel(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = option
+                item.indentationLevel = 1
+                if let active, active.engine == option.engine, active.identifier == option.identifier {
+                    item.state = .on
+                }
+                submenu.addItem(item)
+            }
+            addedAnything = true
+        }
+
+        if !addedAnything {
+            let none = NSMenuItem(title: NSLocalizedString("No models available", comment: ""), action: nil, keyEquivalent: "")
+            none.isEnabled = false
+            submenu.addItem(none)
+        }
+    }
+
+    @objc private func selectModel(_ sender: NSMenuItem) {
+        guard let option = sender.representedObject as? DictationModelOption else { return }
+        let context = RecordingContext.shared
+        // Ask the scope only when it's meaningful: context-awareness is on, there's
+        // more than one model to choose between, and we're in a recognized app
+        // whose current rule differs. Otherwise just set the system default.
+        if AppPreferences.shared.contextAwareModelMode.prompts,
+           ModelCatalog.allAvailable().count > 1,
+           let bundleID = context.bundleID, let scopeLabel = context.scopeLabel,
+           AppContextModelRules.rule(for: bundleID, host: context.host) != option {
+            promptForModelScope(option, bundleID: bundleID, host: context.host, scopeLabel: scopeLabel)
+        } else {
+            MainActor.assumeIsolated { ModelSelectionStore.shared.select(option) }
+        }
+        populateModelSubmenu()
+    }
+
+    /// Picking a model can mean: the system default (everywhere, except apps with
+    /// their own rule), the default for the current app, just the next recording in
+    /// that app, or — when the app already has a rule — forgetting it. Never
+    /// overwrites a rule silently.
+    private func promptForModelScope(_ option: DictationModelOption, bundleID: String, host: String?, scopeLabel: String) {
+        // "scope" is the most specific bindable context: the site (host) inside a
+        // browser, otherwise the app.
+        let hasRule = AppContextModelRules.exactRule(for: bundleID, host: host) != nil
+        let alert = NSAlert()
+        alert.messageText = "Apply “\(option.displayName)”?"
+        alert.informativeText = "Set it as your system default, the default for \(scopeLabel), or just for your next recording."
+        alert.addButton(withTitle: "System Default")
+        alert.addButton(withTitle: "Default for \(scopeLabel)")
+        alert.addButton(withTitle: "Just This Time")
+        if hasRule {
+            alert.addButton(withTitle: "Forget \(scopeLabel)’s Default")
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            // System default — change the active model everywhere (scopes with
+            // their own rule still win); drop any pending one-time override.
+            MainActor.assumeIsolated { ModelSelectionStore.shared.select(option) }
+            RecordingContext.shared.clearOneTimeModel(for: bundleID)
+        case .alertSecondButtonReturn:
+            // Default for this scope (site or app) — apply now and persist.
+            MainActor.assumeIsolated { ModelSelectionStore.shared.select(option) }
+            AppContextModelRules.set(option, for: bundleID, host: host)
+            RecordingContext.shared.clearOneTimeModel(for: bundleID)
+        case .alertThirdButtonReturn:
+            // Just this time — next recording uses it; the system default is left
+            // untouched (the override fires at record-start).
+            RecordingContext.shared.setOneTimeModel(option, for: bundleID)
+        default:
+            // Fourth button (only present when this scope has a rule): forget it so
+            // it falls back to the app rule, then the system default.
+            AppContextModelRules.remove(bundleID: bundleID, host: host)
+            RecordingContext.shared.clearOneTimeModel(for: bundleID)
+        }
     }
     
     @objc private func statusBarButtonClicked(_ sender: Any) {
@@ -364,10 +497,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     
     @objc private func selectLanguage(_ sender: NSMenuItem) {
         guard let languageCode = sender.representedObject as? String else { return }
-        
-        // Update preferences
-        AppPreferences.shared.whisperLanguage = languageCode
-        
+
+        // Single mutation point — persists and notifies an open Settings window.
+        MainActor.assumeIsolated { LanguageStore.shared.select(languageCode) }
+
         // Update menu item states
         if let submenu = sender.menu {
             for item in submenu.items {
@@ -418,6 +551,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 }
 
 extension AppDelegate: NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // Keep the main window alive — just hide it — instead of letting SwiftUI destroy
+        // it on close. A destroyed WindowGroup window can't be reliably re-created from
+        // within the app on macOS 26, which left the menu-bar "Open Window"/"Settings"
+        // items doing nothing. Hidden, it stays in the windows list so showMainWindow()
+        // can always bring it back. (Settings is a separate scene — let it close.)
+        guard sender.title != "Settings" else { return true }
+        sender.orderOut(nil)
+        NSApplication.shared.setActivationPolicy(.accessory)
+        return false
+    }
+
     func windowWillClose(_ notification: Notification) {
         NSApplication.shared.setActivationPolicy(.accessory)
     }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -93,6 +93,13 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    /// Context-aware model selection mode (per-app / per-site rules). See F2.
+    @Published var contextAwareModelMode: ContextAwareModelMode {
+        didSet {
+            AppPreferences.shared.contextAwareModelMode = contextAwareModelMode
+        }
+    }
+
     /// Re-initialize the engine on a remote-config change, but only when the remote
     /// engine is the active one (editing the config while on Whisper shouldn't reload).
     private func reloadRemoteEngineIfSelected() {
@@ -508,6 +515,7 @@ class SettingsViewModel: ObservableObject {
         self.remoteServerAPIKey = prefs.remoteServerAPIKey ?? ""
         self.remoteServerTimeoutEnabled = prefs.remoteServerTimeoutEnabled
         self.remoteServerTimeoutSeconds = prefs.remoteServerTimeoutSeconds
+        self.contextAwareModelMode = prefs.contextAwareModelMode
         self.selectedLanguage = prefs.whisperLanguage
         self.translateToEnglish = prefs.translateToEnglish
         self.suppressBlankAudio = prefs.suppressBlankAudio
@@ -1050,10 +1058,11 @@ struct SettingRow<Trailing: View>: View {
 
 /// The settings tabs, shown as a vertical sidebar in the dedicated settings window.
 enum SettingsTab: String, CaseIterable, Identifiable {
-    case general, model, transcription, history, advanced, updates, feedback
+    case general, model, transcription, history, appContext, advanced, updates, feedback
     var id: String { rawValue }
     var title: String {
         switch self {
+        case .appContext: return "App Context"
         case .general: return "General"
         case .model: return "Engine & Model"
         case .transcription: return "Transcription"
@@ -1065,6 +1074,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     }
     var icon: String {
         switch self {
+        case .appContext: return "macwindow"
         case .general: return "slider.horizontal.3"
         case .model: return "cpu"
         case .transcription: return "text.bubble"
@@ -1155,6 +1165,7 @@ struct SettingsView: View {
     /// Content for the currently-selected sidebar tab.
     @ViewBuilder private var detailContent: some View {
         switch selectedTab {
+        case .appContext:    AppContextSettingsView(viewModel: viewModel)
         case .general:       shortcutSettings
         case .model:         modelSettings
         case .transcription: transcriptionSettings

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -109,6 +109,23 @@ final class AppPreferences {
     @UserDefault(key: "cachedRemoteModels", defaultValue: [String]())
     var cachedRemoteModels: [String]
 
+    // MARK: - Context-aware model selection (per-app / per-site rules)
+
+    // Per-app default model rules (bundle id -> model, or "bundleID|host" -> model),
+    // JSON-encoded. Managed by AppContextModelRules; empty until the user binds a model.
+    @UserDefault(key: "appModelRules", defaultValue: Data())
+    var appModelRulesData: Data
+
+    // Context-aware model selection mode: "ask" (auto-switch + prompt), "auto"
+    // (auto-switch, no prompt), or "off". Stored raw; use contextAwareModelMode.
+    @UserDefault(key: "contextAwareModelMode", defaultValue: "ask")
+    var contextAwareModelModeRaw: String
+
+    var contextAwareModelMode: ContextAwareModelMode {
+        get { ContextAwareModelMode(rawValue: contextAwareModelModeRaw) ?? .ask }
+        set { contextAwareModelModeRaw = newValue.rawValue }
+    }
+
     // Local fallback for the remote engine: when the server is unreachable, transcribe
     // with a downloaded on-device model instead. Off by default; the chosen model is a
     // DictationModelOption stored as JSON (empty until the user picks one).

--- a/OpenSuperWhisperTests/AppContextModelRulesTests.swift
+++ b/OpenSuperWhisperTests/AppContextModelRulesTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// Per-app / per-site model rules resolve with **site-beats-app** precedence: a
+/// rule bound to a specific website (`bundleID|host`) wins over the app-wide rule
+/// (`bundleID`), which wins over nothing. The composite key encodes that. This
+/// guards the key format and the resolution order so dictating on a ruled site
+/// picks the intended model, and removing a site rule falls back to the app rule.
+final class AppContextModelRulesTests: XCTestCase {
+
+    private var savedRules: Data!
+
+    override func setUp() {
+        super.setUp()
+        savedRules = AppPreferences.shared.appModelRulesData
+        AppPreferences.shared.appModelRulesData = Data()  // start from a clean store
+    }
+
+    override func tearDown() {
+        AppPreferences.shared.appModelRulesData = savedRules
+        super.tearDown()
+    }
+
+    private func model(_ id: String) -> DictationModelOption {
+        DictationModelOption(engine: "remote", identifier: id, displayName: id)
+    }
+
+    // MARK: - Key format
+
+    func testKeyIsBundleIDAloneForAppRule() {
+        XCTAssertEqual(AppContextModelRules.key(bundleID: "com.apple.Safari", host: nil), "com.apple.Safari")
+        XCTAssertEqual(AppContextModelRules.key(bundleID: "com.apple.Safari", host: ""), "com.apple.Safari")
+    }
+
+    func testKeyIsCompositeForSiteRule() {
+        XCTAssertEqual(AppContextModelRules.key(bundleID: "com.google.Chrome", host: "github.com"),
+                       "com.google.Chrome|github.com")
+    }
+
+    // MARK: - Resolution precedence
+
+    func testSiteRuleWinsOverAppRule() {
+        AppContextModelRules.set(model("app-model"), for: "com.google.Chrome")
+        AppContextModelRules.set(model("site-model"), for: "com.google.Chrome", host: "github.com")
+
+        // On the ruled site → the site model.
+        XCTAssertEqual(AppContextModelRules.rule(for: "com.google.Chrome", host: "github.com")?.identifier,
+                       "site-model")
+        // On a different (unruled) site in the same app → app fallback.
+        XCTAssertEqual(AppContextModelRules.rule(for: "com.google.Chrome", host: "example.com")?.identifier,
+                       "app-model")
+        // No site context → app rule.
+        XCTAssertEqual(AppContextModelRules.rule(for: "com.google.Chrome", host: nil)?.identifier,
+                       "app-model")
+    }
+
+    func testNoRuleReturnsNil() {
+        XCTAssertNil(AppContextModelRules.rule(for: "com.unknown.App", host: nil))
+        XCTAssertNil(AppContextModelRules.rule(for: "com.unknown.App", host: "example.com"))
+    }
+
+    func testRemoveDeletesExactScopeAndFallsBack() {
+        AppContextModelRules.set(model("app-model"), for: "com.google.Chrome")
+        AppContextModelRules.set(model("site-model"), for: "com.google.Chrome", host: "github.com")
+        AppContextModelRules.remove(bundleID: "com.google.Chrome", host: "github.com")
+
+        // The exact site scope is gone; resolution falls back to the still-present app rule.
+        XCTAssertNil(AppContextModelRules.exactRule(for: "com.google.Chrome", host: "github.com"))
+        XCTAssertEqual(AppContextModelRules.rule(for: "com.google.Chrome", host: "github.com")?.identifier,
+                       "app-model")
+    }
+}

--- a/OpenSuperWhisperTests/AppContextRuleKeyTests.swift
+++ b/OpenSuperWhisperTests/AppContextRuleKeyTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// `AppContextRuleRow.parse` is the inverse of `AppContextModelRules.key`: the
+/// latter builds a stored rule key (`bundleID` or `bundleID|host`), the former
+/// splits it back into (bundleID, host) for display. This guards that the
+/// composite format round-trips, so the App Context list shows the right app/site
+/// for each stored rule.
+final class AppContextRuleKeyTests: XCTestCase {
+
+    func testParsesAppOnlyKey() {
+        let parsed = AppContextRuleRow.parse("com.apple.Safari")
+        XCTAssertEqual(parsed.bundleID, "com.apple.Safari")
+        XCTAssertNil(parsed.host)
+    }
+
+    func testParsesCompositeSiteKey() {
+        let parsed = AppContextRuleRow.parse("com.google.Chrome|github.com")
+        XCTAssertEqual(parsed.bundleID, "com.google.Chrome")
+        XCTAssertEqual(parsed.host, "github.com")
+    }
+
+    func testRoundTripsWithKeyBuilder() {
+        let cases: [(bundle: String, host: String?)] = [
+            ("com.apple.Safari", nil),
+            ("com.google.Chrome", "docs.google.com"),
+        ]
+        for c in cases {
+            let key = AppContextModelRules.key(bundleID: c.bundle, host: c.host)
+            let parsed = AppContextRuleRow.parse(key)
+            XCTAssertEqual(parsed.bundleID, c.bundle)
+            XCTAssertEqual(parsed.host, c.host)
+        }
+    }
+}

--- a/OpenSuperWhisperTests/ContextAwareModelModeTests.swift
+++ b/OpenSuperWhisperTests/ContextAwareModelModeTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// The context-aware model mode gates two behaviors independently: whether to
+/// auto-switch the model by app at record-start (`autoSwitches`), and whether to
+/// prompt for scope when you pick a model in the menu-bar picker (`prompts`).
+/// `.ask` does both, `.auto` switches silently, `.off` does neither. This guards
+/// that mapping and the raw-value round-trip used to persist the setting.
+final class ContextAwareModelModeTests: XCTestCase {
+
+    func testAskAutoSwitchesAndPrompts() {
+        XCTAssertTrue(ContextAwareModelMode.ask.autoSwitches)
+        XCTAssertTrue(ContextAwareModelMode.ask.prompts)
+    }
+
+    func testAutoSwitchesWithoutPrompting() {
+        XCTAssertTrue(ContextAwareModelMode.auto.autoSwitches)
+        XCTAssertFalse(ContextAwareModelMode.auto.prompts)
+    }
+
+    func testOffDoesNeither() {
+        XCTAssertFalse(ContextAwareModelMode.off.autoSwitches)
+        XCTAssertFalse(ContextAwareModelMode.off.prompts)
+    }
+
+    func testRoundTripsThroughRawValue() {
+        for mode in ContextAwareModelMode.allCases {
+            XCTAssertEqual(ContextAwareModelMode(rawValue: mode.rawValue), mode)
+        }
+    }
+}


### PR DESCRIPTION
Fourth and final carved slice of #21 (menu items **7** and **10**) — code by @EvanSchalton, credited via commit co-authorship.

- Per-app / per-site model rules with Ask / Auto / Off modes, applied at record-start in both record paths.
- App Context settings tab (rules CRUD, gated behind ≥2 available models).
- Menu-bar Model submenu + working Open (⌘O)/Settings items (window hidden, not destroyed, on close).

Suite: **185 tests green locally**. With this merged, the only #21 item not carried is the opt-in Stop/Cancel indicator buttons (item 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzqCgLqxHEtcEFLsSKxD5V