### PR TITLE
Apple Speech engine (SpeechAnalyzer, macOS 26+)

### DIFF
--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -1,0 +1,135 @@
+import Speech
+import SwiftUI
+
+/// Apple Speech row (Settings → Models when browsing the Apple engine, macOS 26+).
+/// There is no app-side model file: macOS downloads per-language assets through
+/// AssetInventory, shares them across apps and updates them with the OS. Clicking
+/// installs the assets for the current transcription language if needed, then
+/// activates the engine — same interaction as every other engine.
+@available(macOS 26.0, *)
+struct AppleSpeechModelSection: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    @State private var checked = false
+    @State private var isInstalled = false
+    @State private var isInstalling = false
+    @State private var progress: Double = 0
+    @State private var localeName = ""
+    @State private var errorMessage: String?
+
+    var body: some View {
+        SSection(title: "System speech model") {
+            row
+            if let errorMessage {
+                Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
+            }
+            Text("Built into macOS: the model is downloaded per language by the system, shared across apps, and updated with the OS — nothing is stored in the app. Change the transcription language in Output.")
+                .font(.system(size: 11))
+                .foregroundColor(STheme.hint)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .task(id: viewModel.selectedLanguage) { await refresh() }
+    }
+
+    private var active: Bool { viewModel.selectedEngine == "apple" && isInstalled }
+
+    private var row: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Apple Speech")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                if isInstalling {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .frame(height: 6)
+                        .padding(.top, 2)
+                }
+            }
+
+            Spacer()
+
+            if active {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                    .imageScale(.large)
+            } else if isInstalling || !checked {
+                ProgressView().controlSize(.small)
+            } else if isInstalled {
+                Button("Select") { viewModel.selectAppleSpeech() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            } else {
+                Button(action: install) {
+                    Label("Download", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(12)
+        .background(Color(.controlBackgroundColor).opacity(active ? 0.7 : 0.5))
+        .cornerRadius(8)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if isInstalled && !active { viewModel.selectAppleSpeech() }
+        }
+    }
+
+    private var subtitle: String {
+        let lang = localeName.isEmpty ? "your language" : localeName
+        if !checked { return "Checking \(lang) assets…" }
+        return isInstalled
+            ? "\(lang) · on-device · managed by macOS"
+            : "\(lang) · one-time system download"
+    }
+
+    private func refresh() async {
+        checked = false
+        let locale = await AppleSpeechSupport.resolveLocale(language: viewModel.selectedLanguage)
+        localeName = Locale.current.localizedString(forIdentifier: locale.identifier) ?? locale.identifier
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+        let status = await AssetInventory.status(forModules: [transcriber])
+        isInstalled = (status == .installed)
+        checked = true
+        await AppleSpeechSupport.refreshCaches()
+    }
+
+    private func install() {
+        errorMessage = nil
+        isInstalling = true
+        progress = 0
+        Task {
+            do {
+                let locale = await AppleSpeechSupport.resolveLocale(language: viewModel.selectedLanguage)
+                let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+                if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                    // AssetInstallationRequest reports through Foundation.Progress; poll it
+                    // into SwiftUI state for the linear bar.
+                    let poller = Task {
+                        while !Task.isCancelled {
+                            let fraction = request.progress.fractionCompleted
+                            await MainActor.run { progress = fraction }
+                            try? await Task.sleep(nanoseconds: 200_000_000)
+                        }
+                    }
+                    defer { poller.cancel() }
+                    try await request.downloadAndInstall()
+                }
+                await AppleSpeechSupport.refreshCaches()
+                await MainActor.run {
+                    isInstalled = true
+                    isInstalling = false
+                    viewModel.selectAppleSpeech()
+                }
+            } catch {
+                await MainActor.run {
+                    isInstalling = false
+                    errorMessage = "Couldn't download the speech assets. Check your connection and try again."
+                }
+            }
+        }
+    }
+}

