### PR TITLE
feat: voice commands — spoken app open / switch / quit

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -252,6 +252,24 @@ class IndicatorViewModel: ObservableObject {
                         text = fallback
                     }
 
+                    // Voice command (opt-in): a leading trigger word ("whisper open slack") performs
+                    // an action instead of being typed. Skips LLM cleanup, history, and insertion.
+                    if AppPreferences.shared.voiceCommandsEnabled {
+                        switch VoiceCommandRouter.classify(text, trigger: AppPreferences.shared.voiceCommandTrigger) {
+                        case .command(let command):
+                            try? FileManager.default.removeItem(at: tempURL)
+                            let feedback = await VoiceCommandRouter.execute(command)
+                            await MainActor.run { self.showInfo(feedback) }
+                            return
+                        case .unrecognized:
+                            try? FileManager.default.removeItem(at: tempURL)
+                            await MainActor.run { self.showInfo("Sorry, I didn't catch that command") }
+                            return
+                        case .dictation:
+                            break
+                        }
+                    }
+
                     // Optional LLM cleanup (no-op when disabled; returns the raw text on failure).
                     text = await LLMPostProcessor.process(text)
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -489,6 +489,21 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    /// Voice commands: a leading trigger word ("whisper open slack") performs an action
+    /// instead of being typed. Opt-in. See `VoiceCommandRouter`.
+    @Published var voiceCommandsEnabled: Bool {
+        didSet {
+            AppPreferences.shared.voiceCommandsEnabled = voiceCommandsEnabled
+        }
+    }
+
+    /// The wake word that marks an utterance as a command. Default "whisper".
+    @Published var voiceCommandTrigger: String {
+        didSet {
+            AppPreferences.shared.voiceCommandTrigger = voiceCommandTrigger
+        }
+    }
+
     @Published var pauseMediaOnRecord: Bool {
         didSet {
             AppPreferences.shared.pauseMediaOnRecord = pauseMediaOnRecord
@@ -637,6 +652,8 @@ class SettingsViewModel: ObservableObject {
         self.pasteInsteadOfTyping = prefs.pasteInsteadOfTyping
         self.notifyWhenNoPasteTarget = prefs.notifyWhenNoPasteTarget
         self.submitOnVoiceCommand = prefs.submitOnVoiceCommand
+        self.voiceCommandsEnabled = prefs.voiceCommandsEnabled
+        self.voiceCommandTrigger = prefs.voiceCommandTrigger
         self.pauseMediaOnRecord = prefs.pauseMediaOnRecord
         self.reduceVolumeOnRecord = prefs.reduceVolumeOnRecord
         self.reduceVolumeLevel = prefs.reduceVolumeLevel
@@ -1826,6 +1843,18 @@ struct SettingsView: View {
                         sEditor($viewModel.aiPostProcessingPrompt, height: 64)
                     }
                     .padding(.leading, 16)
+                }
+            }
+
+            SSection(title: "Voice Commands") {
+                SRow(title: "Enable voice commands",
+                     hint: "A leading trigger word (\"\(viewModel.voiceCommandTrigger) open slack\") performs an action instead of being typed — open / switch to / quit + an app name.") {
+                    SToggle(isOn: $viewModel.voiceCommandsEnabled)
+                }
+                if viewModel.voiceCommandsEnabled {
+                    SRow(title: "Trigger word", indented: true) {
+                        sInput($viewModel.voiceCommandTrigger, prompt: "whisper", width: 160)
+                    }
                 }
             }
 

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -373,30 +373,20 @@ final class AppPreferences {
     @UserDefault(key: "submitOnVoiceCommand", defaultValue: false)
     var submitOnVoiceCommand: Bool
 
-    /// Detects a trailing "press enter" voice command, gated by `submitOnVoiceCommand`. Returns the
-    /// text with the command removed, plus whether it was present. No-op (text unchanged,
-    /// `submit: false`) when the preference is off. The matching itself is in `parseSubmitCommand`.
+    /// Voice commands: a leading trigger word ("whisper open slack") performs an action instead of
+    /// being typed. Opt-in. See `VoiceCommandRouter`.
+    @UserDefault(key: "voiceCommandsEnabled", defaultValue: false)
+    var voiceCommandsEnabled: Bool
+
+    /// The wake word that marks an utterance as a command. Default "whisper".
+    @UserDefault(key: "voiceCommandTrigger", defaultValue: "whisper")
+    var voiceCommandTrigger: String
+
+    /// Detects a trailing "press enter" voice command (parse lives in `VoiceCommandRouter`).
+    /// No-op (returns the text unchanged with `submit: false`) unless `submitOnVoiceCommand` is on.
     func stripSubmitCommand(_ text: String) -> (text: String, submit: Bool) {
         guard submitOnVoiceCommand else { return (text, false) }
-        return Self.parseSubmitCommand(text)
-    }
-
-    /// Pure regex extraction behind `stripSubmitCommand` (unit-tested directly). Strips a trailing
-    /// "press enter" — optionally preceded by whitespace/commas and followed by trailing
-    /// whitespace/punctuation — anchored to the end of the text.
-    ///
-    /// Because it only anchors to the end, "press enter" earlier in a sentence ("press enter to
-    /// continue reading") is left alone. A phrase that genuinely *ends* in "press enter"
-    /// ("tell him to press enter") IS stripped — an accepted ambiguity of an end-of-utterance voice
-    /// command. A preceding sentence period ("Send this. Press enter.") is kept (only whitespace/
-    /// commas are consumed before the command).
-    static func parseSubmitCommand(_ text: String) -> (text: String, submit: Bool) {
-        let pattern = "[\\s,]*press[\\s,]+enter[\\s\\p{P}]*$"
-        guard let range = text.range(
-            of: pattern, options: [.regularExpression, .caseInsensitive]) else {
-            return (text, false)
-        }
-        return (String(text[..<range.lowerBound]), true)
+        return VoiceCommandRouter.parseSubmitCommand(text)
     }
 
     /// Pause currently-playing media while recording, then resume. Opt-in (default

--- a/OpenSuperWhisper/Utils/InstalledApps.swift
+++ b/OpenSuperWhisper/Utils/InstalledApps.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Foundation
+
+/// A user-facing application discovered on disk, used by the app-aware formatting picker so the
+/// user chooses an app from a list instead of typing its bundle identifier.
+struct InstalledApp: Identifiable, Hashable {
+    var id: String { bundleIdentifier }
+    let bundleIdentifier: String
+    let name: String
+    let url: URL
+}
+
+enum InstalledApps {
+    /// Standard locations where `.app` bundles live. Covers the vast majority of apps; anything
+    /// outside these can still be added via the picker's "Browse…" (NSOpenPanel) escape hatch.
+    private static let searchRoots: [URL] = [
+        "/Applications",
+        "/Applications/Utilities",
+        "/System/Applications",
+        "/System/Applications/Utilities",
+        NSHomeDirectory() + "/Applications",
+    ].map { URL(fileURLWithPath: $0) }
+
+    /// All installed apps, de-duplicated by bundle id and sorted by display name.
+    static func all() -> [InstalledApp] {
+        var seen = Set<String>()
+        var result: [InstalledApp] = []
+        for root in searchRoots {
+            // Path-based enumeration on purpose: the URL-based `contentsOfDirectory(at:)` silently
+            // drops symlinks into the macOS Cryptex (e.g. /Applications/Safari.app →
+            // ../System/Cryptexes/…), which would omit Safari and other sealed system apps. The
+            // path variant lists the symlink; `Bundle(url:)` then resolves it to the real bundle.
+            let names = (try? FileManager.default.contentsOfDirectory(atPath: root.path)) ?? []
+            for name in names where name.hasSuffix(".app") {
+                let url = root.appendingPathComponent(name)
+                guard let app = app(at: url), !seen.contains(app.bundleIdentifier) else { continue }
+                seen.insert(app.bundleIdentifier)
+                result.append(app)
+            }
+        }
+        return result.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Reads an `.app` bundle into an `InstalledApp` (nil if it has no bundle identifier).
+    static func app(at url: URL) -> InstalledApp? {
+        guard let bundle = Bundle(url: url), let bid = bundle.bundleIdentifier else { return nil }
+        let name = FileManager.default.displayName(atPath: url.path)
+            .replacingOccurrences(of: ".app", with: "")
+        return InstalledApp(bundleIdentifier: bid, name: name, url: url)
+    }
+
+    /// Best match for a spoken app name ("slack" → Slack), preferring exact, then prefix, then the
+    /// shortest containing name (so "slack" picks "Slack" over "Slack Helper"). Pure; testable.
+    static func bestMatch(forSpokenName query: String, in apps: [InstalledApp]) -> InstalledApp? {
+        let q = query.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+        guard !q.isEmpty else { return nil }
+        if let exact = apps.first(where: { $0.name.lowercased() == q }) { return exact }
+        if let prefix = apps.first(where: { $0.name.lowercased().hasPrefix(q) }) { return prefix }
+        return apps
+            .filter { $0.name.lowercased().contains(q) }
+            .min { $0.name.count < $1.name.count }
+    }
+
+    /// Icon for a discovered app.
+    static func icon(for url: URL) -> NSImage {
+        NSWorkspace.shared.icon(forFile: url.path)
+    }
+
+    /// Best-effort icon for an already-stored bundle id (so existing profiles show the app icon
+    /// even though they only persist the identifier). Falls back to a generic app icon.
+    static func icon(forBundleIdentifier bundleIdentifier: String) -> NSImage {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
+            return NSWorkspace.shared.icon(forFile: url.path)
+        }
+        return NSWorkspace.shared.icon(for: .applicationBundle)
+    }
+}

--- a/OpenSuperWhisper/Utils/VoiceCommandRouter.swift
+++ b/OpenSuperWhisper/Utils/VoiceCommandRouter.swift
@@ -1,0 +1,114 @@
+import AppKit
+import Foundation
+
+/// Parses (and executes) spoken voice commands, the single home for command-vs-dictation logic.
+///
+/// Two kinds:
+///  - A leading **wake word** ("whisper open slack") routes the rest as an app command (open /
+///    focus / quit) and is performed instead of being typed. Opt-in via `voiceCommandsEnabled`.
+///  - A trailing **"press enter"** submits after insertion (folded in from the old
+///    `stripSubmitCommand`; the pure parse lives here, the pref gate stays in `AppPreferences`).
+///
+/// The classification/parse functions are pure (no I/O) so they're unit-tested; `execute` does the
+/// disk scan + AppKit side effects.
+enum VoiceCommandRouter {
+
+    enum AppAction: Equatable { case activate, quit }
+
+    struct AppCommand: Equatable {
+        let action: AppAction
+        let query: String   // spoken app name, e.g. "slack"
+    }
+
+    /// What the router decided the utterance is.
+    enum Outcome: Equatable {
+        case command(AppCommand)   // wake word + recognized verb + app name
+        case unrecognized          // wake word present but nothing parseable → user feedback
+        case dictation             // not a command → normal insertion path
+    }
+
+    // Verb phrases mapped to an action. Multi-word phrases are matched as written.
+    private static let quitVerbs = ["quit", "close", "kill", "exit"]
+    private static let activateVerbs = ["switch to", "go to", "bring up", "pull up",
+                                        "open", "launch", "start", "focus", "show"]
+
+    // MARK: - Classification (pure)
+
+    /// Classifies `text` against the configured `trigger`. Pure; no I/O.
+    static func classify(_ text: String, trigger: String) -> Outcome {
+        guard let remainder = stripWakeWord(text, trigger: trigger) else { return .dictation }
+        guard let command = parseAppCommand(remainder) else { return .unrecognized }
+        return .command(command)
+    }
+
+    /// The text after a leading `trigger` word (consuming a trailing comma/space), or nil if the
+    /// utterance doesn't start with the trigger as a whole word, or is *only* the trigger.
+    static func stripWakeWord(_ text: String, trigger: String) -> String? {
+        let t = trigger.trimmingCharacters(in: .whitespaces)
+        guard !t.isEmpty else { return nil }
+        let pattern = "^\\s*\(NSRegularExpression.escapedPattern(for: t))\\b[\\s,]*"
+        guard let range = text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return nil
+        }
+        let rest = String(text[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return rest.isEmpty ? nil : rest
+    }
+
+    /// Parses a command remainder ("open slack") into an `AppCommand`, or nil if no verb matches.
+    static func parseAppCommand(_ remainder: String) -> AppCommand? {
+        for verb in quitVerbs {
+            if let query = appQuery(after: verb, in: remainder) { return AppCommand(action: .quit, query: query) }
+        }
+        for verb in activateVerbs {
+            if let query = appQuery(after: verb, in: remainder) { return AppCommand(action: .activate, query: query) }
+        }
+        return nil
+    }
+
+    /// The non-empty app name following `verb` at the start of `text`, or nil.
+    private static func appQuery(after verb: String, in text: String) -> String? {
+        let pattern = "^\(NSRegularExpression.escapedPattern(for: verb))\\b\\s*"
+        guard let range = text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return nil
+        }
+        // Trim surrounding whitespace AND punctuation: speech-to-text appends a period to short
+        // utterances ("open safari." → "safari."), which would otherwise break the app match.
+        let app = String(text[range.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+        return app.isEmpty ? nil : app
+    }
+
+    /// Trailing "press enter" → (text without it, submit: true). Pure; gate on the pref at the call
+    /// site (see `AppPreferences.stripSubmitCommand`).
+    static func parseSubmitCommand(_ text: String) -> (text: String, submit: Bool) {
+        let pattern = "[\\s,]*press[\\s,]+enter[\\s\\p{P}]*$"
+        guard let range = text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return (text, false)
+        }
+        return (String(text[..<range.lowerBound]), true)
+    }
+
+    // MARK: - Execution (side effects)
+
+    /// Resolves the command's app and performs it, returning a short feedback string for the indicator.
+    static func execute(_ command: AppCommand) async -> String {
+        let apps = InstalledApps.all()
+        guard let app = InstalledApps.bestMatch(forSpokenName: command.query, in: apps) else {
+            return "No app named “\(command.query)”"
+        }
+        switch command.action {
+        case .activate:
+            await MainActor.run {
+                let config = NSWorkspace.OpenConfiguration()
+                config.activates = true
+                NSWorkspace.shared.openApplication(at: app.url, configuration: config, completionHandler: nil)
+            }
+            return "Opening \(app.name)…"
+        case .quit:
+            let running = NSRunningApplication.runningApplications(withBundleIdentifier: app.bundleIdentifier)
+            guard !running.isEmpty else { return "\(app.name) isn't running" }
+            await MainActor.run { running.forEach { $0.terminate() } }
+            return "Quitting \(app.name)…"
+        }
+    }
+}

--- a/OpenSuperWhisperTests/SubmitCommandTests.swift
+++ b/OpenSuperWhisperTests/SubmitCommandTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class SubmitCommandTests: XCTestCase {
 
     private func parse(_ s: String) -> (text: String, submit: Bool) {
-        AppPreferences.parseSubmitCommand(s)
+        VoiceCommandRouter.parseSubmitCommand(s)
     }
 
     func testStripsTrailingCommand() {

--- a/OpenSuperWhisperTests/VoiceCommandRouterTests.swift
+++ b/OpenSuperWhisperTests/VoiceCommandRouterTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import OpenSuperWhisper
+
+/// Covers the pure parsing behind voice commands: wake-word detection, verb/app parsing, the
+/// dictation-vs-command classification, the trailing submit command, and the fuzzy app matcher.
+/// Execution (NSWorkspace side effects) is not unit-tested.
+final class VoiceCommandRouterTests: XCTestCase {
+
+    // MARK: - stripWakeWord
+
+    func testStripWakeWordBasic() {
+        XCTAssertEqual(VoiceCommandRouter.stripWakeWord("whisper open slack", trigger: "whisper"), "open slack")
+    }
+
+    func testStripWakeWordCaseAndCommaInsensitive() {
+        XCTAssertEqual(VoiceCommandRouter.stripWakeWord("Whisper, open Slack", trigger: "whisper"), "open Slack")
+    }
+
+    func testStripWakeWordRequiresWholeWord() {
+        // "whispering" must not trigger on the "whisper" prefix.
+        XCTAssertNil(VoiceCommandRouter.stripWakeWord("whispering quietly to him", trigger: "whisper"))
+    }
+
+    func testStripWakeWordAbsent() {
+        XCTAssertNil(VoiceCommandRouter.stripWakeWord("open slack", trigger: "whisper"))
+    }
+
+    func testStripWakeWordAloneIsNotACommand() {
+        XCTAssertNil(VoiceCommandRouter.stripWakeWord("whisper", trigger: "whisper"))
+    }
+
+    // MARK: - parseAppCommand
+
+    func testParseOpen() {
+        XCTAssertEqual(VoiceCommandRouter.parseAppCommand("open slack"),
+                       .init(action: .activate, query: "slack"))
+    }
+
+    func testParseSwitchToMultiWordVerb() {
+        XCTAssertEqual(VoiceCommandRouter.parseAppCommand("switch to visual studio code"),
+                       .init(action: .activate, query: "visual studio code"))
+    }
+
+    func testParseQuit() {
+        XCTAssertEqual(VoiceCommandRouter.parseAppCommand("quit spotify"),
+                       .init(action: .quit, query: "spotify"))
+    }
+
+    func testParseUnknownVerb() {
+        XCTAssertNil(VoiceCommandRouter.parseAppCommand("hello there"))
+    }
+
+    func testParseVerbWithoutAppIsNil() {
+        XCTAssertNil(VoiceCommandRouter.parseAppCommand("open"))
+    }
+
+    func testParseStripsTrailingPunctuationFromSpeech() {
+        // Whisper appends a period to short utterances ("open safari." → query "safari").
+        XCTAssertEqual(VoiceCommandRouter.parseAppCommand("open safari."),
+                       .init(action: .activate, query: "safari"))
+        XCTAssertEqual(VoiceCommandRouter.parseAppCommand("switch to visual studio code."),
+                       .init(action: .activate, query: "visual studio code"))
+    }
+
+    // MARK: - classify
+
+    func testClassifyDictationWhenNoTrigger() {
+        XCTAssertEqual(VoiceCommandRouter.classify("open slack", trigger: "whisper"), .dictation)
+    }
+
+    func testClassifyCommand() {
+        XCTAssertEqual(VoiceCommandRouter.classify("whisper open slack", trigger: "whisper"),
+                       .command(.init(action: .activate, query: "slack")))
+    }
+
+    func testClassifyUnrecognizedWhenTriggerButNoVerb() {
+        XCTAssertEqual(VoiceCommandRouter.classify("whisper hello there", trigger: "whisper"), .unrecognized)
+    }
+
+    // MARK: - parseSubmitCommand
+
+    func testSubmitCommandDetected() {
+        let result = VoiceCommandRouter.parseSubmitCommand("send the message press enter")
+        XCTAssertEqual(result.text, "send the message")
+        XCTAssertTrue(result.submit)
+    }
+
+    func testSubmitCommandAbsent() {
+        let result = VoiceCommandRouter.parseSubmitCommand("just some dictation")
+        XCTAssertEqual(result.text, "just some dictation")
+        XCTAssertFalse(result.submit)
+    }
+
+    // MARK: - InstalledApps.bestMatch
+
+    private let apps = [
+        InstalledApp(bundleIdentifier: "com.tinyspeck.slackmacgap", name: "Slack", url: URL(fileURLWithPath: "/Applications/Slack.app")),
+        InstalledApp(bundleIdentifier: "com.tinyspeck.slack.helper", name: "Slack Helper", url: URL(fileURLWithPath: "/x/Slack Helper.app")),
+        InstalledApp(bundleIdentifier: "com.microsoft.VSCode", name: "Visual Studio Code", url: URL(fileURLWithPath: "/Applications/Visual Studio Code.app")),
+    ]
+
+    func testBestMatchExactBeatsContaining() {
+        // "slack" must pick "Slack", not "Slack Helper".
+        XCTAssertEqual(InstalledApps.bestMatch(forSpokenName: "slack", in: apps)?.name, "Slack")
+    }
+
+    func testBestMatchContains() {
+        XCTAssertEqual(InstalledApps.bestMatch(forSpokenName: "visual studio", in: apps)?.name, "Visual Studio Code")
+    }
+
+    func testBestMatchNone() {
+        XCTAssertNil(InstalledApps.bestMatch(forSpokenName: "photoshop", in: apps))
+    }
+
+    func testBestMatchIgnoresTrailingPunctuation() {
+        XCTAssertEqual(InstalledApps.bestMatch(forSpokenName: "slack.", in: apps)?.name, "Slack")
+    }
+}


### PR DESCRIPTION
## What

Adds **voice commands**: a dictation that begins with a configurable trigger word (e.g. `whisper open slack`) performs an action — **open**, **switch to**, or **quit** an app resolved by name — instead of being typed.

Opt-in via a new `voiceCommandsEnabled` preference (default **off**), with a configurable trigger word (`voiceCommandTrigger`, default `whisper`).

## How it works

- **`VoiceCommandRouter`** (`Utils/VoiceCommandRouter.swift`) — a pure `classify(_:trigger:)` (wake word → verb → app query) returning `.command` / `.unrecognized` / `.dictation`, plus `execute(_:)` which acts via `NSWorkspace`. Verbs map to open/activate (`open`, `switch to`, `focus`, …) or quit (`quit`, `close`, …).
- **`InstalledApps`** (`Utils/InstalledApps.swift`) — enumerates installed apps, best-matches a spoken name, and resolves icons.
- Wired into the hotkey path in `IndicatorWindow`: when enabled, a recognized command **short-circuits before** LLM cleanup, history, and text insertion; an unrecognized command after the trigger word shows feedback rather than typing.
- Settings → new **Voice Commands** section (enable toggle + trigger word).

## Note on `parseSubmitCommand`

The trailing "press enter" submit parse (merged in #14) is **moved** from `AppPreferences` into `VoiceCommandRouter`, so all utterance-command parsing lives in one place. `stripSubmitCommand` and its tests are updated to call the new location; behavior is unchanged.

## Testing

- New `VoiceCommandRouterTests` cover classification (wake-word matching, verb/app parsing, dictation passthrough).
- `SubmitCommandTests` updated for the moved parser; still green.
- Full `./run.sh build` succeeds (arm64 Debug), app signs and validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
