### PR TITLE
feat(settings): live shortcut recorder + trigger-mode memory

### DIFF
--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1118,33 +1118,6 @@ struct InfoButton: View {
     }
 }
 
-/// A standard setting row: title (+ optional ⓘ with full details), a short caption, and a
-/// trailing control (e.g. a Toggle).
-struct SettingRow<Trailing: View>: View {
-    let title: LocalizedStringKey
-    let caption: LocalizedStringKey
-    var info: LocalizedStringKey? = nil
-    @ViewBuilder let trailing: () -> Trailing
-
-    var body: some View {
-        HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 5) {
-                    Text(title).font(.subheadline)
-                    if let info { InfoButton(text: info) }
-                }
-                Text(caption)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            Spacer()
-            trailing()
-        }
-    }
-}
-
 /// The settings tabs, shown as a vertical sidebar in the dedicated settings window.
 enum SettingsTab: String, CaseIterable, Identifiable {
     case dictation, models, output, rules, history, advanced, updates, feedback
@@ -1194,7 +1167,6 @@ struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
     @ObservedObject private var launchAtLogin = LaunchAtLoginManager.shared
     @Environment(\.dismiss) var dismiss
-    @State private var isRecordingNewShortcut = false
     @State private var selectedTab: SettingsTab = .dictation
     @State private var sidebarSearch = ""
     @FocusState private var sidebarSearchFocused: Bool
@@ -2122,10 +2094,6 @@ struct SettingsView: View {
         }
     }
 
