### PR TITLE
feat(shortcuts): re-paste the last transcription on demand

### DIFF
--- a/OpenSuperWhisper/DictationPipeline.swift
+++ b/OpenSuperWhisper/DictationPipeline.swift
@@ -269,47 +269,11 @@ final class DictationPipeline: ObservableObject {
     }
 
     /// Returns `true` when auto-paste ran but no editable field was focused, so the caller can leave
-    /// the text on the clipboard and notify ⌘V. When no target is found, typing is skipped. Moved
-    /// here from the indicator view model; behaviour matches master incl. the #45 clipboard restore.
+    /// the text on the clipboard and notify ⌘V. When no target is found, typing is skipped. The
+    /// insertion policy itself lives in `TranscriptInserter`, shared with the re-paste shortcut.
     @discardableResult
     private func insertText(_ text: String) -> Bool {
-        let finalText = IndicatorViewModel.applyPostProcessing(text)
-        let prefs = AppPreferences.shared
-
-        // Optional, independent clipboard stash (never the insertion mechanism).
-        if prefs.autoCopyToClipboard {
-            ClipboardUtil.copyToClipboard(finalText)
-        }
-
-        guard prefs.autoPasteTranscription else { return false }
-
-        if prefs.pasteInsteadOfTyping {
-            // Paste is universal: ⌘V lands in any text field, including apps the accessibility check
-            // can't read (Messages, Electron), and is a harmless no-op otherwise. So no editable-
-            // target gate — it only ever produces false negatives (#paste-messages).
-            if prefs.autoCopyToClipboard {
-                Diag.measure("TextInserter.paste") { TextInserter.paste() }
-            } else {
-                // The clipboard is only the paste vehicle here — the user opted out of keeping the
-                // text on it (#44) — so put the previous contents back after the ⌘V lands.
-                ClipboardUtil.borrowForPaste(finalText) {
-                    Diag.measure("TextInserter.paste") { TextInserter.paste() }
-                }
-            }
-            return false
-        }
-
-        // Typing mode: synthetic keystrokes go wherever focus is, so only type when we're confident
-        // there's an editable target; otherwise stash on the clipboard and notify ⌘V.
-        let targetMissing = prefs.notifyWhenNoPasteTarget
-            && Diag.measure("focusedElementIsEditable") { FocusUtils.focusedElementIsEditable() } == false
-        if targetMissing {
-            if !prefs.autoCopyToClipboard {
-                ClipboardUtil.copyToClipboard(finalText)
-            }
-            return true
-        }
-        Diag.measure("TextInserter.type") { TextInserter.type(finalText) }
-        return false
+        TranscriptInserter.insert(IndicatorViewModel.applyPostProcessing(text),
+                                  honorAutoPastePreference: true)
     }
 }

