### PR TITLE
Add mouse Button 7 to recording trigger options

### DIFF
--- a/OpenSuperWhisper/MouseButtonMonitor.swift
+++ b/OpenSuperWhisper/MouseButtonMonitor.swift
@@ -8,6 +8,7 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
     case button4 = "button4"
     case button5 = "button5"
     case button6 = "button6"
+    case button7 = "button7"
 
     var id: String { rawValue }
 
@@ -18,6 +19,7 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
         case .button4: return "Button 4 (Back)"
         case .button5: return "Button 5 (Forward)"
         case .button6: return "Button 6"
+        case .button7: return "Button 7"
         }
     }
 
@@ -28,6 +30,7 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
         case .button4: return "🖱4"
         case .button5: return "🖱5"
         case .button6: return "🖱6"
+        case .button7: return "🖱7"
         }
     }
 
@@ -42,6 +45,7 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
         case .button4: return 3
         case .button5: return 4
         case .button6: return 5
+        case .button7: return 6
         }
     }
 }

--- a/OpenSuperWhisper/MouseButtonMonitor.swift
+++ b/OpenSuperWhisper/MouseButtonMonitor.swift
@@ -18,8 +18,8 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
         case .middle: return "Button 3 (Middle)"
         case .button4: return "Button 4 (Back)"
         case .button5: return "Button 5 (Forward)"
-        case .button6: return "Button 6"
-        case .button7: return "Button 7"
+        case .button6: return "Button 6 (Thumb)"
+        case .button7: return "Button 7 (Ring)"
         }
     }
 

--- a/OpenSuperWhisper/MouseButtonMonitor.swift
+++ b/OpenSuperWhisper/MouseButtonMonitor.swift
@@ -15,7 +15,7 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
     var displayName: String {
         switch self {
         case .none: return "None"
-        case .middle: return "Button 3 (Middle)"
+        case .middle: return "Button 3 (Top)"
         case .button4: return "Button 4 (Back)"
         case .button5: return "Button 5 (Forward)"
         case .button6: return "Button 6 (Thumb)"

--- a/OpenSuperWhisper/MouseButtonMonitor.swift
+++ b/OpenSuperWhisper/MouseButtonMonitor.swift
@@ -15,11 +15,11 @@ enum MouseButton: String, CaseIterable, Identifiable, Codable {
     var displayName: String {
         switch self {
         case .none: return "None"
-        case .middle: return "Button 3 (Top)"
+        case .middle: return "Button 3 (Middle)"
         case .button4: return "Button 4 (Back)"
         case .button5: return "Button 5 (Forward)"
-        case .button6: return "Button 6 (Thumb)"
-        case .button7: return "Button 7 (Ring)"
+        case .button6: return "Button 6"
+        case .button7: return "Button 7"
         }
     }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2200,7 +2200,7 @@ struct SettingsView: View {
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.warnBorder, lineWidth: 1))
                     }
                 case .mouse:
-                    SRow(title: "Mouse button", hint: "Middle or an extra (thumb) button — click to toggle, hold when Hold to Record is on") {
+                    SRow(title: "Mouse button", hint: "Middle, thumb, ring, or other extra buttons — click to toggle, hold when Hold to Record is on") {
                         Picker("", selection: $viewModel.mouseButtonHotkey) {
                             ForEach(MouseButton.allCases.filter { $0 != .none }) { button in
                                 Text(button.displayName).tag(button)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2200,7 +2200,7 @@ struct SettingsView: View {
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.warnBorder, lineWidth: 1))
                     }
                 case .mouse:
-                    SRow(title: "Mouse button", hint: "Middle, thumb, ring, or other extra buttons — click to toggle, hold when Hold to Record is on") {
+                    SRow(title: "Mouse button", hint: "Top, thumb, ring, or other extra buttons — click to toggle, hold when Hold to Record is on") {
                         Picker("", selection: $viewModel.mouseButtonHotkey) {
                             ForEach(MouseButton.allCases.filter { $0 != .none }) { button in
                                 Text(button.displayName).tag(button)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2200,7 +2200,7 @@ struct SettingsView: View {
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.warnBorder, lineWidth: 1))
                     }
                 case .mouse:
-                    SRow(title: "Mouse button", hint: "Top, thumb, ring, or other extra buttons — click to toggle, hold when Hold to Record is on") {
+                    SRow(title: "Mouse button", hint: "Middle or other extra buttons — click to toggle, hold when Hold to Record is on") {
                         Picker("", selection: $viewModel.mouseButtonHotkey) {
                             ForEach(MouseButton.allCases.filter { $0 != .none }) { button in
                                 Text(button.displayName).tag(button)


### PR DESCRIPTION
## Summary

- Adds `button7` to the `MouseButton` enum (`buttonNumber` 6 in CGEvent)
- Settings picker picks it up automatically via `allCases`

Closes #49

## Test plan

- [x] Settings → Dictation → Trigger → Mouse Button shows **Button 7**
- [x] Binding Button 7 starts/stops recording (hold-to-record and toggle)
- [x] Button 7 is consumed and does not fire its default app action
- [x] Verified on Logitech MX Master 4

Made with [Cursor](https://cursor.com)