-    private var useModifierKey: Bool {
-        viewModel.modifierOnlyHotkey != .none
-    }
-
     private enum TriggerMode: Hashable {
         case keyCombo
         case modifier
@@ -2149,20 +2117,27 @@ struct SettingsView: View {
                     Picker("", selection: Binding(
                         get: { triggerMode },
                         set: { newMode in
+                            // Remember the outgoing mode's choice so switching modes
+                            // round-trips (leaving Single Modifier used to reset it
+                            // to Left Command).
+                            if viewModel.modifierOnlyHotkey != .none {
+                                AppPreferences.shared.lastModifierOnlyHotkey = viewModel.modifierOnlyHotkey.rawValue
+                            }
+                            if viewModel.mouseButtonHotkey != .none {
+                                AppPreferences.shared.lastMouseButtonHotkey = viewModel.mouseButtonHotkey.rawValue
+                            }
                             switch newMode {
                             case .keyCombo:
                                 viewModel.mouseButtonHotkey = .none
                                 viewModel.modifierOnlyHotkey = .none
                             case .modifier:
                                 viewModel.mouseButtonHotkey = .none
-                                if viewModel.modifierOnlyHotkey == .none {
-                                    viewModel.modifierOnlyHotkey = .leftCommand
-                                }
+                                viewModel.modifierOnlyHotkey =
+                                    ModifierKey(rawValue: AppPreferences.shared.lastModifierOnlyHotkey) ?? .leftCommand
                             case .mouse:
                                 viewModel.modifierOnlyHotkey = .none
-                                if viewModel.mouseButtonHotkey == .none {
-                                    viewModel.mouseButtonHotkey = .middle
-                                }
+                                viewModel.mouseButtonHotkey =
+                                    MouseButton(rawValue: AppPreferences.shared.lastMouseButtonHotkey) ?? .middle
                             }
                         }
                     )) {
@@ -2224,9 +2199,9 @@ struct SettingsView: View {
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.warnBorder, lineWidth: 1))
                     }
                 case .keyCombo:
-                    SRow(title: "Shortcut") {
-                        KeyboardShortcuts.Recorder("", name: .toggleRecord)
-                            .frame(width: 150)
+                    SRow(title: "Shortcut", hint: "Click, then press a combination with ⌘, ⌥ or ⌃ — ⌫ clears it") {
+                        ShortcutRecorderField(name: .toggleRecord)
+                            .frame(width: 170)
                     }
                 }
                 SRow(title: "Hold to record", hint: "Hold the shortcut to record, release to stop") {
@@ -2333,323 +2308,6 @@ struct SettingsView: View {
                     .fixedSize()
                 }
             }
-        }
-    }
-
-    private var shortcutSettings: some View {
-        ScrollView {
-            VStack(spacing: 20) {
-                // Recording Trigger
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Recording Trigger")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                    
-                    VStack(alignment: .leading, spacing: 16) {
-                        Picker("", selection: Binding(
-                            get: { useModifierKey },
-                            set: { newValue in
-                                if !newValue {
-                                    viewModel.modifierOnlyHotkey = .none
-                                } else if viewModel.modifierOnlyHotkey == .none {
-                                    viewModel.modifierOnlyHotkey = .leftCommand
-                                }
-                            }
-                        )) {
-                            Text("Key Combination").tag(false)
-                            Text("Single Modifier Key").tag(true)
-                        }
-                        .pickerStyle(.segmented)
-                        
-                        if useModifierKey {
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text("Modifier Key")
-                                        .font(.subheadline)
-                                    Spacer()
-                                    Picker("", selection: $viewModel.modifierOnlyHotkey) {
-                                        ForEach(ModifierKey.allCases.filter { $0 != .none }) { key in
-                                            Text(key.displayName).tag(key)
-                                        }
-                                    }
-                                    .pickerStyle(.menu)
-                                    .frame(width: 200)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 10)
-                                .background(Color(.textBackgroundColor).opacity(0.5))
-                                .cornerRadius(8)
-                                
-                                Text("One-tap to toggle recording")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-
-                                Text("⚠️ This mode requires Input Monitoring permission. macOS requires this to detect single modifier key presses globally. Only modifier key events (⌘, ⌥, ⇧, ⌃, Fn) are monitored — no regular keystrokes are captured.")
-                                    .font(.caption)
-                                    .foregroundColor(.orange)
-                                    .fixedSize(horizontal: false, vertical: true)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.top, 4)
-
-                                Button("Open Input Monitoring Settings…") {
-                                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent") {
-                                        NSWorkspace.shared.open(url)
-                                    }
-                                }
-                                .font(.caption)
-                            }
-                        } else {
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text("Shortcut")
-                                        .font(.subheadline)
-                                    Spacer()
-                                    KeyboardShortcuts.Recorder("", name: .toggleRecord)
-                                        .frame(width: 150)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 10)
-                                .background(Color(.textBackgroundColor).opacity(0.5))
-                                .cornerRadius(8)
-                                
-                                if isRecordingNewShortcut {
-                                    Text("Press your new shortcut combination...")
-                                        .foregroundColor(.secondary)
-                                        .font(.subheadline)
-                                }
-                            }
-                        }
-                    }
-                }
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.controlBackgroundColor).opacity(0.3))
-                .cornerRadius(12)
-                
-                // Recording Behavior
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Recording Behavior")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        SettingRow(
-                            title: "Indicator position",
-                            caption: "Where the recording indicator appears.",
-                            info: "Near cursor (default) shows it just above your text caret. Top, Center or Bottom pin it to the middle of the screen instead."
-                        ) {
-                            HStack(spacing: 8) {
-                                Picker("", selection: $viewModel.indicatorPosition) {
-                                    Text("Near cursor").tag("cursor")
-                                    Text("Notch").tag("notch")
-                                    Text("Top").tag("top")
-                                    Text("Center").tag("center")
-                                    Text("Bottom").tag("bottom")
-                                }
-                                .labelsHidden()
-                                .frame(width: 140)
-                                Button("Preview") {
-                                    IndicatorWindowManager.shared.preview()
-                                }
-                                .controlSize(.small)
-                                .help("Briefly show the indicator at this position")
-                            }
-                        }
-
-                        SettingRow(
-                            title: "Cancel Shortcut",
-                            caption: "Press while recording to discard it.",
-                            info: "Press this key during recording to cancel and discard it without transcribing. Esc is the default; the ⌘/⌥/⌃ combos are there in case Esc conflicts with something else."
-                        ) {
-                            Picker("", selection: $cancelKey) {
-                                ForEach(SettingsView.cancelKeyChoices) { choice in
-                                    Text(choice.label).tag(choice.id)
-                                }
-                            }
-                            .labelsHidden()
-                            .frame(width: 140)
-                            .onChange(of: cancelKey) { _, id in
-                                if let choice = SettingsView.cancelKeyChoices.first(where: { $0.id == id }) {
-                                    KeyboardShortcuts.setShortcut(choice.shortcut, for: .escape)
-                                }
-                            }
-                            .onAppear { cancelKey = SettingsView.currentCancelKeyID() }
-                        }
-
-                        SettingRow(
-                            title: "Show Stop Button on Recording Bar",
-                            caption: "A stop-and-transcribe button on the recording indicator."
-                        ) {
-                            Toggle("", isOn: $viewModel.showStopButtonOnIndicator)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                        }
-
-                        SettingRow(
-                            title: "Show Cancel Button on Recording Bar",
-                            caption: "A discard (trash) button on the recording indicator."
-                        ) {
-                            Toggle("", isOn: $viewModel.showCancelButtonOnIndicator)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                        }
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Hold to Record")
-                                    .font(.subheadline)
-                                Text("Hold the shortcut to record, release to stop")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                            Spacer()
-                            Toggle("", isOn: $viewModel.holdToRecord)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                        }
-                        
-                        HStack {
-                            Text("Play sound when recording starts")
-                                .font(.subheadline)
-                            Spacer()
-                            Toggle("", isOn: $viewModel.playSoundOnRecordStart)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                                .help("Play a notification sound when recording begins")
-                        }
-
-                        SettingRow(
-                            title: "Live transcription",
-                            caption: "Preview your speech in the indicator as you talk (Parakeet only).",
-                            info: "The text appears after a short delay and is a rough live preview — it may differ from the final result. The text that actually gets inserted always comes from the full, accurate transcription, not from this preview."
-                        ) {
-                            Toggle("", isOn: $viewModel.liveTranscriptionEnabled)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                                .disabled(viewModel.selectedEngine != "fluidaudio")
-                                .help("Show the transcription live while recording (Parakeet only)")
-                        }
-                        .opacity(viewModel.selectedEngine == "fluidaudio" ? 1 : 0.5)
-
-                        SettingRow(
-                            title: "Pause media during recording",
-                            caption: "Pause other apps' playback while recording, then resume.",
-                            info: "Pauses the system's active player while recording, then resumes what was playing. If the app can't detect what was playing (unsigned builds), it leaves playback paused — press play to resume. Acts on the system's active player, so it can't independently restore several sources at once."
-                        ) {
-                            Toggle("", isOn: $viewModel.pauseMediaOnRecord)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                                .help("Automatically pause media playback when recording starts")
-                        }
-
-                        SettingRow(
-                            title: "Lower system volume while recording",
-                            caption: "Temporarily reduce the output volume, then restore it."
-                        ) {
-                            Toggle("", isOn: $viewModel.reduceVolumeOnRecord)
-                                .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                                .labelsHidden()
-                                .help("Lower the system output volume while recording, then restore it")
-                        }
-
-                        if viewModel.reduceVolumeOnRecord {
-                            HStack {
-                                Text("Volume while recording")
-                                    .font(.subheadline)
-                                Spacer()
-                                Slider(value: $viewModel.reduceVolumeLevel, in: 0...0.5)
-                                    .frame(width: 160)
-                                Text("\(Int((viewModel.reduceVolumeLevel * 100).rounded()))%")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .frame(width: 44, alignment: .trailing)
-                            }
-                        }
-                    }
-                }
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.controlBackgroundColor).opacity(0.3))
-                .cornerRadius(12)
-
-                // Startup
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Startup")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    SettingRow(
-                        title: "Launch at Login",
-                        caption: "Start OpenSuperWhisper automatically when you log in."
-                    ) {
-                        Toggle("", isOn: Binding(
-                            get: { launchAtLogin.isEnabled },
-                            set: { launchAtLogin.setEnabled($0) }
-                        ))
-                        .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                        .labelsHidden()
-                    }
-
-                    SettingRow(
-                        title: "Start in the Menu Bar",
-                        caption: "Launch without the main window — open it from the menu bar icon.",
-                        info: "Launches straight into the menu bar with no window shown. Open the window anytime from the menu bar icon. Takes effect on next launch."
-                    ) {
-                        Toggle("", isOn: $viewModel.startHidden)
-                            .toggleStyle(SwitchToggleStyle(tint: Color.accentColor))
-                            .labelsHidden()
-                    }
-                }
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.controlBackgroundColor).opacity(0.3))
-                .cornerRadius(12)
-
-                // Interface Language
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Language")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-
-                    SettingRow(
-                        title: "App Language",
-                        caption: "Language of the app interface. Relaunch to apply.",
-                        info: "Overrides your Mac's language for OpenSuperWhisper only. \"System\" follows your Mac's language. This is separate from the transcription language."
-                    ) {
-                        Picker("", selection: $appLanguage) {
-                            Text("System").tag("system")
-                            Text("English").tag("en")
-                            Text("Français").tag("fr")
-                            Text("Deutsch").tag("de")
-                            Text("Español").tag("es")
-                            Text("Italiano").tag("it")
-                            Text("Português (BR)").tag("pt-BR")
-                            Text("Tiếng Việt").tag("vi")
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 150)
-                        .labelsHidden()
-                        .onChange(of: appLanguage) { _, newValue in
-                            LanguageManager.selected = newValue
-                            langNeedsRelaunch = true
-                        }
-                    }
-
-                    if langNeedsRelaunch {
-                        HStack {
-                            Text("Relaunch to apply the new language.")
-                                .font(.caption).foregroundColor(.secondary)
-                            Spacer()
-                            Button("Relaunch Now") { LanguageManager.relaunch() }
-                        }
-                    }
-                }
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.controlBackgroundColor).opacity(0.3))
-                .cornerRadius(12)
-            }
-            .padding()
         }
     }
 }

--- a/OpenSuperWhisper/ShortcutRecorderField.swift
+++ b/OpenSuperWhisper/ShortcutRecorderField.swift
@@ -1,0 +1,176 @@
+import AppKit
+import Carbon.HIToolbox
+import KeyboardShortcuts
+import SwiftUI
+
+/// The combo rule the recorder enforces, kept pure so it's unit-testable.
+/// A shortcut needs at least one of ⌘ ⌥ ⌃ (⇧ alone can't be a global hotkey),
+/// except function keys, which work bare (F5 as a dictation trigger).
+enum RecorderCombo {
+    static let functionKeyCodes: Set<Int> = [
+        kVK_F1, kVK_F2, kVK_F3, kVK_F4, kVK_F5, kVK_F6, kVK_F7, kVK_F8, kVK_F9,
+        kVK_F10, kVK_F11, kVK_F12, kVK_F13, kVK_F14, kVK_F15, kVK_F16, kVK_F17,
+        kVK_F18, kVK_F19, kVK_F20,
+    ]
+
+    static func isValid(modifiers: NSEvent.ModifierFlags, keyCode: Int) -> Bool {
+        !modifiers.intersection([.command, .option, .control]).isEmpty
+            || functionKeyCodes.contains(keyCode)
+    }
+}
+
+/// Atelier-styled shortcut recorder replacing `KeyboardShortcuts.Recorder`,
+/// which renders as a bare search field and gives no feedback while keys are
+/// held. Click to arm, and the ⌃ ⌥ ⇧ ⌘ badges light up live as modifiers are
+/// pressed; a valid combo is saved through `KeyboardShortcuts.setShortcut`, so
+/// the Carbon hotkey engine underneath is unchanged. Esc cancels, ⌫ clears,
+/// clicking anywhere else disarms.
+struct ShortcutRecorderField: View {
+    let name: KeyboardShortcuts.Name
+
+    @State private var shortcut: KeyboardShortcuts.Shortcut?
+    @State private var isRecording = false
+    @State private var heldModifiers: NSEvent.ModifierFlags = []
+    @State private var invalidCombo = false
+    @State private var isHovering = false
+    @State private var monitors: [Any] = []
+
+    private static let badges: [(flag: NSEvent.ModifierFlags, symbol: String)] = [
+        (.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘"),
+    ]
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if isRecording {
+                recordingBody
+            } else {
+                idleBody
+            }
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 26)
+        .background(RoundedRectangle(cornerRadius: 7).fill(isRecording ? STheme.accentSoft : STheme.inputBg))
+        .overlay(RoundedRectangle(cornerRadius: 7)
+            .stroke(invalidCombo ? STheme.warn : (isRecording ? STheme.accent : STheme.controlBorder), lineWidth: 1))
+        .contentShape(RoundedRectangle(cornerRadius: 7))
+        .onTapGesture { if isRecording { disarm() } else { arm() } }
+        .onHover { isHovering = $0 }
+        .onAppear { shortcut = KeyboardShortcuts.getShortcut(for: name) }
+        .onDisappear { disarm() }
+        .animation(.easeOut(duration: 0.12), value: heldModifiers.rawValue)
+        .animation(.easeOut(duration: 0.12), value: isRecording)
+    }
+
+    private var idleBody: some View {
+        HStack(spacing: 6) {
+            if let shortcut {
+                Text(shortcut.description)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(STheme.textBright)
+                Spacer(minLength: 0)
+                if isHovering {
+                    Button {
+                        KeyboardShortcuts.setShortcut(nil, for: name)
+                        self.shortcut = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 11))
+                            .foregroundColor(STheme.hint)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Clear shortcut")
+                }
+            } else {
+                Text("Click to record")
+                    .font(.system(size: 11))
+                    .foregroundColor(STheme.hint)
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var recordingBody: some View {
+        HStack(spacing: 4) {
+            ForEach(Self.badges, id: \.symbol) { badge in
+                let held = heldModifiers.contains(badge.flag)
+                Text(badge.symbol)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(held ? .white : STheme.hint)
+                    .frame(width: 18, height: 18)
+                    .background(RoundedRectangle(cornerRadius: 4).fill(held ? STheme.accent : STheme.controlBg))
+            }
+            Text(invalidCombo ? "add ⌘ ⌥ or ⌃" : "key…")
+                .font(.system(size: 11))
+                .foregroundColor(invalidCombo ? STheme.warn : STheme.hint)
+                .padding(.leading, 2)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func arm() {
+        guard !isRecording else { return }
+        isRecording = true
+        heldModifiers = []
+        invalidCombo = false
+        // Pause the live hotkey so re-recording the current combo doesn't
+        // toggle a dictation mid-capture.
+        KeyboardShortcuts.isEnabled = false
+
+        monitors.append(NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+            heldModifiers = event.modifierFlags.intersection([.control, .option, .shift, .command])
+            if invalidCombo, !heldModifiers.intersection([.command, .option, .control]).isEmpty {
+                invalidCombo = false
+            }
+            return event
+        }!)
+
+        monitors.append(NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+                .subtracting(.function)
+            if modifiers.isEmpty {
+                switch Int(event.keyCode) {
+                case kVK_Escape:
+                    disarm()
+                    return nil
+                case kVK_Delete, kVK_ForwardDelete:
+                    KeyboardShortcuts.setShortcut(nil, for: name)
+                    shortcut = nil
+                    disarm()
+                    return nil
+                case kVK_Tab:
+                    disarm()
+                    return event
+                default:
+                    break
+                }
+            }
+            guard RecorderCombo.isValid(modifiers: modifiers, keyCode: Int(event.keyCode)),
+                  let captured = KeyboardShortcuts.Shortcut(event: event)
+            else {
+                NSSound.beep()
+                invalidCombo = true
+                return nil
+            }
+            KeyboardShortcuts.setShortcut(captured, for: name)
+            shortcut = captured
+            disarm()
+            return nil
+        }!)
+
+        // A click outside the field disarms; a click on it is handled by the
+        // tap gesture (toggle), so only forward those.
+        monitors.append(NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { event in
+            if !isHovering { disarm() }
+            return event
+        }!)
+    }
+
+    private func disarm() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors = []
+        KeyboardShortcuts.isEnabled = true
+        isRecording = false
+        heldModifiers = []
+        invalidCombo = false
+    }
+}

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -265,6 +265,15 @@ final class AppPreferences {
     @UserDefault(key: "mouseButtonHotkey", defaultValue: "none")
     var mouseButtonHotkey: String
 
+    // The trigger modes are mutually exclusive, so switching modes clears the
+    // other two prefs. These remember each mode's last choice so switching
+    // back restores it instead of the hardcoded default.
+    @UserDefault(key: "lastModifierOnlyHotkey", defaultValue: "leftCommand")
+    var lastModifierOnlyHotkey: String
+
+    @UserDefault(key: "lastMouseButtonHotkey", defaultValue: "middle")
+    var lastMouseButtonHotkey: String
+
     // When false (default), pressing Esc to cancel a recording longer than
     // ~10s first asks for confirmation (press Esc again) instead of discarding
     // it outright — a safety net against an accidental Esc losing a long dictation.

--- a/OpenSuperWhisperTests/RecorderComboTests.swift
+++ b/OpenSuperWhisperTests/RecorderComboTests.swift
@@ -1,0 +1,24 @@
+import AppKit
+import Carbon.HIToolbox
+import XCTest
+
+@testable import OpenSuperWhisper
+
+final class RecorderComboTests: XCTestCase {
+    func testRequiresCommandOptionOrControl() {
+        XCTAssertTrue(RecorderCombo.isValid(modifiers: [.command], keyCode: kVK_ANSI_A))
+        XCTAssertTrue(RecorderCombo.isValid(modifiers: [.option, .shift], keyCode: kVK_ANSI_A))
+        XCTAssertTrue(RecorderCombo.isValid(modifiers: [.control], keyCode: kVK_Space))
+        XCTAssertFalse(RecorderCombo.isValid(modifiers: [], keyCode: kVK_ANSI_A))
+    }
+
+    func testShiftAloneIsRejected() {
+        XCTAssertFalse(RecorderCombo.isValid(modifiers: [.shift], keyCode: kVK_ANSI_A))
+    }
+
+    func testBareFunctionKeysAllowed() {
+        XCTAssertTrue(RecorderCombo.isValid(modifiers: [], keyCode: kVK_F5))
+        XCTAssertTrue(RecorderCombo.isValid(modifiers: [.shift], keyCode: kVK_F13))
+        XCTAssertFalse(RecorderCombo.isValid(modifiers: [], keyCode: kVK_Escape))
+    }
+}


### PR DESCRIPTION
Le recorder « Key Combination » était le `KeyboardShortcuts.Recorder` brut — rendu champ de recherche, aucun feedback pendant la frappe.

## Nouveau : `ShortcutRecorderField`
- Clic pour armer → les badges **⌃ ⌥ ⇧ ⌘ s'allument en live** pendant que les modificateurs sont tenus
- Combo valide (au moins ⌘/⌥/⌃, ou touche F nue) → sauvegardée via `KeyboardShortcuts.setShortcut` — **le moteur Carbon dessous ne change pas**
- Esc annule, ⌫ efface, clic ailleurs désarme ; combo invalide → beep + hint « add ⌘ ⌥ or ⌃ »
- Style Atelier (STheme), règle de validation extraite en `RecorderCombo.isValid` + tests

## Fix : mémoire des modes de trigger
Passer de « Single Modifier Key » à « Key Combination » perdait la touche configurée (retour = Left Command imposé). Le dernier choix de chaque mode (modifier + mouse button) est mémorisé dans `AppPreferences` et restauré au switch.

## Ménage
Suppression de la vue legacy `shortcutSettings` (~360 lignes, plus référencée depuis le redesign Atelier) et de ses helpers orphelins — dont le second call site du Recorder stock.

## Testing
- `./run.sh build` vert, suite `OpenSuperWhisperTests` verte (dont 3 nouveaux `RecorderComboTests`)
- À tester à la main : armement/désarmement, badges live, Esc/⌫, round-trip des modes

Closes rien — demande directe de @MaximCosta en session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkpL2i9dvfnKjbBevJfkxa