### PR TITLE
ci: pin Build Check to the macos-26 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # Pinned to the macOS 26 runner: it ships only Xcode 26.x (macOS 26 SDK), so the
+    # Apple Speech engine (SpeechTranscriber/AssetInventory, gated on
+    # `#if canImport(FoundationModels)`) is always compiled and tested. `macos-latest`
+    # (macOS 15) rotates its default Xcode between 16.4 and 26.5, which non-deterministically
+    # dropped the whole Apple Speech path and broke builds depending on which runner we drew.
+    runs-on: macos-26
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to #39. `macos-latest` (macOS 15) ships **both Xcode 16.4 and 26.5** and
rotates its default, so Build Check non-deterministically compiled *without* the
macOS 26 SDK — dropping the entire Apple Speech engine (`canImport(FoundationModels)`
== false) and, before #39, breaking the build depending on which runner we drew.

The **`macos-26`** runner ships only Xcode 26.x (macOS 26 SDK), so the Apple Speech
path is always compiled and tested and builds are deterministic.