--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -1,0 +1,134 @@
+import AVFoundation
+import Foundation
+import Speech
+
+/// Availability + locale bookkeeping for Apple's on-device speech stack
+/// (SpeechAnalyzer/SpeechTranscriber, macOS 26+). Model assets are downloaded and
+/// updated by the SYSTEM (AssetInventory) and shared across apps — the app never
+/// stores them itself.
+///
+/// The framework only exposes its locale lists as async properties, but the model
+/// catalog and the language picker need synchronous answers — so we cache the
+/// language codes in UserDefaults, refreshed at launch and after every install.
+enum AppleSpeechSupport {
+    /// True when the OS ships the new Speech stack and it reports availability.
+    static var isSupported: Bool {
+        if #available(macOS 26.0, *) { return SpeechTranscriber.isAvailable }
+        return false
+    }
+
+    private static let supportedKey = "appleSpeechSupportedLanguages"
+    private static let installedKey = "appleSpeechInstalledLanguages"
+
+    /// Whisper-style language codes ("en", "fr", …) the system model can transcribe.
+    static var cachedSupportedLanguages: [String] {
+        UserDefaults.standard.stringArray(forKey: supportedKey) ?? []
+    }
+
+    /// Languages whose assets are installed on this Mac right now.
+    static var cachedInstalledLanguages: [String] {
+        UserDefaults.standard.stringArray(forKey: installedKey) ?? []
+    }
+
+    /// The engine is usable without triggering a download (the catalog's rule:
+    /// listing a model in the menu must never start one).
+    static var hasInstalledModel: Bool { !cachedInstalledLanguages.isEmpty }
+
+    @available(macOS 26.0, *)
+    static func refreshCaches() async {
+        let supported = languageCodes(from: await SpeechTranscriber.supportedLocales)
+        let installed = languageCodes(from: await SpeechTranscriber.installedLocales)
+        UserDefaults.standard.set(supported, forKey: supportedKey)
+        UserDefaults.standard.set(installed, forKey: installedKey)
+    }
+
+    /// Locale list → deduplicated language codes, keeping the framework's order.
+    static func languageCodes(from locales: [Locale]) -> [String] {
+        var seen = Set<String>()
+        return locales.compactMap { locale in
+            guard let code = locale.language.languageCode?.identifier else { return nil }
+            return seen.insert(code).inserted ? code : nil
+        }
+    }
+
+    /// The Locale to transcribe with for the app's language setting.
+    /// "auto" means the user's system language (per-transcriber locale is fixed —
+    /// the system model has no cross-language auto-detect).
+    @available(macOS 26.0, *)
+    static func resolveLocale(language: String) async -> Locale {
+        let wanted = language == "auto" ? Locale.current : Locale(identifier: language)
+        if let match = await SpeechTranscriber.supportedLocale(equivalentTo: wanted) {
+            return match
+        }
+        // Unsupported language: fall back to the first supported locale (English ships
+        // everywhere) so a stale picker value degrades instead of failing the dictation.
+        return await SpeechTranscriber.supportedLocales.first ?? Locale(identifier: "en_US")
+    }
+}
+
+/// On-device transcription through the system speech model. No app-side model files:
+/// initialize() is instant, and missing locale assets are fetched through
+/// AssetInventory on first use.
+@available(macOS 26.0, *)
+final class AppleSpeechEngine: TranscriptionEngine {
+    var engineName: String { "Apple Speech" }
+    private(set) var isModelLoaded = false
+    private var currentAnalyzer: SpeechAnalyzer?
+
+    func initialize() async throws {
+        guard SpeechTranscriber.isAvailable else {
+            throw TranscriptionError.contextInitializationFailed
+        }
+        isModelLoaded = true
+    }
+
+    func transcribeAudio(url: URL, settings: Settings) async throws -> String {
+        let locale = await AppleSpeechSupport.resolveLocale(language: settings.selectedLanguage)
+        let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+
+        // Settings installs assets up front, but a language switched from the menu bar
+        // may not have them yet — fetch now rather than fail the dictation.
+        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+            try await request.downloadAndInstall()
+            await AppleSpeechSupport.refreshCaches()
+        }
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        currentAnalyzer = analyzer
+        defer { currentAnalyzer = nil }
+
+        let file = try AVAudioFile(forReading: url)
+
+        // Start draining results before feeding audio — the sequence ends when the
+        // analyzer finishes, which is what terminates the collector.
+        async let collected = Self.collectFinalText(from: transcriber)
+        try await analyzer.analyzeSequence(from: file)
+        try await analyzer.finalizeAndFinishThroughEndOfInput()
+
+        var text = try await collected.trimmingCharacters(in: .whitespacesAndNewlines)
+        if settings.shouldApplyAsianAutocorrect && !text.isEmpty {
+            text = AutocorrectWrapper.format(text)
+        }
+        if settings.shouldApplyCustomDictionary {
+            text = CustomDictionary.apply(text, entries: settings.customDictionaryEntries)
+        }
+        return text.isEmpty ? TranscriptionResult.noSpeech : text
+    }
+
+    private static func collectFinalText(from transcriber: SpeechTranscriber) async throws -> String {
+        var out = ""
+        for try await result in transcriber.results where result.isFinal {
+            out += String(result.text.characters)
+        }
+        return out
+    }
+
+    func cancelTranscription() {
+        guard let analyzer = currentAnalyzer else { return }
+        Task { await analyzer.cancelAndFinishNow() }
+    }
+
+    func getSupportedLanguages() -> [String] {
+        EngineCapabilities.supportedLanguages(engine: "apple", fluidAudioModelVersion: "")
+    }
+}

--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -2,6 +2,12 @@ import AVFoundation
 import Foundation
 import Speech
 
+// SpeechAnalyzer/SpeechTranscriber only exist in the macOS 26 SDK. `@available` guards
+// the runtime, not compilation — so the whole engine is gated on the SDK, keyed off
+// FoundationModels (a macOS-26-only framework). Older toolchains (CI's macos-latest,
+// contributors on Xcode 16) build the stub below and simply never offer the engine.
+#if canImport(FoundationModels)
+
 /// Availability + locale bookkeeping for Apple's on-device speech stack
 /// (SpeechAnalyzer/SpeechTranscriber, macOS 26+). Model assets are downloaded and
 /// updated by the SYSTEM (AssetInventory) and shared across apps — the app never
@@ -132,3 +138,16 @@ final class AppleSpeechEngine: TranscriptionEngine {
         EngineCapabilities.supportedLanguages(engine: "apple", fluidAudioModelVersion: "")
     }
 }
+
+#else
+
+/// Old-SDK stub: the engine is never supported, so no UI or catalog entry appears
+/// and none of the SpeechAnalyzer symbols are referenced.
+enum AppleSpeechSupport {
+    static var isSupported: Bool { false }
+    static var cachedSupportedLanguages: [String] { [] }
+    static var cachedInstalledLanguages: [String] { [] }
+    static var hasInstalledModel: Bool { false }
+}
+
+#endif

--- a/OpenSuperWhisper/Engines/TranscriptionEngine.swift
+++ b/OpenSuperWhisper/Engines/TranscriptionEngine.swift
@@ -35,6 +35,12 @@ enum EngineCapabilities {
             // The remote server decides language support; advertise the full Whisper set
             // (incl. "auto") so the user's choice is forwarded verbatim.
             return LanguageUtil.availableLanguages
+        case "apple":
+            // System speech model (macOS 26). "auto" = the user's system language — the
+            // transcriber has no cross-language auto-detect. The cache is refreshed at
+            // launch; before the first refresh, English is the only safe promise.
+            let cached = AppleSpeechSupport.cachedSupportedLanguages
+            return ["auto"] + (cached.isEmpty ? ["en"] : cached)
         case "sensevoice":
             return ["auto", "zh", "en", "ja", "ko", "yue"]
         case "fluidaudio":

--- a/OpenSuperWhisper/ModelCatalog.swift
+++ b/OpenSuperWhisper/ModelCatalog.swift
@@ -69,10 +69,18 @@ enum ModelCatalog {
         }
     }
 
+    /// The system speech model (macOS 26+) — one entry, only when the OS supports it
+    /// AND at least one locale's assets are already installed (the cached check keeps
+    /// the never-download-from-the-menu rule).
+    static func appleSpeechModels() -> [DictationModelOption] {
+        guard AppleSpeechSupport.isSupported, AppleSpeechSupport.hasInstalledModel else { return [] }
+        return [DictationModelOption(engine: "apple", identifier: "default", displayName: "Apple Speech")]
+    }
+
     /// Every usable model across engines. Used to decide whether switching is
     /// even meaningful (one model → nothing to choose).
     static func allAvailable() -> [DictationModelOption] {
-        whisperModels() + parakeetModels() + senseVoiceModels() + remoteModels()
+        whisperModels() + parakeetModels() + senseVoiceModels() + appleSpeechModels() + remoteModels()
     }
 
     /// The model currently in effect (active engine + its selected model).
@@ -94,6 +102,8 @@ enum ModelCatalog {
             )
         case "sensevoice":
             return DictationModelOption(engine: "sensevoice", identifier: "default", displayName: "SenseVoice")
+        case "apple":
+            return DictationModelOption(engine: "apple", identifier: "default", displayName: "Apple Speech")
         case "remote":
             let id = prefs.remoteServerModel.trimmingCharacters(in: .whitespacesAndNewlines)
             return id.isEmpty
@@ -116,7 +126,7 @@ enum ModelCatalog {
             prefs.fluidAudioModelVersion = option.identifier
         case "remote":
             prefs.remoteServerModel = option.identifier
-        case "sensevoice":
+        case "sensevoice", "apple":
             break  // single model, nothing else to set
         default:
             break

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -135,6 +135,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, ObservableOb
         OpenSuperWhisperApp.startTranscriptionQueue()
         OpenSuperWhisperApp.startRetentionScheduler()
         observeMicrophoneChanges()
+
+        // The Apple Speech locale lists are async-only; refresh the sync caches the
+        // model catalog and language picker read (menu must never trigger a download).
+        if #available(macOS 26.0, *) {
+            Task.detached(priority: .utility) { await AppleSpeechSupport.refreshCaches() }
+        }
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -138,9 +138,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, ObservableOb
 
         // The Apple Speech locale lists are async-only; refresh the sync caches the
         // model catalog and language picker read (menu must never trigger a download).
+#if canImport(FoundationModels)
         if #available(macOS 26.0, *) {
             Task.detached(priority: .utility) { await AppleSpeechSupport.refreshCaches() }
         }
+#endif
     }
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -150,6 +150,13 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    func selectAppleSpeech() {
+        MainActor.assumeIsolated {
+            ModelSelectionStore.shared.select(DictationModelOption(
+                engine: "apple", identifier: "default", displayName: "Apple Speech"))
+        }
+    }
+
     @Published var availableModels: [URL] = []
     
     @Published var downloadableModels: [SettingsDownloadableModel] = []
@@ -1162,6 +1169,7 @@ struct SettingsView: View {
         case "fluidaudio": return "Parakeet"
         case "whisper": return "Whisper"
         case "sensevoice": return "SenseVoice"
+        case "apple": return "Apple Speech"
         case "remote": return "Remote"
         default: return engine
         }
@@ -1173,6 +1181,7 @@ struct SettingsView: View {
         case "fluidaudio": return "Parakeet"
         case "whisper": return "Whisper"
         case "sensevoice": return "SenseVoice"
+        case "apple": return "Apple"
         case "remote": return "Remote"
         default: return engine
         }
@@ -1184,6 +1193,8 @@ struct SettingsView: View {
             return "Most accurate, ~99 languages, and can translate to English. Runs fully on-device."
         case "sensevoice":
             return "Fast — Chinese, Cantonese, English, Japanese, Korean. Runs fully on-device."
+        case "apple":
+            return "macOS's built-in speech model — zero download in the app, managed by the system."
         case "remote":
             return "Cloud / self-hosted — any OpenAI-compatible server (Groq, speaches, LiteLLM, …)."
         default:
@@ -1525,6 +1536,9 @@ struct SettingsView: View {
 #if arch(arm64)
                 engineCard(tag: "sensevoice", name: "SenseVoice", sub: "zh · yue · ja · ko")
 #endif
+                if AppleSpeechSupport.isSupported {
+                    engineCard(tag: "apple", name: "Apple", sub: "Built into macOS")
+                }
                 engineCard(tag: "remote", name: "Remote", sub: "Your own server")
             }
             .padding(.horizontal, 24).padding(.top, 12)
@@ -1574,6 +1588,9 @@ struct SettingsView: View {
                         SenseVoiceModelSection(viewModel: viewModel)
                     }
 #endif
+                    if browseEngine == "apple", #available(macOS 26.0, *) {
+                        AppleSpeechModelSection(viewModel: viewModel)
+                    }
                     if browseEngine == "remote" {
                         RemoteSettingsSection(viewModel: viewModel)
                     }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -944,6 +944,14 @@ struct SettingsDownloadableModels {
             description: "Fastest processing"
         ),
         SettingsDownloadableModel(
+            name: "Distil large v3 — English",
+            isDownloaded: false,
+            url: URL(string: "https://huggingface.co/distil-whisper/distil-large-v3-ggml/resolve/main/ggml-distil-large-v3.bin?download=true")!,
+            size: 1520,
+            description: "Distilled large-v3: much faster, near-large accuracy, English only. Selecting it sets the language to English.",
+            preferredLanguage: "en"
+        ),
+        SettingsDownloadableModel(
             name: "Hebrew — ivrit.ai Turbo v3",
             isDownloaded: false,
             url: URL(string: "https://huggingface.co/ivrit-ai/whisper-large-v3-turbo-ggml/resolve/main/ggml-model.bin?download=true")!,

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1588,9 +1588,11 @@ struct SettingsView: View {
                         SenseVoiceModelSection(viewModel: viewModel)
                     }
 #endif
+#if canImport(FoundationModels)
                     if browseEngine == "apple", #available(macOS 26.0, *) {
                         AppleSpeechModelSection(viewModel: viewModel)
                     }
+#endif
                     if browseEngine == "remote" {
                         RemoteSettingsSection(viewModel: viewModel)
                     }

--- a/OpenSuperWhisper/TranscriptionService.swift
+++ b/OpenSuperWhisper/TranscriptionService.swift
@@ -75,6 +75,14 @@ class TranscriptionService: ObservableObject {
 #endif
             } else if selectedEngine == "remote" {
                 engine = RemoteEngine()
+            } else if selectedEngine == "apple" {
+                if #available(macOS 26.0, *) {
+                    engine = AppleSpeechEngine()
+                } else {
+                    // A pref synced from a newer machine; the catalog never offers
+                    // "apple" here, so quietly fall back.
+                    engine = await WhisperEngine()
+                }
             } else {
                 engine = await WhisperEngine()
             }
@@ -268,6 +276,12 @@ class TranscriptionService: ObservableObject {
             switch option.engine {
             case "fluidaudio":
                 engine = await FluidAudioEngine(versionOverride: option.identifier)
+            case "apple":
+                if #available(macOS 26.0, *) {
+                    engine = AppleSpeechEngine()
+                } else {
+                    engine = await WhisperEngine()
+                }
             case "sensevoice":
 #if arch(arm64)
                 engine = SenseVoiceEngine()

--- a/OpenSuperWhisper/TranscriptionService.swift
+++ b/OpenSuperWhisper/TranscriptionService.swift
@@ -76,6 +76,7 @@ class TranscriptionService: ObservableObject {
             } else if selectedEngine == "remote" {
                 engine = RemoteEngine()
             } else if selectedEngine == "apple" {
+#if canImport(FoundationModels)
                 if #available(macOS 26.0, *) {
                     engine = AppleSpeechEngine()
                 } else {
@@ -83,6 +84,9 @@ class TranscriptionService: ObservableObject {
                     // "apple" here, so quietly fall back.
                     engine = await WhisperEngine()
                 }
+#else
+                engine = await WhisperEngine()
+#endif
             } else {
                 engine = await WhisperEngine()
             }
@@ -277,11 +281,15 @@ class TranscriptionService: ObservableObject {
             case "fluidaudio":
                 engine = await FluidAudioEngine(versionOverride: option.identifier)
             case "apple":
+#if canImport(FoundationModels)
                 if #available(macOS 26.0, *) {
                     engine = AppleSpeechEngine()
                 } else {
                     engine = await WhisperEngine()
                 }
+#else
+                engine = await WhisperEngine()
+#endif
             case "sensevoice":
 #if arch(arm64)
                 engine = SenseVoiceEngine()


### PR DESCRIPTION
Fifth engine: **Apple Speech** — the system's on-device speech model, through the new Speech framework (SpeechAnalyzer + SpeechTranscriber, macOS 26+).

## Why

Zero download in the app: macOS manages per-language assets (AssetInventory), shares them across apps and updates them with the OS. Instant onboarding for anyone on macOS 26+.

## How it works

- `AppleSpeechEngine` implements `TranscriptionEngine`: resolves the locale from the transcription language ("auto" = system language), feeds the recorded file to a `SpeechAnalyzer`, collects final results. Missing locale assets are installed on first use instead of failing the dictation.
- `AppleSpeechSupport` caches the framework's async-only locale lists in UserDefaults (refreshed at launch + after installs), preserving the catalog's synchronous never-download-from-the-menu contract.
- Models pane: an "Apple — Built into macOS" card (hidden on older OSes) with a system-model section — asset status for the current language, one-time system download with progress, select-to-activate.
- Wired everywhere an engine matters: menu-bar picker, Rules, local fallback, active pill, language-picker filtering (no translation support, like Parakeet/SenseVoice).

On macOS < 26 the engine is never offered; a synced "apple" pref quietly falls back to Whisper.

## Verified on-device (Tahoe 27)

- Locale resolution from a French (Switzerland) system language, asset install through Settings, engine activation.
- A 19 s French recording re-transcribed at Parakeet-level quality, plus several live dictations through the normal recording flow.
- 193 unit tests green.