### PR TITLE
fix(build): gate AppleSpeechModelSection on the macOS 26 SDK

### DIFF
--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -1,6 +1,14 @@
 import Speech
 import SwiftUI
 
+// SpeechTranscriber/AssetInventory and the full AppleSpeechSupport only exist in the
+// macOS 26 SDK. `@available` guards the runtime, not compilation — so gate the whole
+// file on the SDK (keyed off FoundationModels, a macOS-26-only framework), exactly like
+// AppleSpeechEngine.swift. Without this, an older toolchain (CI's Xcode 16 runner) fails
+// to compile it even though the call site is already #if-gated. No #else stub is needed:
+// the only reference (Settings) is itself behind `#if canImport(FoundationModels)`.
+#if canImport(FoundationModels)
+
 /// Apple Speech section (Settings → Models when browsing the Apple engine, macOS 26+).
 /// Works like every other engine's model list, with one row per language: Download
 /// fetches its system assets (AssetInventory — shared across apps, updated with the
@@ -209,3 +217,5 @@ struct AppleSpeechModelSection: View {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
`AppleSpeechModelSection` was guarded only by `@available(macOS 26.0, *)`, which
gates the **runtime**, not compilation. On a toolchain without the macOS 26 SDK —
GitHub's `macos-latest` still rotates in **Xcode 16.4** — `SpeechTranscriber` /
`AssetInventory` and the full `AppleSpeechSupport` don't exist, so the file fails
to compile. Its only reference (in Settings) is already behind
`#if canImport(FoundationModels)`, so wrapping the whole file the same way
(matching `AppleSpeechEngine.swift`) fixes it with no `#else` stub.

This is a latent bug on master surfaced by CI non-determinism: builds that land
on Xcode 26.5 pass, builds on Xcode 16.4 fail. With this, both compile.