### PR TITLE
fix(clipboard): restore the previous clipboard after paste when 'Copy to clipboard' is off

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -422,8 +422,15 @@ class IndicatorViewModel: ObservableObject {
             // check can't read (Messages, Electron), and is a harmless no-op otherwise (the text
             // is on the clipboard). So no editable-target gate — it only ever produces false
             // negatives that wrongly suppress a valid paste (#paste-messages).
-            if !prefs.autoCopyToClipboard { ClipboardUtil.copyToClipboard(finalText) }
-            Diag.measure("TextInserter.paste") { TextInserter.paste() }
+            if prefs.autoCopyToClipboard {
+                Diag.measure("TextInserter.paste") { TextInserter.paste() }
+            } else {
+                // The clipboard is only the paste vehicle here — the user opted out of keeping
+                // the text on it (#44) — so put the previous contents back after the ⌘V lands.
+                ClipboardUtil.borrowForPaste(finalText) {
+                    Diag.measure("TextInserter.paste") { TextInserter.paste() }
+                }
+            }
             return false
         }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1907,7 +1907,7 @@ struct SettingsView: View {
             }
 
             SSection(title: "Delivery") {
-                SRow(title: "Copy to clipboard", hint: "Also place the transcription on the clipboard") {
+                SRow(title: "Copy to clipboard", hint: "Also place the transcription on the clipboard. When off, the previous clipboard contents are preserved") {
                     SToggle(isOn: $viewModel.autoCopyToClipboard)
                 }
                 SRow(title: "Auto-paste transcription", hint: "Insert the transcription into the focused app") {

--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -4,10 +4,63 @@ import Carbon
 enum ClipboardUtil {
     /// Copies text to the clipboard. Used only as an optional independent stash;
     /// insertion into the focused app is done by `TextInserter`, not the clipboard.
-    static func copyToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
+    static func copyToClipboard(_ text: String, to pasteboard: NSPasteboard = .general) {
         pasteboard.declareTypes([.string], owner: nil)
         pasteboard.setString(text, forType: .string)
+    }
+
+    // MARK: - Borrow-and-restore (paste mode with "Copy to clipboard" off — #44)
+
+    /// The pasteboard's full contents (every item, every type), so it can be put back
+    /// after the clipboard is borrowed as the ⌘V paste vehicle.
+    struct Snapshot {
+        let items: [[NSPasteboard.PasteboardType: Data]]
+    }
+
+    static func snapshot(of pasteboard: NSPasteboard = .general) -> Snapshot {
+        let items = (pasteboard.pasteboardItems ?? []).map { item in
+            item.types.reduce(into: [NSPasteboard.PasteboardType: Data]()) { acc, type in
+                acc[type] = item.data(forType: type)
+            }
+        }
+        return Snapshot(items: items)
+    }
+
+    /// Writes a snapshot back, replacing the pasteboard's current contents.
+    static func restore(_ snapshot: Snapshot, to pasteboard: NSPasteboard = .general) {
+        pasteboard.clearContents()
+        guard !snapshot.items.isEmpty else { return }
+        let items = snapshot.items.map { typeMap -> NSPasteboardItem in
+            let item = NSPasteboardItem()
+            for (type, data) in typeMap { item.setData(data, forType: type) }
+            return item
+        }
+        pasteboard.writeObjects(items)
+    }
+
+    /// How long the borrowed pasteboard keeps the transcription before the previous contents come
+    /// back: long enough for the frontmost app to service the synthetic ⌘V even under post-
+    /// transcription CPU load (the pre-0.9.0 restore logic topped out at 0.5s under load — this
+    /// adds margin, and being generous costs nothing now that the wait no longer blocks a thread).
+    static let borrowRestoreDelay: TimeInterval = 1.0
+
+    /// Puts `text` on the pasteboard just long enough for `paste` (a synthetic ⌘V) to be serviced,
+    /// then restores the previous contents — for when the user opted out of keeping transcriptions
+    /// on the clipboard and it's only borrowed as the paste vehicle (#44). The restore is skipped
+    /// if anything else writes to the pasteboard within the delay (a user copy, a clipboard
+    /// manager): newer content wins over our restore.
+    static func borrowForPaste(_ text: String,
+                               on pasteboard: NSPasteboard = .general,
+                               restoreAfter delay: TimeInterval = borrowRestoreDelay,
+                               paste: () -> Void) {
+        let saved = snapshot(of: pasteboard)
+        copyToClipboard(text, to: pasteboard)
+        let borrowChangeCount = pasteboard.changeCount
+        paste()
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard pasteboard.changeCount == borrowChangeCount else { return }
+            restore(saved, to: pasteboard)
+        }
     }
 
     // MARK: - Input source helpers (used by keyboard-layout tests)

--- a/OpenSuperWhisperTests/ClipboardRestoreTests.swift
+++ b/OpenSuperWhisperTests/ClipboardRestoreTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Covers the pasteboard snapshot/restore behind paste mode with "Copy to clipboard" off (#44),
+/// where the clipboard is only borrowed as the ⌘V vehicle and must be given back. Runs against a
+/// private named pasteboard so the developer's real clipboard is never touched.
+final class ClipboardRestoreTests: XCTestCase {
+
+    private var pasteboard: NSPasteboard!
+
+    override func setUp() {
+        super.setUp()
+        pasteboard = NSPasteboard(name: NSPasteboard.Name("OpenSuperWhisperTests." + UUID().uuidString))
+    }
+
+    override func tearDown() {
+        pasteboard.releaseGlobally()
+        pasteboard = nil
+        super.tearDown()
+    }
+
+    // MARK: - snapshot / restore
+
+    func testSnapshotRestoreRoundtripsString() {
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+        let snapshot = ClipboardUtil.snapshot(of: pasteboard)
+
+        ClipboardUtil.copyToClipboard("transcription", to: pasteboard)
+        ClipboardUtil.restore(snapshot, to: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testSnapshotRestorePreservesEveryTypeOfAnItem() {
+        // An item carrying several representations (e.g. rich text copied from a browser)
+        // must come back whole, not just its plain-string face.
+        let blobType = NSPasteboard.PasteboardType("com.example.blob")
+        let item = NSPasteboardItem()
+        item.setString("styled", forType: .string)
+        item.setData(Data([1, 2, 3]), forType: blobType)
+        pasteboard.clearContents()
+        pasteboard.writeObjects([item])
+        let snapshot = ClipboardUtil.snapshot(of: pasteboard)
+
+        ClipboardUtil.copyToClipboard("transcription", to: pasteboard)
+        ClipboardUtil.restore(snapshot, to: pasteboard)
+
+        XCTAssertEqual(pasteboard.string(forType: .string), "styled")
+        XCTAssertEqual(pasteboard.pasteboardItems?.first?.data(forType: blobType), Data([1, 2, 3]))
+    }
+
+    func testRestoreOfEmptySnapshotLeavesPasteboardEmpty() {
+        pasteboard.clearContents()
+        let empty = ClipboardUtil.snapshot(of: pasteboard)
+
+        ClipboardUtil.copyToClipboard("transcription", to: pasteboard)
+        ClipboardUtil.restore(empty, to: pasteboard)
+
+        XCTAssertNil(pasteboard.string(forType: .string))
+    }
+
+    // MARK: - borrowForPaste
+
+    func testBorrowForPasteHasTextOnPasteboardDuringPaste() {
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        var textDuringPaste: String?
+        ClipboardUtil.borrowForPaste("transcription", on: pasteboard, restoreAfter: 0.05) {
+            textDuringPaste = pasteboard.string(forType: .string)
+        }
+
+        XCTAssertEqual(textDuringPaste, "transcription")
+    }
+
+    func testBorrowForPasteRestoresPreviousContentsAfterDelay() {
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        ClipboardUtil.borrowForPaste("transcription", on: pasteboard, restoreAfter: 0.05) {}
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testBorrowForPasteSkipsRestoreWhenSomethingElseWroteMeanwhile() {
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        ClipboardUtil.borrowForPaste("transcription", on: pasteboard, restoreAfter: 0.05) {}
+        ClipboardUtil.copyToClipboard("user copy in between", to: pasteboard)
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "user copy in between")
+    }
+}


### PR DESCRIPTION
Fixes #44.

In paste mode the synthetic ⌘V **is** the insertion mechanism, so the transcription always landed on the clipboard and the previous contents were lost — the "Copy to clipboard" toggle had no observable effect (this was not a 0.9.6→0.9.9 regression; the insertion code is identical between the two tags).

Now, when the toggle is off, the clipboard is only **borrowed**: `ClipboardUtil.borrowForPaste()` snapshots the full pasteboard (all items, all types), pastes, then restores the snapshot 1s later. The restore is skipped if anything else wrote to the pasteboard in the meantime (user copy, clipboard manager) — newer content wins, guarded by `changeCount`.

Unchanged paths: toggle on → same as before; typing mode → clipboard already untouched; the "no paste target — press ⌘V" notice still intentionally leaves the text on the clipboard.

## Testing

- New `ClipboardRestoreTests` (6 tests, run against a private named pasteboard so the dev's clipboard is untouched): snapshot/restore roundtrip incl. multi-type items, restore-after-delay, and the skip-restore-when-clobbered guard.
- Full `./run.sh build` + `OpenSuperWhisperTests` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcMxhfLfbWaDXpaTvaHXpV