### PR TITLE
Drop Distil large-v3 from the Whisper catalog

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -950,14 +950,10 @@ struct SettingsDownloadableModels {
             size: 574,
             description: "Fastest processing"
         ),
-        SettingsDownloadableModel(
-            name: "Distil large v3 — English",
-            isDownloaded: false,
-            url: URL(string: "https://huggingface.co/distil-whisper/distil-large-v3-ggml/resolve/main/ggml-distil-large-v3.bin?download=true")!,
-            size: 1520,
-            description: "Distilled large-v3: much faster, near-large accuracy, English only. Selecting it sets the language to English.",
-            preferredLanguage: "en"
-        ),
+        // Distil large-v3 was here briefly — dropped after our FLEURS benchmark: on
+        // Metal it matches large-v3-turbo's speed exactly (the shared large encoder
+        // dominates short dictation clips) with worse accuracy (8% vs 5.9% WER) and
+        // English only. Anyone who downloaded it keeps using it via the on-disk list.
         SettingsDownloadableModel(
             name: "Hebrew — ivrit.ai Turbo v3",
             isDownloaded: false,


### PR DESCRIPTION
Benchmark verdict (FLEURS, steady-state A/B on the same clips): identical speed to large-v3-turbo on Metal, worse WER (8% vs 5.9%), English only — turbo strictly dominates it. Same treatment as Moonshine: measured, documented on the site's comparator as benchmarked-but-not-shipped, not offered in the app. Already-downloaded copies keep working via the on-disk list.