### PR TITLE
fix(live): recover short dictations & clear stale caption on the Parakeet live path

### DIFF
--- a/OpenSuperWhisper/Engines/StreamingTranscriptionController.swift
+++ b/OpenSuperWhisper/Engines/StreamingTranscriptionController.swift
@@ -17,12 +17,24 @@ final class StreamingTranscriptionController: ObservableObject {
     @Published private(set) var confirmedText: String = ""
     @Published private(set) var volatileText: String = ""
 
+    /// The caption exactly as shown in the bubble (confirmed + volatile tail). Used as the
+    /// fallback transcription for very short clips, where the offline file model comes back
+    /// empty even though this preview caught the words (#short-dictation).
+    var liveCaption: String {
+        [confirmedText, volatileText].filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
     private let audioEngine = AVAudioEngine()
     private var manager: SlidingWindowAsrManager?
     private var updatesTask: Task<Void, Never>?
     private var feederTask: Task<Void, Never>?
     private var bufferContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
     private(set) var isRunning = false
+    /// Bumped by every start()/cancel()/finish(). `start()` captures its value and bails out if
+    /// it changes mid-setup — a stop can land before `isRunning` is even true (so cancel/finish
+    /// no-op), and without this the half-set-up stream goes live as a zombie: it keeps feeding the
+    /// old caption and its lingering `isRunning` blocks the next recording (#stale-caption).
+    private var startGeneration = 0
 
     private init() {}
 
@@ -30,6 +42,8 @@ final class StreamingTranscriptionController: ObservableObject {
     /// file-based flow. `boostTerms` (the custom dictionary's terms) bias recognition when present.
     func start(boostTerms: [String]) async throws {
         guard !isRunning else { return }
+        startGeneration &+= 1
+        let generation = startGeneration
         confirmedText = ""
         volatileText = ""
 
@@ -53,9 +67,17 @@ final class StreamingTranscriptionController: ObservableObject {
         await configureVocabulary(on: manager, boostTerms: boostTerms)
         try await manager.loadModels(models)
         try await manager.startStreaming(source: .microphone)
+        let updates = await manager.transcriptionUpdates
+
+        // A stop (cancel/finish) or a newer start() may have landed during the async setup
+        // above — before `isRunning` was true, so it no-op'd on us. Don't go live as a zombie:
+        // tear the half-built stream down and return (#stale-caption).
+        guard generation == startGeneration else {
+            await manager.cancel()
+            return
+        }
         self.manager = manager
 
-        let updates = await manager.transcriptionUpdates
         updatesTask = Task { [weak self] in
             for await _ in updates {
                 let confirmed = await manager.confirmedTranscript
@@ -89,15 +111,19 @@ final class StreamingTranscriptionController: ObservableObject {
 
     /// Stops streaming and returns the complete transcript (nil if streaming wasn't running).
     func finish() async -> String? {
+        startGeneration &+= 1  // abort any start() still in setup
         guard isRunning, let manager = manager else { return nil }
         stopAudio()
         let text = try? await manager.finish()
         self.manager = nil
+        confirmedText = ""
+        volatileText = ""
         return text
     }
 
     /// Stops and discards (used when a recording is cancelled).
     func cancel() async {
+        startGeneration &+= 1  // abort any start() still in setup
         guard isRunning else { return }
         stopAudio()
         await manager?.cancel()

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -182,22 +182,33 @@ class IndicatorViewModel: ObservableObject {
                 
                 do {
                     print("start decoding...")
-                    // Live streaming is a preview only; the inserted text always comes from the
-                    // accurate file pass. Stop the preview, then transcribe the recording.
+                    // Live streaming is a preview; the inserted text normally comes from the
+                    // accurate file pass. Grab the preview text first, though: a very short clip
+                    // can come back empty from the offline file model even when the sliding-window
+                    // preview caught it — then it's the only transcription we have (#short-dictation).
+                    var streamedFallback = ""
                     if self.liveStreamingActive {
                         self.liveStreamingActive = false
+                        streamedFallback = StreamingTranscriptionController.shared.liveCaption
                         await StreamingTranscriptionController.shared.cancel()
                     }
                     let rawText = try await transcriptionService.transcribeAudio(url: tempURL, settings: Settings())
                     var text = AppPreferences.shared.cleanTranscription(rawText)
 
-                    // Nothing intelligible was said: never paste the placeholder — just give a
-                    // brief on-screen hint and finish (don't store an empty recording either).
+                    // File pass found nothing. Fall back to the live preview if it caught the
+                    // words (short clip); only with neither is it genuinely "no speech" — then
+                    // never paste the placeholder, just hint and finish (no empty recording).
                     if text == TranscriptionResult.noSpeech
                         || text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        try? FileManager.default.removeItem(at: tempURL)
-                        await MainActor.run { self.showInfo("No speech detected") }
-                        return
+                        let fallback = AppPreferences.shared
+                            .cleanTranscription(streamedFallback)
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !fallback.isEmpty else {
+                            try? FileManager.default.removeItem(at: tempURL)
+                            await MainActor.run { self.showInfo("No speech detected") }
+                            return
+                        }
+                        text = fallback
                     }
 
                     // Optional LLM cleanup (no-op when disabled; returns the raw text on failure).


### PR DESCRIPTION
Two bugs on the **fluidaudio (Parakeet) live-transcription** path.

### 1. Short clips produced no transcription
The offline file pass returns empty for sub-second audio, and the live-preview
text the user *saw in the notch* was thrown away via `cancel()`. Now the live
caption is captured before the stream is torn down and used as a fallback when
the file pass comes back empty — a quick "439" gets inserted instead of nothing.

### 2. Stale caption on relaunch
A stop landing during `start()`'s async setup (before `isRunning` is `true`)
no-op'd `cancel()`/`finish()`, so the half-built stream went live as a **zombie**
that kept the old caption and blocked the next `start()`. A generation counter now
invalidates any in-flight setup, which tears itself down cleanly.

### Scope
Only the Parakeet + live-transcription path. Other engines are untouched.

### Testing
Built + installed; validated live: short clips now insert, and rapid back-to-back
recordings no longer show the previous caption.