### PR TITLE
Apple Speech: resolve bare language codes to canonical locales

### DIFF
--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -92,7 +92,16 @@ enum AppleSpeechSupport {
     /// the system model has no cross-language auto-detect).
     @available(macOS 26.0, *)
     static func resolveLocale(language: String) async -> Locale {
-        let wanted = language == "auto" ? Locale.current : Locale(identifier: language)
+        let wanted: Locale
+        if language == "auto" {
+            wanted = Locale.current
+        } else {
+            // The picker's bare Whisper codes ("fr") name no region, and the framework's
+            // equivalence then picks an arbitrary supported variant (fr → fr_CA or fr_CH).
+            // CLDR likely-subtags ("fr" → fr-Latn-FR) land each language on its canonical
+            // region: fr_FR, en_US, pt_BR, zh_CN (Simplified), …
+            wanted = Locale(identifier: Locale.Language(identifier: language).maximalIdentifier)
+        }
         if let match = await SpeechTranscriber.supportedLocale(equivalentTo: wanted) {
             return match
         }


### PR DESCRIPTION
"fr" resolved to fr_CH or fr_CA (arbitrary equivalence pick), never fr_FR — Swiss French notably writes *septante* for 70. Bare codes now go through CLDR likely-subtags (fr → fr-Latn-FR → fr_FR); verified live for all nine languages: fr_FR, en_US, pt_BR, zh_CN, ko_KR, de_DE, es_ES, it_IT, ja_JP.