### PR TITLE
docs(ui): warn that scheme-less server URLs default to plain http://

### DIFF
--- a/OpenSuperWhisper/RemoteCleanupSettingsView.swift
+++ b/OpenSuperWhisper/RemoteCleanupSettingsView.swift
@@ -15,7 +15,9 @@ struct RemoteCleanupSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            SRow(title: "Server", indented: true) {
+            SRow(title: "Server",
+                 hint: "Without a scheme, plain http:// (unencrypted) is used — type https:// explicitly for TLS.",
+                 indented: true) {
                 TextField("", text: $viewModel.aiRemoteEndpoint,
                           prompt: Text("https://api.groq.com/openai/v1"))
                     .textFieldStyle(.plain)

--- a/OpenSuperWhisper/RemoteServerSettingsView.swift
+++ b/OpenSuperWhisper/RemoteServerSettingsView.swift
@@ -32,7 +32,8 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
         VStack(alignment: .leading, spacing: 16) {
             SSection(title: "Server") {
                 presetRow()
-                SRow(title: "Server URL") {
+                SRow(title: "Server URL",
+                     hint: "Without a scheme, plain http:// (unencrypted) is used — type https:// explicitly for TLS.") {
                     TextField("", text: $viewModel.remoteServerURL,
                               prompt: Text("http://localhost:11434"))
                         .textFieldStyle(.plain)


### PR DESCRIPTION
Fixes #62.

Both remote endpoints — the transcription server (`RemoteEngine.endpoint(base:)`) and the LLM cleanup server (`LLMPostProcessor`) — normalize a bare hostname to `http://`, i.e. plaintext. That's intentional (LAN servers like speaches/Ollama are commonly plain HTTP), but a user typing `myserver.local` doesn't realize traffic goes unencrypted.

This is option (a) from the issue, the lowest-risk one: a hint at both configuration points (Remote Server settings + AI cleanup remote settings) via the existing `SRow` hint slot: *“Without a scheme, plain http:// (unencrypted) is used — type https:// explicitly for TLS.”* No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkpL2i9dvfnKjbBevJfkxa