### PR TITLE
Apple Speech: user-selectable regional variant

### DIFF
--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -19,6 +19,19 @@ struct AppleSpeechModelSection: View {
     /// one in effect. The picker only shows when there's an actual choice.
     @State private var variants: [Locale] = []
     @State private var selectedVariantID = ""
+    /// Every language the system model supports, with its resolved locale and asset
+    /// status — so any language can be preloaded from here, not just the current one.
+    @State private var languages: [LangAsset] = []
+    @State private var installingCode: String?
+    @State private var langProgress: Double = 0
+
+    private struct LangAsset: Identifiable {
+        let code: String
+        let localeID: String
+        let name: String
+        var installed: Bool
+        var id: String { code }
+    }
 
     var body: some View {
         SSection(title: "System speech model") {
@@ -50,8 +63,62 @@ struct AppleSpeechModelSection: View {
                 .font(.system(size: 11))
                 .foregroundColor(STheme.hint)
                 .fixedSize(horizontal: false, vertical: true)
+
+            if !languages.isEmpty {
+                SSection(title: "Languages") {
+                    VStack(spacing: 0) {
+                        ForEach(languages) { lang in
+                            languageRow(lang)
+                            if lang.id != languages.last?.id {
+                                Rectangle().fill(STheme.border).frame(height: 1)
+                            }
+                        }
+                    }
+                    .background(RoundedRectangle(cornerRadius: 9).fill(STheme.cardBg))
+                    .overlay(RoundedRectangle(cornerRadius: 9).stroke(STheme.border, lineWidth: 1))
+                    Text("Preload any language's assets here; the language you dictate in is set in Output (or the menu bar).")
+                        .font(.system(size: 11))
+                        .foregroundColor(STheme.hint)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
         .task(id: viewModel.selectedLanguage) { await refresh() }
+    }
+
+    private func languageRow(_ lang: LangAsset) -> some View {
+        let isCurrent = lang.code == AppleSpeechSupport.effectiveLanguageCode(for: viewModel.selectedLanguage)
+        return HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(lang.name)
+                    .font(.system(size: 12.5))
+                    .foregroundColor(STheme.text)
+                if installingCode == lang.code {
+                    ProgressView(value: langProgress)
+                        .progressViewStyle(.linear)
+                        .frame(width: 160, height: 5)
+                        .padding(.top, 2)
+                }
+            }
+            if isCurrent { STag("Current") }
+            Spacer(minLength: 8)
+            if lang.installed {
+                Image(systemName: "checkmark.circle")
+                    .foregroundColor(STheme.ok)
+            } else if installingCode == lang.code {
+                ProgressView().controlSize(.small)
+            } else {
+                Button {
+                    installLanguage(lang)
+                } label: {
+                    Label("Download", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(installingCode != nil)
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
     }
 
     private var active: Bool { viewModel.selectedEngine == "apple" && isInstalled }
@@ -121,6 +188,63 @@ struct AppleSpeechModelSection: View {
         isInstalled = (status == .installed)
         checked = true
         await AppleSpeechSupport.refreshCaches()
+        await refreshLanguages()
+    }
+
+    /// One row per supported language, resolved to its effective locale (override or
+    /// canonical) with the asset status. "mul" is the framework's multilingual pseudo
+    /// entry — not a language anyone dictates in.
+    private func refreshLanguages() async {
+        var rows: [LangAsset] = []
+        for code in AppleSpeechSupport.cachedSupportedLanguages where code != "mul" {
+            let locale = await AppleSpeechSupport.resolveLocale(language: code)
+            let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+            let status = await AssetInventory.status(forModules: [transcriber])
+            rows.append(LangAsset(
+                code: code,
+                localeID: locale.identifier,
+                name: Locale.current.localizedString(forIdentifier: locale.identifier) ?? locale.identifier,
+                installed: status == .installed))
+        }
+        languages = rows.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private func installLanguage(_ lang: LangAsset) {
+        errorMessage = nil
+        installingCode = lang.code
+        langProgress = 0
+        Task {
+            do {
+                let locale = Locale(identifier: lang.localeID)
+                let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
+                var poller: Task<Void, Never>?
+                defer { poller?.cancel() }
+                try await AppleSpeechSupport.installAssetsIfNeeded(
+                    supporting: transcriber, locale: locale,
+                    onProgress: { systemProgress in
+                        poller?.cancel()
+                        poller = Task {
+                            while !Task.isCancelled {
+                                let fraction = systemProgress.fractionCompleted
+                                await MainActor.run { langProgress = fraction }
+                                try? await Task.sleep(nanoseconds: 200_000_000)
+                            }
+                        }
+                    })
+                await MainActor.run {
+                    if let i = languages.firstIndex(where: { $0.code == lang.code }) {
+                        languages[i].installed = true
+                    }
+                    installingCode = nil
+                }
+                await refresh()
+            } catch {
+                await MainActor.run {
+                    installingCode = nil
+                    errorMessage = "Couldn't download \(lang.name). Check your connection and try again."
+                }
+            }
+        }
     }
 
     private func install() {

--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -15,10 +15,34 @@ struct AppleSpeechModelSection: View {
     @State private var progress: Double = 0
     @State private var localeName = ""
     @State private var errorMessage: String?
+    /// Regional variants of the current language (fr → fr_FR/fr_CH/fr_CA/fr_BE) and the
+    /// one in effect. The picker only shows when there's an actual choice.
+    @State private var variants: [Locale] = []
+    @State private var selectedVariantID = ""
 
     var body: some View {
         SSection(title: "System speech model") {
             row
+            if variants.count > 1 {
+                SRow(title: "Regional variant",
+                     hint: "Which regional model transcribes this language — spelling and numbers follow it.") {
+                    Picker("", selection: $selectedVariantID) {
+                        ForEach(variants, id: \.identifier) { locale in
+                            Text(Locale.current.localizedString(forIdentifier: locale.identifier) ?? locale.identifier)
+                                .tag(locale.identifier)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                    .onChange(of: selectedVariantID) { _, newID in
+                        guard !newID.isEmpty else { return }
+                        let code = AppleSpeechSupport.effectiveLanguageCode(for: viewModel.selectedLanguage)
+                        guard AppleSpeechSupport.localeOverrides[code] != newID else { return }
+                        AppleSpeechSupport.localeOverrides[code] = newID
+                        Task { await refresh() }
+                    }
+                }
+            }
             if let errorMessage {
                 Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
             }
@@ -90,6 +114,8 @@ struct AppleSpeechModelSection: View {
         checked = false
         let locale = await AppleSpeechSupport.resolveLocale(language: viewModel.selectedLanguage)
         localeName = Locale.current.localizedString(forIdentifier: locale.identifier) ?? locale.identifier
+        variants = await AppleSpeechSupport.supportedVariants(for: viewModel.selectedLanguage)
+        selectedVariantID = locale.identifier
         let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
         let status = await AssetInventory.status(forModules: [transcriber])
         isInstalled = (status == .installed)

--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -87,11 +87,41 @@ enum AppleSpeechSupport {
         try await request.downloadAndInstall()
     }
 
+    /// Per-language regional overrides ("fr" → "fr_CH"), chosen by the user in the
+    /// Models pane. Absent = the canonical CLDR resolution below.
+    private static let overridesKey = "appleSpeechLocaleOverrides"
+    static var localeOverrides: [String: String] {
+        get { UserDefaults.standard.dictionary(forKey: overridesKey) as? [String: String] ?? [:] }
+        set { UserDefaults.standard.set(newValue, forKey: overridesKey) }
+    }
+
+    /// The effective language code for the app's language setting ("auto" = system).
+    static func effectiveLanguageCode(for language: String) -> String {
+        language == "auto"
+            ? (Locale.current.language.languageCode?.identifier ?? "en")
+            : language
+    }
+
+    /// All supported regional variants of one language (fr → fr_FR, fr_CH, fr_CA, fr_BE),
+    /// for the Models pane's variant picker.
+    @available(macOS 26.0, *)
+    static func supportedVariants(for language: String) async -> [Locale] {
+        let code = effectiveLanguageCode(for: language)
+        return await SpeechTranscriber.supportedLocales
+            .filter { $0.language.languageCode?.identifier == code }
+            .sorted { $0.identifier < $1.identifier }
+    }
+
     /// The Locale to transcribe with for the app's language setting.
     /// "auto" means the user's system language (per-transcriber locale is fixed —
     /// the system model has no cross-language auto-detect).
     @available(macOS 26.0, *)
     static func resolveLocale(language: String) async -> Locale {
+        // A user-chosen regional variant wins (Models → Apple → Regional variant).
+        if let overrideID = localeOverrides[effectiveLanguageCode(for: language)],
+           let match = await SpeechTranscriber.supportedLocale(equivalentTo: Locale(identifier: overrideID)) {
+            return match
+        }
         let wanted: Locale
         if language == "auto" {
             wanted = Locale.current


### PR DESCRIPTION
Follow-up to #34: the canonical default (fr → fr_FR) is right for most, but Swiss/Québécois/Belgian speakers legitimately want their regional model (septante!). New Regional variant picker in Models → Apple, shown only when the language has 2+ supported variants; stored per language, wins over the canonical resolution, and re-checks asset status on switch.