### PR TITLE
feat: opt-in Stop/Cancel buttons on the recording indicator (from #21)

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -283,9 +283,9 @@ class IndicatorViewModel: ObservableObject {
                 }
             }
         } else {
-            
+
             print("!!! Not found record url !!!")
-            
+
             Task {
                 await MainActor.run {
                     self.delegate?.didFinishDecoding()
@@ -293,7 +293,7 @@ class IndicatorViewModel: ObservableObject {
             }
         }
     }
-    
+
     /// Insert a recording (already at its final URL) into the store with the measured
     /// audio duration and the captured source context (app / window / URL / model used).
     /// Shared by the success and failure paths so their metadata wiring can't drift.
@@ -473,6 +473,25 @@ struct RecordingIndicator: View {
     }
 }
 
+/// Pointing-hand cursor while hovering (macOS 14 predates SwiftUI's .pointerStyle).
+/// Pops on disappear too, so the cursor never sticks when the bubble goes away
+/// mid-hover (e.g. after clicking Stop).
+private struct PointerCursorModifier: ViewModifier {
+    @State private var hovering = false
+    func body(content: Content) -> some View {
+        content
+            .onHover { inside in
+                hovering = inside
+                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .onDisappear { if hovering { NSCursor.pop(); hovering = false } }
+    }
+}
+
+extension View {
+    func pointerCursorOnHover() -> some View { modifier(PointerCursorModifier()) }
+}
+
 /// Reports the indicator bubble's laid-out size (before the entrance render transforms) so the
 /// window manager can size the panel itself — see the note on `.onPreferenceChange` below.
 private struct IndicatorContentSizeKey: PreferenceKey {
@@ -505,10 +524,58 @@ struct IndicatorWindow: View {
             return hasCaption ? max(notch.width, 440) : notch.width
         }
         let live = viewModel.state == .recording && IndicatorViewModel.shouldUseLiveStreaming
-        return live ? 380 : 200
+        if live { return 380 }
+        // Widen the recording pill to fit any enabled on-bubble buttons so the
+        // "Recording…" label never wraps; compact (200) otherwise.
+        var width: CGFloat = 200
+        if viewModel.state == .recording {
+            if AppPreferences.shared.showStopButtonOnIndicator { width += 20 }
+            if AppPreferences.shared.showCancelButtonOnIndicator { width += 20 }
+        }
+        return width
     }
     
     private var isNotchMode: Bool { AppPreferences.shared.indicatorPosition == "notch" }
+
+    /// Opt-in on-bubble controls (default off). Shown on the trailing side while
+    /// recording. Stop = stop & transcribe (same as the hotkey toggle); Cancel =
+    /// discard (same as the Esc cancel shortcut). Fixed-size, so they don't couple
+    /// the bubble's size to the window (see the recursion-crash note above).
+    private var anyIndicatorButton: Bool {
+        AppPreferences.shared.showStopButtonOnIndicator
+            || AppPreferences.shared.showCancelButtonOnIndicator
+    }
+
+    @ViewBuilder private var indicatorControls: some View {
+        HStack(spacing: 8) {
+            if AppPreferences.shared.showStopButtonOnIndicator {
+                Button { IndicatorWindowManager.shared.stopRecording() } label: {
+                    // A red ring with a red stop square inside (transparent interior).
+                    Image(systemName: "stop.circle")
+                        .font(.system(size: 19, weight: .regular))
+                        .foregroundColor(.red)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .pointerCursorOnHover()
+                .help("Finish recording")
+            }
+            if AppPreferences.shared.showCancelButtonOnIndicator {
+                Button { IndicatorWindowManager.shared.stopForce() } label: {
+                    // A plain red trash can — discard without transcribing.
+                    Image(systemName: "trash")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundColor(.red)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .pointerCursorOnHover()
+                .help("Cancel recording")
+            }
+        }
+    }
 
     var body: some View {
 
@@ -527,7 +594,7 @@ struct IndicatorWindow: View {
                     
                     Text("Connecting...")
                         .font(.system(size: 13, weight: .semibold))
-                }
+                }                
             case .recording:
                 if streaming.confirmedText.isEmpty && streaming.volatileText.isEmpty {
                     // Before any text arrives, just the dot + label, vertically centered.
@@ -537,6 +604,10 @@ struct IndicatorWindow: View {
                         Text("Recording…")
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundColor(.secondary)
+                        if anyIndicatorButton {
+                            Spacer(minLength: 8)
+                            indicatorControls
+                        }
                     }
                 } else {
                     // Once text starts, drop the label: just the dot + the text, which grows
@@ -551,6 +622,10 @@ struct IndicatorWindow: View {
                             .font(.system(size: 14))
                             .fixedSize(horizontal: false, vertical: true)
                             .frame(width: 300, alignment: .leading)
+                        if anyIndicatorButton {
+                            Spacer(minLength: 8)
+                            indicatorControls
+                        }
                     }
                 }
 
@@ -564,7 +639,7 @@ struct IndicatorWindow: View {
 
                     Text("Transcribing...")
                         .font(.system(size: 13, weight: .semibold))
-                }
+                }                
             case .busy:
                 HStack(spacing: 8) {
                     Image(systemName: "hourglass")
@@ -574,7 +649,7 @@ struct IndicatorWindow: View {
                     Text("Processing...")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(.orange)
-                }
+                }                
             case .error(let message):
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -48,6 +48,10 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             panel.backgroundColor = .clear
             panel.isOpaque = false
             panel.hasShadow = false
+            // Fully click-through by default, matching the my-monkeys baseline: the
+            // indicator never intercepts clicks meant for the app underneath. When the
+            // opt-in on-bubble Stop/Cancel buttons are enabled, this is flipped per
+            // show() below so they're tappable.
             panel.ignoresMouseEvents = true
             panel.hidesOnDeactivate = false
             // Belt-and-suspenders: the window is sized manually + non-animated via
@@ -69,6 +73,12 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         )
         hostingController.sizingOptions = Self.hostingSizingOptions
         window?.contentViewController = hostingController
+
+        // Accept clicks only when an on-bubble button is enabled (so it's tappable);
+        // otherwise stay fully click-through (baseline). Re-evaluated each show() so
+        // toggling the setting takes effect on the next recording.
+        window?.ignoresMouseEvents = !(AppPreferences.shared.showStopButtonOnIndicator
+            || AppPreferences.shared.showCancelButtonOnIndicator)
 
         // Position window - use the screen containing the point, or main screen as fallback
         let targetScreen = point.flatMap { FocusUtils.screenContaining(point: $0) } ?? NSScreen.main

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -280,6 +280,14 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var showStopButtonOnIndicator: Bool {
+        didSet { AppPreferences.shared.showStopButtonOnIndicator = showStopButtonOnIndicator }
+    }
+
+    @Published var showCancelButtonOnIndicator: Bool {
+        didSet { AppPreferences.shared.showCancelButtonOnIndicator = showCancelButtonOnIndicator }
+    }
+
     @Published var remoteFallbackEnabled: Bool {
         didSet { AppPreferences.shared.remoteFallbackEnabled = remoteFallbackEnabled }
     }
@@ -532,6 +540,8 @@ class SettingsViewModel: ObservableObject {
         self.playSoundOnRecordStart = prefs.playSoundOnRecordStart
         self.startHidden = prefs.startHidden
         self.indicatorPosition = prefs.indicatorPosition
+        self.showStopButtonOnIndicator = prefs.showStopButtonOnIndicator
+        self.showCancelButtonOnIndicator = prefs.showCancelButtonOnIndicator
         self.remoteFallbackEnabled = prefs.remoteFallbackEnabled
         self.remoteFallbackModel = prefs.remoteFallbackModel
         self.liveTranscriptionEnabled = prefs.liveTranscriptionEnabled
@@ -2449,6 +2459,24 @@ struct SettingsView: View {
                                 }
                             }
                             .onAppear { cancelKey = SettingsView.currentCancelKeyID() }
+                        }
+
+                        SettingRow(
+                            title: "Show Stop Button on Recording Bar",
+                            caption: "A stop-and-transcribe button on the recording indicator."
+                        ) {
+                            Toggle("", isOn: $viewModel.showStopButtonOnIndicator)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
+                        }
+
+                        SettingRow(
+                            title: "Show Cancel Button on Recording Bar",
+                            caption: "A discard (trash) button on the recording indicator."
+                        ) {
+                            Toggle("", isOn: $viewModel.showCancelButtonOnIndicator)
+                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
+                                .labelsHidden()
                         }
 
                         HStack {

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -220,6 +220,13 @@ final class AppPreferences {
     @UserDefault(key: "useBeamSearch", defaultValue: false)
     var useBeamSearch: Bool
 
+    // Opt-in on-bubble recording controls (default off; additive to the baseline).
+    @UserDefault(key: "showStopButtonOnIndicator", defaultValue: false)
+    var showStopButtonOnIndicator: Bool
+
+    @UserDefault(key: "showCancelButtonOnIndicator", defaultValue: false)
+    var showCancelButtonOnIndicator: Bool
+    
     @UserDefault(key: "beamSize", defaultValue: 5)
     var beamSize: Int
     


### PR DESCRIPTION
Fifth and final slice of #21 (menu item **9**) — code by @EvanSchalton, credited via commit co-authorship.

Opt-in (default **off**) Stop and Cancel buttons on the recording bubble; panel stays click-through unless enabled; fixed-size controls (no size↔window coupling, macOS 26 recursion guard); pointer-cursor hover that can't stick.

With this merged, **all 12 menu items of #21 are upstreamed** and the tree fully converges with @EvanSchalton's branch. Suite: **185 tests green locally**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzqCgLqxHEtcEFLsSKxD5V