### PR TITLE
Fix Apple Speech asset installs beyond the system's 5-locale cap

### DIFF
--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -105,20 +105,22 @@ struct AppleSpeechModelSection: View {
             do {
                 let locale = await AppleSpeechSupport.resolveLocale(language: viewModel.selectedLanguage)
                 let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
-                if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-                    // AssetInstallationRequest reports through Foundation.Progress; poll it
-                    // into SwiftUI state for the linear bar.
-                    let poller = Task {
-                        while !Task.isCancelled {
-                            let fraction = request.progress.fractionCompleted
-                            await MainActor.run { progress = fraction }
-                            try? await Task.sleep(nanoseconds: 200_000_000)
+                // The install reports through Foundation.Progress; poll it into
+                // SwiftUI state for the linear bar.
+                var poller: Task<Void, Never>?
+                defer { poller?.cancel() }
+                try await AppleSpeechSupport.installAssetsIfNeeded(
+                    supporting: transcriber, locale: locale,
+                    onProgress: { systemProgress in
+                        poller?.cancel()
+                        poller = Task {
+                            while !Task.isCancelled {
+                                let fraction = systemProgress.fractionCompleted
+                                await MainActor.run { progress = fraction }
+                                try? await Task.sleep(nanoseconds: 200_000_000)
+                            }
                         }
-                    }
-                    defer { poller.cancel() }
-                    try await request.downloadAndInstall()
-                }
-                await AppleSpeechSupport.refreshCaches()
+                    })
                 await MainActor.run {
                     isInstalled = true
                     isInstalling = false

--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -57,6 +57,36 @@ enum AppleSpeechSupport {
         }
     }
 
+    /// Install the locale's assets if they're missing. The system caps reserved
+    /// locales ("Too many allocated locales, 5 maximum") — when the quota is full,
+    /// release one we're not about to use and retry once. `onProgress` exposes the
+    /// system download's Progress for UI.
+    @available(macOS 26.0, *)
+    static func installAssetsIfNeeded(supporting transcriber: SpeechTranscriber, locale: Locale,
+                                      onProgress: ((Foundation.Progress) -> Void)? = nil) async throws {
+        do {
+            try await installOnce(transcriber, onProgress: onProgress)
+        } catch {
+            let reserved = await AssetInventory.reservedLocales
+            guard let victim = reserved.first(where: { $0.identifier != locale.identifier }) else {
+                throw error
+            }
+            _ = await AssetInventory.release(reservedLocale: victim)
+            try await installOnce(transcriber, onProgress: onProgress)
+        }
+        await refreshCaches()
+    }
+
+    @available(macOS 26.0, *)
+    private static func installOnce(_ transcriber: SpeechTranscriber,
+                                    onProgress: ((Foundation.Progress) -> Void)?) async throws {
+        guard let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) else {
+            return
+        }
+        onProgress?(request.progress)
+        try await request.downloadAndInstall()
+    }
+
     /// The Locale to transcribe with for the app's language setting.
     /// "auto" means the user's system language (per-transcriber locale is fixed —
     /// the system model has no cross-language auto-detect).
@@ -94,10 +124,7 @@ final class AppleSpeechEngine: TranscriptionEngine {
 
         // Settings installs assets up front, but a language switched from the menu bar
         // may not have them yet — fetch now rather than fail the dictation.
-        if let request = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
-            try await request.downloadAndInstall()
-            await AppleSpeechSupport.refreshCaches()
-        }
+        try await AppleSpeechSupport.installAssetsIfNeeded(supporting: transcriber, locale: locale)
 
         let analyzer = SpeechAnalyzer(modules: [transcriber])
         currentAnalyzer = analyzer


### PR DESCRIPTION
AssetInventory caps reserved locales at 5 — the sixth language would throw "Too many allocated locales", and dictation in that language returned empty text. Found by the FLEURS benchmark (pt/hi/zh/ja/ko at 100% error). Installs now release an unused reserved locale and retry once; the Settings install path shares the same code and keeps its progress bar. Verified on-device: Korean transcribes right after five other locales filled the quota.