--- a/OpenSuperWhisper/PasteLastTranscript.swift
+++ b/OpenSuperWhisper/PasteLastTranscript.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Foundation
+
+/// Re-inserts the most recent transcription into the focused app on demand.
+///
+/// Dictation inserts once, wherever the caret happened to be. This puts the same text somewhere
+/// else — a second field, a chat window, a commit message — without re-recording it, and without
+/// requiring the transcription to still be on the clipboard. That matters for anyone who leaves
+/// "Copy to clipboard" off precisely so dictation stops trampling what they had copied: they lose
+/// the text the moment it is inserted, and re-dictating is the only way to get it back.
+///
+/// Unbound by default; a shortcut is assigned in Settings > Shortcuts.
+enum PasteLastTranscript {
+
+    /// How many recent recordings are scanned for a re-pastable transcription. Only failed,
+    /// in-flight and empty clips are skipped, so the newest usable one is nearly always within
+    /// the first few rows.
+    static let scanDepth = 20
+
+    /// The newest transcription worth pasting, or `nil` when there isn't one yet.
+    ///
+    /// Skips clips that failed (their `transcription` holds the retry placeholder), clips still
+    /// being transcribed (partial or empty text), and ones that produced nothing. Ordering is
+    /// computed here rather than trusted from the caller, so a change in how the store sorts
+    /// can't silently start pasting an old transcription.
+    static func pick(from recordings: [Recording]) -> String? {
+        recordings
+            .filter { $0.status == .completed && !$0.transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .max { $0.timestamp < $1.timestamp }?
+            .transcription
+    }
+
+    /// Handles one press of the shortcut: find the last transcription and insert it.
+    @MainActor
+    static func run() async {
+        let recordings: [Recording]
+        do {
+            recordings = try await RecordingStore.shared.fetchRecordings(limit: scanDepth, offset: 0)
+        } catch {
+            print("Paste last transcription: failed to read recordings: \(error)")
+            IndicatorWindowManager.shared.flash(.error("Couldn't read transcriptions"))
+            return
+        }
+
+        guard let text = pick(from: recordings) else {
+            IndicatorWindowManager.shared.flash(.info("No transcription to paste yet"))
+            return
+        }
+
+        await waitForModifiersToClear()
+
+        // `honorAutoPastePreference: false` — pressing the shortcut *is* the request to insert, so
+        // a user who dictates to the clipboard only still gets text where the cursor is.
+        let targetMissing = TranscriptInserter.insert(IndicatorViewModel.applyPostProcessing(text),
+                                                      honorAutoPastePreference: false)
+        if targetMissing {
+            IndicatorWindowManager.shared.flash(.info("Copied — press ⌘V"))
+        }
+    }
+
+    /// Waits (briefly) for the shortcut's own modifiers to come back up.
+    ///
+    /// The insertion is a synthetic ⌘V, and macOS merges the physically-held modifiers into it.
+    /// Fire while ⌃⌘ is still down and the frontmost app sees ⌃⌘V — not a paste — so the text
+    /// silently fails to appear. Typing mode is just as exposed: held modifiers turn the
+    /// keystrokes into shortcuts.
+    @MainActor
+    static func waitForModifiersToClear(timeout: TimeInterval = 1.0,
+                                        pollInterval: TimeInterval = 0.02) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while modifiersAreHeld(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+    }
+
+    @MainActor
+    private static func modifiersAreHeld() -> Bool {
+        !NSEvent.modifierFlags.intersection([.command, .control, .option, .shift]).isEmpty
+    }
+}

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2207,6 +2207,11 @@ struct SettingsView: View {
                 SRow(title: "Hold to record", hint: "Hold the shortcut to record, release to stop") {
                     SToggle(isOn: $viewModel.holdToRecord)
                 }
+                SRow(title: "Paste last transcription",
+                     hint: "Inserts your most recent transcription again, wherever the cursor is. Unbound by default — ⌫ clears it") {
+                    ShortcutRecorderField(name: .pasteLastTranscription)
+                        .frame(width: 170)
+                }
                 SRow(title: "Cancel shortcut") {
                     Picker("", selection: $cancelKey) {
                         ForEach(SettingsView.cancelKeyChoices) { choice in

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -9,6 +9,10 @@ import SwiftUI
 extension KeyboardShortcuts.Name {
     static let toggleRecord = Self("toggleRecord", default: .init(.backtick, modifiers: .option))
     static let escape = Self("escape", default: .init(.escape))
+    /// Re-pastes the last transcription. Deliberately unbound by default — it is opt-in, and
+    /// claiming a global combination for every user isn't ours to do. ⌃⌘V is a natural pick: it
+    /// sits next to ⌘V without colliding with it or with paste-and-match-style (⌥⇧⌘V).
+    static let pasteLastTranscription = Self("pasteLastTranscription")
 }
 
 class ShortcutManager {
@@ -66,6 +70,15 @@ class ShortcutManager {
 
         KeyboardShortcuts.onKeyUp(for: .toggleRecord) { [weak self] in
             self?.handleKeyUp()
+        }
+
+        // On key-UP: the handler waits for the modifiers to lift before synthesizing ⌘V, and
+        // starting that wait only once the key is released keeps a held-down shortcut from
+        // firing repeatedly.
+        KeyboardShortcuts.onKeyUp(for: .pasteLastTranscription) {
+            Task { @MainActor in
+                await PasteLastTranscript.run()
+            }
         }
 
         KeyboardShortcuts.onKeyUp(for: .escape) { [weak self] in

--- a/OpenSuperWhisper/Utils/ClipboardUtil.swift
+++ b/OpenSuperWhisper/Utils/ClipboardUtil.swift
@@ -44,23 +44,43 @@ enum ClipboardUtil {
     /// adds margin, and being generous costs nothing now that the wait no longer blocks a thread).
     static let borrowRestoreDelay: TimeInterval = 1.0
 
+    /// Borrows whose restore hasn't fired yet, keyed by pasteboard name. A borrow that lands while
+    /// another is still pending must NOT snapshot — the pasteboard currently holds the previous
+    /// borrow's transcription, and restoring that later would overwrite the user's contents with
+    /// dictated text, the very thing "Copy to clipboard" off exists to prevent. Instead it inherits
+    /// the pending borrow's snapshot and cancels its timer, so any number of overlapping borrows
+    /// collapse into a single restore of the original contents. Main-thread only, like every
+    /// caller (the restore timers are on the main queue too, so there is no interleaving).
+    private static var pendingBorrows: [NSPasteboard.Name: (saved: Snapshot, restore: DispatchWorkItem)] = [:]
+
     /// Puts `text` on the pasteboard just long enough for `paste` (a synthetic ⌘V) to be serviced,
     /// then restores the previous contents — for when the user opted out of keeping transcriptions
     /// on the clipboard and it's only borrowed as the paste vehicle (#44). The restore is skipped
     /// if anything else writes to the pasteboard within the delay (a user copy, a clipboard
-    /// manager): newer content wins over our restore.
+    /// manager): newer content wins over our restore. Overlapping borrows — a dictation insert
+    /// followed within the delay by the paste-last shortcut — coalesce onto the first borrow's
+    /// snapshot, so the user's clipboard comes back no matter how many borrows stacked up.
     static func borrowForPaste(_ text: String,
                                on pasteboard: NSPasteboard = .general,
                                restoreAfter delay: TimeInterval = borrowRestoreDelay,
                                paste: () -> Void) {
-        let saved = snapshot(of: pasteboard)
+        let saved: Snapshot
+        if let pending = pendingBorrows[pasteboard.name] {
+            pending.restore.cancel()
+            saved = pending.saved
+        } else {
+            saved = snapshot(of: pasteboard)
+        }
         copyToClipboard(text, to: pasteboard)
         let borrowChangeCount = pasteboard.changeCount
         paste()
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+        let restoreItem = DispatchWorkItem {
+            pendingBorrows[pasteboard.name] = nil
             guard pasteboard.changeCount == borrowChangeCount else { return }
             restore(saved, to: pasteboard)
         }
+        pendingBorrows[pasteboard.name] = (saved, restoreItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: restoreItem)
     }
 
     // MARK: - Input source helpers (used by keyboard-layout tests)

--- a/OpenSuperWhisper/Utils/TranscriptInserter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptInserter.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The single place that decides *how* a finished transcription reaches the focused app:
+/// clipboard stash, paste-vs-type, and the no-editable-target fallback.
+///
+/// Shared by the automatic insertion at the end of a dictation (`DictationPipeline`) and by any
+/// explicit, user-triggered insertion, so the two can't drift apart.
+enum TranscriptInserter {
+
+    /// Inserts `text` into the focused app.
+    ///
+    /// - Parameters:
+    ///   - text: Post-processed transcription, ready to insert.
+    ///   - honorAutoPastePreference: `true` for automatic insertion after a dictation, where the
+    ///     "Auto-paste transcription" preference decides whether anything is inserted at all.
+    ///     `false` when the user explicitly asked for this insertion — the request itself is the
+    ///     intent, so a clipboard-only workflow still gets text where the cursor is.
+    /// - Returns: `true` when insertion was skipped because no editable field was focused, so the
+    ///   caller can leave the text on the clipboard and notify ⌘V.
+    @MainActor
+    @discardableResult
+    static func insert(_ text: String, honorAutoPastePreference: Bool) -> Bool {
+        let prefs = AppPreferences.shared
+
+        // Optional, independent clipboard stash (never the insertion mechanism).
+        if prefs.autoCopyToClipboard {
+            ClipboardUtil.copyToClipboard(text)
+        }
+
+        guard prefs.autoPasteTranscription || !honorAutoPastePreference else { return false }
+
+        if prefs.pasteInsteadOfTyping {
+            // Paste is universal: ⌘V lands in any text field, including apps the accessibility check
+            // can't read (Messages, Electron), and is a harmless no-op otherwise. So no editable-
+            // target gate — it only ever produces false negatives (#paste-messages).
+            if prefs.autoCopyToClipboard {
+                Diag.measure("TextInserter.paste") { TextInserter.paste() }
+            } else {
+                // The clipboard is only the paste vehicle here — the user opted out of keeping the
+                // text on it (#44) — so put the previous contents back after the ⌘V lands.
+                ClipboardUtil.borrowForPaste(text) {
+                    Diag.measure("TextInserter.paste") { TextInserter.paste() }
+                }
+            }
+            return false
+        }
+
+        // Typing mode: synthetic keystrokes go wherever focus is, so only type when we're confident
+        // there's an editable target; otherwise stash on the clipboard and notify ⌘V.
+        let targetMissing = prefs.notifyWhenNoPasteTarget
+            && Diag.measure("focusedElementIsEditable") { FocusUtils.focusedElementIsEditable() } == false
+        if targetMissing {
+            if !prefs.autoCopyToClipboard {
+                ClipboardUtil.copyToClipboard(text)
+            }
+            return true
+        }
+        Diag.measure("TextInserter.type") { TextInserter.type(text) }
+        return false
+    }
+}

--- a/OpenSuperWhisperTests/ClipboardRestoreTests.swift
+++ b/OpenSuperWhisperTests/ClipboardRestoreTests.swift
@@ -96,4 +96,88 @@ final class ClipboardRestoreTests: XCTestCase {
         wait(for: [restoreWindowElapsed], timeout: 2)
         XCTAssertEqual(pasteboard.string(forType: .string), "user copy in between")
     }
+
+    // MARK: - Overlapping borrows (#69 review)
+
+    func testOverlappingBorrowsRestoreTheOriginalContents() {
+        // Dictation borrows the clipboard, and before its restore fires the user re-pastes
+        // (or a second dictation lands). The second borrow must NOT snapshot the first borrow's
+        // transcription — it inherits the original snapshot, and the one surviving restore
+        // brings back the user's contents.
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        ClipboardUtil.borrowForPaste("transcription A", on: pasteboard, restoreAfter: 0.05) {}
+        ClipboardUtil.borrowForPaste("transcription B", on: pasteboard, restoreAfter: 0.05) {}
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original",
+                       "the second borrow must not end up restoring the first borrow's text")
+    }
+
+    func testManyOverlappingBorrowsStillRestoreTheOriginal() {
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        for n in 1...4 {
+            ClipboardUtil.borrowForPaste("transcription \(n)", on: pasteboard, restoreAfter: 0.05) {}
+        }
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original")
+    }
+
+    func testUserCopyAfterOverlappingBorrowsStillWins() {
+        // Newer content beats our restore even when borrows have coalesced.
+        ClipboardUtil.copyToClipboard("original", to: pasteboard)
+
+        ClipboardUtil.borrowForPaste("transcription A", on: pasteboard, restoreAfter: 0.05) {}
+        ClipboardUtil.borrowForPaste("transcription B", on: pasteboard, restoreAfter: 0.05) {}
+        ClipboardUtil.copyToClipboard("user copy in between", to: pasteboard)
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "user copy in between")
+    }
+
+    func testSequentialBorrowsDoNotInheritAStaleSnapshot() {
+        // Once a borrow's restore has fired, the next borrow is a fresh cycle: it must snapshot
+        // whatever is on the pasteboard NOW, not resurrect the coalescing state of the last one.
+        ClipboardUtil.copyToClipboard("first original", to: pasteboard)
+        ClipboardUtil.borrowForPaste("transcription A", on: pasteboard, restoreAfter: 0.05) {}
+
+        let firstRestoreDone = expectation(description: "first restore done")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { firstRestoreDone.fulfill() }
+        wait(for: [firstRestoreDone], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "first original")
+
+        ClipboardUtil.copyToClipboard("second original", to: pasteboard)
+        ClipboardUtil.borrowForPaste("transcription B", on: pasteboard, restoreAfter: 0.05) {}
+
+        let secondRestoreDone = expectation(description: "second restore done")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { secondRestoreDone.fulfill() }
+        wait(for: [secondRestoreDone], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "second original")
+    }
+
+    func testBorrowsOnDistinctPasteboardsDoNotShareSnapshots() {
+        // Coalescing is per pasteboard: a pending borrow on one must not donate its snapshot
+        // to a borrow on another.
+        let other = NSPasteboard(name: NSPasteboard.Name("OpenSuperWhisperTests." + UUID().uuidString))
+        defer { other.releaseGlobally() }
+        ClipboardUtil.copyToClipboard("original A", to: pasteboard)
+        ClipboardUtil.copyToClipboard("original B", to: other)
+
+        ClipboardUtil.borrowForPaste("transcription", on: pasteboard, restoreAfter: 0.05) {}
+        ClipboardUtil.borrowForPaste("transcription", on: other, restoreAfter: 0.05) {}
+
+        let restoreWindowElapsed = expectation(description: "restore window elapsed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { restoreWindowElapsed.fulfill() }
+        wait(for: [restoreWindowElapsed], timeout: 2)
+        XCTAssertEqual(pasteboard.string(forType: .string), "original A")
+        XCTAssertEqual(other.string(forType: .string), "original B")
+    }
 }

--- a/OpenSuperWhisperTests/PasteLastTranscriptTests.swift
+++ b/OpenSuperWhisperTests/PasteLastTranscriptTests.swift
@@ -1,0 +1,104 @@
+import KeyboardShortcuts
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Covers which stored recording the "paste last transcription" shortcut re-pastes: the newest
+/// one that actually produced text. Failed clips (whose `transcription` holds the retry
+/// placeholder), clips still being transcribed, and empty results must all be skipped, or the
+/// shortcut pastes a placeholder — or nothing — instead of the user's last dictation.
+///
+/// The insertion itself isn't covered here: it synthesizes real keystrokes into whatever app has
+/// focus, which a unit test has no business doing. It goes through `TranscriptInserter`, the same
+/// path the end-of-dictation insertion uses.
+final class PasteLastTranscriptTests: XCTestCase {
+
+    private func makeRecording(_ transcription: String,
+                               status: RecordingStatus = .completed,
+                               secondsAgo: TimeInterval) -> Recording {
+        Recording(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000_000 - secondsAgo),
+            fileName: "\(UUID().uuidString).wav",
+            transcription: transcription,
+            duration: 1,
+            status: status,
+            progress: 1,
+            sourceFileURL: nil
+        )
+    }
+
+    func testPicksTheNewestCompletedTranscription() {
+        let text = PasteLastTranscript.pick(from: [
+            makeRecording("newest", secondsAgo: 0),
+            makeRecording("older", secondsAgo: 60),
+        ])
+
+        XCTAssertEqual(text, "newest")
+    }
+
+    func testOrdersByTimestampNotArrayPosition() {
+        // The store hands them over newest-first, but nothing in the type enforces that.
+        let text = PasteLastTranscript.pick(from: [
+            makeRecording("older", secondsAgo: 60),
+            makeRecording("newest", secondsAgo: 0),
+        ])
+
+        XCTAssertEqual(text, "newest")
+    }
+
+    func testSkipsFailedRecordings() {
+        // A failed clip stores the retry placeholder as its transcription — pasting that would
+        // drop "Transcription failed — click ↻ to try again." into the user's document.
+        let text = PasteLastTranscript.pick(from: [
+            makeRecording("Transcription failed — click ↻ to try again.", status: .failed, secondsAgo: 0),
+            makeRecording("real transcription", secondsAgo: 60),
+        ])
+
+        XCTAssertEqual(text, "real transcription")
+    }
+
+    func testSkipsRecordingsStillInFlight() {
+        for status in [RecordingStatus.pending, .converting, .transcribing] {
+            let text = PasteLastTranscript.pick(from: [
+                makeRecording("partial…", status: status, secondsAgo: 0),
+                makeRecording("finished", secondsAgo: 60),
+            ])
+
+            XCTAssertEqual(text, "finished", "status \(status.rawValue) should be skipped")
+        }
+    }
+
+    func testSkipsBlankTranscriptions() {
+        let text = PasteLastTranscript.pick(from: [
+            makeRecording("   \n ", secondsAgo: 0),
+            makeRecording("", secondsAgo: 30),
+            makeRecording("finished", secondsAgo: 60),
+        ])
+
+        XCTAssertEqual(text, "finished")
+    }
+
+    func testReturnsNilWhenNothingIsPastable() {
+        XCTAssertNil(PasteLastTranscript.pick(from: []))
+        XCTAssertNil(PasteLastTranscript.pick(from: [
+            makeRecording("nope", status: .failed, secondsAgo: 0),
+            makeRecording("  ", secondsAgo: 60),
+        ]))
+    }
+
+    func testKeepsTheStoredTextVerbatim() {
+        // Leading/trailing whitespace only decides whether a clip counts as blank; the text that
+        // gets pasted is whatever was stored, so post-processing sees exactly what it saw the
+        // first time round.
+        let text = PasteLastTranscript.pick(from: [makeRecording(" hello there ", secondsAgo: 0)])
+
+        XCTAssertEqual(text, " hello there ")
+    }
+
+    func testShortcutIsUnboundByDefault() {
+        // Opt-in: the feature must not claim a global combination on upgrade. Users assign one in
+        // Settings > Shortcuts.
+        XCTAssertNil(KeyboardShortcuts.Name.pasteLastTranscription.defaultShortcut)
+    }
+}


### PR DESCRIPTION
## What

An optional shortcut that re-inserts the most recent transcription wherever the cursor is now, without re-recording it.

Unbound by default; you assign a combination in **Settings > Shortcuts > Paste last transcription**.

## Why

Dictation inserts once, at whatever caret was focused when it finished. If you want that text somewhere else too, the only options today are copying it out of the history window or dictating it again.

That bites hardest with **Copy to clipboard off** — which people turn off precisely so dictation stops trampling what they had copied (#44). With it off, the transcription exists only at the point it was inserted. Re-dictating a long prompt because you put it in the wrong field is a bad trade.

Sourcing the text from the recordings store rather than the clipboard means it works regardless of clipboard settings, and still works after a relaunch.

## Behaviour

- Picks the newest recording that actually produced text. Clips that **failed** are skipped, because their `transcription` field holds the retry placeholder and pasting `Transcription failed — click ↻ to try again.` into someone's document would be a poor showing. Clips still transcribing and empty results are skipped for the same reason.
- Honours **Paste instead of typing** and **Copy to clipboard**, including the borrow-and-restore path from #44.
- Does *not* honour **Auto-paste transcription**. Pressing the shortcut is itself the request to insert, so a clipboard-only workflow still gets text where the cursor is. This is the one deliberate asymmetry with the automatic path, and it's the whole point of the feature.
- Waits for modifiers to lift before synthesizing ⌘V. macOS merges physically-held modifiers into the synthetic event, so firing while e.g. ⌃⌘ is still down makes the frontmost app see ⌃⌘V and paste nothing. Typing mode is equally exposed — held modifiers turn keystrokes into shortcuts.

## Refactor included

The insertion policy (clipboard stash, paste-vs-type, no-editable-target fallback) moves out of `DictationPipeline.insertText` into a new `TranscriptInserter`, so both callers share one implementation rather than drifting apart. The end-of-dictation path is unchanged — the new flag only controls whether **Auto-paste transcription** gates insertion. I'd rather not have duplicated a 30-line policy in a second place.

## Why unbound by default

Claiming a global combination for every user on upgrade isn't a contributor's call to make, and it risks colliding with whatever they already use. ⌃⌘V is my own suggestion for a default if you'd prefer one: it sits next to ⌘V and collides with neither ⌘V nor paste-and-match-style (⌥⇧⌘V). Happy to set it if you want the feature discoverable without a settings trip.

## Tests

8 tests over the selection logic — newest-wins, ordering computed rather than trusted from the caller, failed/in-flight/blank skipping, and the unbound-by-default guarantee.

The insertion itself synthesizes real keystrokes into whatever app has focus, so it is deliberately not unit-tested. It goes through `TranscriptInserter`, the same path the end-of-dictation insertion uses.

Full suite passes locally (222 tests, Xcode 26.4.1, macOS 26).

## Notes

- The two user-facing strings go through `Text(...)`/`flash(...)` like the existing `showError`/`showInfo` call sites, so they're unlocalized in the same way the surrounding code is. Happy to route them through the catalog if you'd like that tightened up here rather than repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
