### PR TITLE
fix(log): stop printing the database path at launch

### DIFF
--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -100,8 +100,6 @@ class RecordingStore: ObservableObject {
         let appDirectory = applicationSupport.appendingPathComponent(Bundle.main.bundleIdentifier!)
         let dbPath = appDirectory.appendingPathComponent("recordings.sqlite")
 
-        print("Database path: \(dbPath.path)")
-
         do {
             try FileManager.default.createDirectory(
                 at: appDirectory, withIntermediateDirectories: true)


### PR DESCRIPTION
Fixes #61.

The resolved DB path embeds the local username (`/Users/<name>/Library/Application Support/…`), so every launch wrote it to the unified log. The print carried no other information — the path is fully derivable from the bundle identifier — so it's removed rather than redacted.

Found during PR #57's security review (pre-existing on master, deliberately left out of the pure-move extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkpL2i9dvfnKjbBevJfkxa