### PR TITLE
chore(whisper): bump whisper.cpp to v1.9.1 + Metal rsets teardown fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libwhisper/whisper.cpp"]
 	path = libwhisper/whisper.cpp
-	url = https://github.com/ggerganov/whisper.cpp
+	url = https://github.com/my-monkeys/whisper.cpp
 [submodule "asian-autocorrect"]
 	path = asian-autocorrect
 	url = https://github.com/huacnlee/autocorrect


### PR DESCRIPTION
Matérialise le « split du bump » demandé dans la review de #57, avec le crash #56 corrigé d'entrée. Closes #56.

## Quoi
- Submodule `libwhisper/whisper.cpp` : `f3ff80ea` (juin 2025) → **`my-monkeys/whisper.cpp` branche `osw/v1.9.1-rsets-teardown-fix`** = tag **v1.9.1** + cherry-pick de [ggml-org/whisper.cpp#3870](https://github.com/ggml-org/whisper.cpp/pull/3870) (`4d3ed9d8`, +23/−3 sur `ggml-metal-device.m`).
- Aucun changement de glue nécessaire (`libwhisper/CMakeLists.txt` intact, régénéré par `run.sh`).

## Pourquoi un fork
Le fix n'existe **nulle part upstream** : llama.cpp #22593 a été fermé par le stale-bot (pas mergé), whisper.cpp #3870 est ouverte non mergée, et v1.9.1 reste la dernière release (analyse corrigée dans #56). Le fork = v1.9.1 + 1 commit ; si #3870 merge un jour, on reconverge sur la release suivante.

## Validation (locale, Apple Silicon, macOS 26)
| Vérification | Résultat |
|---|---|
| `./run.sh build` avec le nouveau submodule | ✅ vert |
| Suite `OpenSuperWhisperTests` | ✅ verte |
| `whisper-cli` + large-v3-turbo (jfk.wav), lifecycle propre | ✅ transcription OK, exit 0 (bare **et** patché) |
| **Repro #56** : contexte whisper vivant à l'exit du process, large-v3-turbo | bare v1.9.1 → **abort exit 134**, `ggml-metal-device.m:622: GGML_ASSERT([rsets->data count] == 0) failed` (mot pour mot l'assert de #56) · patché → **exit 0** |

## Non couvert (assumé)
La dérive qualité/perf de ~1 an d'upstream n'est pas benchée ici — le bench FLEURS/TRIAGE de #57 reste la référence pour ça ; ce split lui donne une base saine à rebaser. Chemins app (`unloadWhisperModelWhenIdle`, switch de modèle) : `whisper_free` explicite était déjà sain en v1.9.1 (`rsets_rm` appelé au buffer free) ; le crash ne concernait que les contextes encore vivants à l'exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkpL2i9dvfnKjbBevJfkxa