### PR TITLE
fix: Apple model install state (#46), System Default microphone (#60), input level meter (#47)

### DIFF
--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -164,16 +164,21 @@ struct AppleSpeechModelSection: View {
     /// canonical) with the asset status. "mul" is the framework's multilingual pseudo
     /// entry — not a language anyone dictates in.
     private func refreshLanguages() async {
+        // Ask what is on this Mac, not what is allocated to this app. `AssetInventory.status`
+        // answers the second question: macOS reserves at most 5 locales per app, and a language
+        // whose assets are installed system-wide but not currently reserved here comes back
+        // `.supported`, not `.installed`. That rendered a Download button for models that were
+        // already present, and pressing it "downloaded" them instantly because
+        // `assetInstallationRequest` had nothing to fetch and returned nil (#46).
+        let installedLocales = await SpeechTranscriber.installedLocales
         var rows: [LangAsset] = []
         for code in AppleSpeechSupport.cachedSupportedLanguages where code != "mul" {
             let locale = await AppleSpeechSupport.resolveLocale(language: code)
-            let transcriber = SpeechTranscriber(locale: locale, preset: .transcription)
-            let status = await AssetInventory.status(forModules: [transcriber])
             rows.append(LangAsset(
                 code: code,
                 localeID: locale.identifier,
                 name: Locale.current.localizedString(forIdentifier: locale.identifier) ?? locale.identifier,
-                installed: status == .installed))
+                installed: LanguageUtil.isInstalled(locale, in: installedLocales)))
         }
         languages = rows.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }

--- a/OpenSuperWhisper/AudioRecorder.swift
+++ b/OpenSuperWhisper/AudioRecorder.swift
@@ -10,6 +10,11 @@ class AudioRecorder: NSObject, ObservableObject {
     @Published var currentlyPlayingURL: URL?
     @Published var canRecord = false
     @Published var isConnecting = false
+    /// Normalized mic input, 0 to 1, sampled while recording so the indicator can show that
+    /// sound is actually arriving. Zero whenever no recording is running.
+    @Published private(set) var inputLevel: Float = 0
+
+    private var levelTimer: DispatchSourceTimer?
     
     private var audioRecorder: AVAudioRecorder?
     private var audioPlayer: AVAudioPlayer?
@@ -197,9 +202,12 @@ class AudioRecorder: NSObject, ObservableObject {
             try Diag.measure("AVAudioRecorder init+record") {
                 audioRecorder = try AVAudioRecorder(url: fileURL, settings: settings)
                 audioRecorder?.delegate = self
-                audioRecorder?.isMeteringEnabled = monitorConnection
+                // Metering also drives the indicator's level meter, so it is on for every
+                // recording, not only the ones being watched for a Bluetooth connection.
+                audioRecorder?.isMeteringEnabled = true
                 audioRecorder?.record()
             }
+            startLevelMonitoring()
             if monitorConnection {
                 startConnectionMonitoring()
             } else {
@@ -216,6 +224,7 @@ class AudioRecorder: NSObject, ObservableObject {
     func stopRecording() -> URL? {
         audioRecorder?.stop()
         updateRecordingState(isRecording: false, isConnecting: false)
+        stopLevelMonitoring()
         stopConnectionMonitoring()
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             self?.primeAudioHardware()  // re-prime so the next recording starts instantly too
@@ -245,6 +254,7 @@ class AudioRecorder: NSObject, ObservableObject {
     func cancelRecording() {
         audioRecorder?.stop()
         updateRecordingState(isRecording: false, isConnecting: false)
+        stopLevelMonitoring()
         stopConnectionMonitoring()
 
         if AppPreferences.shared.pauseMediaOnRecord {
@@ -305,6 +315,29 @@ class AudioRecorder: NSObject, ObservableObject {
         }
     }
     
+    /// Sample the recorder's meter into `inputLevel` at 20 Hz. Fast enough to track speech,
+    /// slow enough that the indicator is not re-rendered on every frame.
+    private func startLevelMonitoring() {
+        stopLevelMonitoring()
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
+        timer.schedule(deadline: .now() + 0.05, repeating: 0.05)
+        timer.setEventHandler { [weak self] in
+            guard let self, let recorder = self.audioRecorder, recorder.isRecording else { return }
+            recorder.updateMeters()
+            let level = AudioLevel.normalize(power: recorder.averagePower(forChannel: 0))
+            DispatchQueue.main.async { self.inputLevel = level }
+        }
+        timer.resume()
+        levelTimer = timer
+    }
+
+    private func stopLevelMonitoring() {
+        levelTimer?.cancel()
+        levelTimer = nil
+        DispatchQueue.main.async { [weak self] in self?.inputLevel = 0 }
+    }
+
     private func startConnectionMonitoring() {
         stopConnectionMonitoring()
         

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -399,6 +399,9 @@ struct IndicatorWindow: View {
     // Surfaces how many earlier clips are still transcribing in the background, so starting a new
     // recording while others are queued shows the backlog. (parallel-recording #3)
     @ObservedObject private var pipeline = DictationPipeline.shared
+    // Observed directly rather than through the view model: `viewModel.recorder` is a nested
+    // ObservableObject, and its changes don't propagate through the outer object.
+    @ObservedObject private var recorder = AudioRecorder.shared
     @Environment(\.colorScheme) private var colorScheme
     
     private var backgroundColor: Color {
@@ -510,6 +513,7 @@ struct IndicatorWindow: View {
                                 .font(.system(size: 13, weight: .semibold))
                                 .foregroundColor(.secondary)
                                 .transition(.opacity)
+                            InputLevelMeter(level: recorder.inputLevel)
                         }
                         if anyIndicatorButton {
                             Spacer(minLength: 8)

--- a/OpenSuperWhisper/Indicator/InputLevelMeter.swift
+++ b/OpenSuperWhisper/Indicator/InputLevelMeter.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Five bars showing mic input while recording, so it is obvious that sound is arriving
+/// before the user has spoken a whole sentence into a muted or wrong device (#47).
+///
+/// The frame is deliberately fixed. The indicator window is resized by hand whenever its
+/// content changes size (`IndicatorWindowManager.resizeToContent`), so a meter that grew
+/// with the level would resize the window at 20 Hz. Only the fill inside each bar moves.
+struct InputLevelMeter: View {
+    let level: Float
+
+    private static let barCount = 5
+    private static let barWidth: CGFloat = 2.5
+    private static let barSpacing: CGFloat = 2.5
+    private static let height: CGFloat = 13
+
+    private var width: CGFloat {
+        CGFloat(Self.barCount) * Self.barWidth + CGFloat(Self.barCount - 1) * Self.barSpacing
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: Self.barSpacing) {
+            ForEach(0..<Self.barCount, id: \.self) { index in
+                let fill = AudioLevel.barFill(index: index, count: Self.barCount, level: level)
+                // Shortest bar stays visible at rest, so the meter reads as "no sound"
+                // rather than as a missing element.
+                let barHeight = Self.height * (0.25 + 0.75 * CGFloat(index + 1) / CGFloat(Self.barCount))
+                Capsule()
+                    .fill(Color.secondary.opacity(0.22 + 0.68 * Double(fill)))
+                    .frame(width: Self.barWidth, height: barHeight)
+            }
+        }
+        .frame(width: width, height: Self.height, alignment: .bottom)
+        .animation(.linear(duration: 0.05), value: level)
+        .accessibilityHidden(true)
+    }
+}

--- a/OpenSuperWhisper/MicrophoneService.swift
+++ b/OpenSuperWhisper/MicrophoneService.swift
@@ -60,6 +60,23 @@ class MicrophoneService: ObservableObject {
             self?.refreshAvailableMicrophones()
             self?.updateCurrentMicrophone()
         }
+
+        #if os(macOS)
+        // Follow the system input device itself, not just connect/disconnect: switching input in
+        // Sound settings changes no device list, so without this the app keeps recording from the
+        // previous mic while claiming to follow the system default.
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, .main
+        ) { [weak self] _, _ in
+            guard let self, self.followsSystemDefault else { return }
+            self.updateCurrentMicrophone()
+        }
+        #endif
     }
     
     func refreshAvailableMicrophones() {
@@ -153,11 +170,34 @@ class MicrophoneService: ObservableObject {
         return availableMicrophones.contains(where: { $0.id == device.id })
     }
     
+    /// Picker value meaning "whatever macOS is using", as opposed to a pinned device.
+    static let systemDefaultID = "__systemDefault__"
+
+    /// True while no specific device is pinned, so the app follows the system input.
+    var followsSystemDefault: Bool { selectedMicrophone == nil }
+
+    /// The device to record from when nothing is pinned. Prefers the system input, which is
+    /// what the user set in Sound settings and what every other app on the Mac will use.
+    /// Falls back to the built-in mic, then to anything, so a machine whose default input
+    /// CoreAudio can't resolve still records.
     func getDefaultMicrophone() -> AudioDevice? {
+        if let systemDefault = systemDefaultMicrophone() {
+            return systemDefault
+        }
         if let builtIn = availableMicrophones.first(where: { $0.isBuiltIn }) {
             return builtIn
         }
         return availableMicrophones.first
+    }
+
+    /// The current system input device, matched against the discovered list by UID.
+    func systemDefaultMicrophone() -> AudioDevice? {
+        #if os(macOS)
+        guard let uid = systemDefaultInputUID() else { return nil }
+        return availableMicrophones.first { $0.id == uid }
+        #else
+        return nil
+        #endif
     }
     
     func selectMicrophone(_ device: AudioDevice) {
@@ -279,6 +319,33 @@ class MicrophoneService: ObservableObject {
     }
     
     #if os(macOS)
+    /// UID of the system input device (`kAudioHardwarePropertyDefaultInputDevice` resolved to
+    /// its UID, which is what `AVCaptureDevice.uniqueID` reports).
+    private func systemDefaultInputUID() -> String? {
+        var defaultAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID = AudioDeviceID()
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject),
+                                         &defaultAddress, 0, nil, &size, &deviceID) == noErr,
+              deviceID != kAudioObjectUnknown
+        else { return nil }
+
+        var uidAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var uid: CFString = "" as CFString
+        var uidSize = UInt32(MemoryLayout<CFString>.size)
+        guard AudioObjectGetPropertyData(deviceID, &uidAddress, 0, nil, &uidSize, &uid) == noErr
+        else { return nil }
+        return uid as String
+    }
+
     func getCoreAudioDeviceID(for device: AudioDevice) -> AudioDeviceID? {
         var deviceID = device.id as CFString
         var audioDeviceID = AudioDeviceID()

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2398,15 +2398,26 @@ struct SettingsView: View {
             }
 
             SSection(title: "Input") {
-                SRow(title: "Microphone", hint: "Also switchable from the menu bar") {
+                SRow(title: "Microphone",
+                     hint: micService.followsSystemDefault
+                        ? "Following the system input\(micService.currentMicrophone.map { " (\($0.name))" } ?? "") — switch headsets and it follows"
+                        : "Also switchable from the menu bar") {
                     Picker("", selection: Binding(
-                        get: { micService.selectedMicrophone?.id ?? micService.currentMicrophone?.id ?? "" },
+                        get: {
+                            micService.followsSystemDefault
+                                ? MicrophoneService.systemDefaultID
+                                : (micService.selectedMicrophone?.id ?? MicrophoneService.systemDefaultID)
+                        },
                         set: { newID in
-                            if let device = micService.availableMicrophones.first(where: { $0.id == newID }) {
+                            if newID == MicrophoneService.systemDefaultID {
+                                micService.resetToDefault()
+                            } else if let device = micService.availableMicrophones.first(where: { $0.id == newID }) {
                                 micService.selectMicrophone(device)
                             }
                         }
                     )) {
+                        Text("System Default").tag(MicrophoneService.systemDefaultID)
+                        Divider()
                         ForEach(micService.availableMicrophones, id: \.id) { device in
                             Text(device.name).tag(device.id)
                         }

--- a/OpenSuperWhisper/Utils/AudioLevel.swift
+++ b/OpenSuperWhisper/Utils/AudioLevel.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Turns `AVAudioRecorder.averagePower` (decibels, -160 to 0) into the 0...1 value the
+/// indicator's meter draws.
+enum AudioLevel {
+    /// Below this, speech is indistinguishable from room noise, so the meter reads empty.
+    /// Chosen for close-range dictation: a normal speaking voice into a laptop mic sits
+    /// around -30 dB, a quiet room floor around -55 dB.
+    static let floorDb: Float = -55
+
+    /// Decibels are logarithmic, so a straight rescale leaves the meter barely moving for
+    /// most of the speaking range. The square root spreads normal speech across the bars
+    /// instead of bunching it near the bottom.
+    static func normalize(power: Float) -> Float {
+        guard power.isFinite else { return 0 }
+        let clamped = min(max(power, floorDb), 0)
+        let linear = (clamped - floorDb) / -floorDb
+        return sqrt(linear)
+    }
+
+    /// Fill level of bar `index` of `count`, so a meter can light bars progressively:
+    /// full below the current level, partial at the boundary, empty above.
+    static func barFill(index: Int, count: Int, level: Float) -> Float {
+        guard count > 0, index >= 0 else { return 0 }
+        let lower = Float(index) / Float(count)
+        let upper = Float(index + 1) / Float(count)
+        if level >= upper { return 1 }
+        if level <= lower { return 0 }
+        return (level - lower) / (upper - lower)
+    }
+}

--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -38,4 +38,18 @@ class LanguageUtil {
             return "eng"
         }
     }
+
+    /// Whether `locale` appears in `installed`, comparing language and region rather than raw
+    /// identifiers. Speech hands the same locale back as "fr_FR" or "fr-FR" depending on the
+    /// call, so a string compare reports a downloaded model as missing. A region-less locale
+    /// ("fr") matches any region of that language, which is what the language rows ask about.
+    static func isInstalled(_ locale: Locale, in installed: [Locale]) -> Bool {
+        installed.contains { matches($0, locale) }
+    }
+
+    static func matches(_ a: Locale, _ b: Locale) -> Bool {
+        guard a.language.languageCode == b.language.languageCode else { return false }
+        guard let wanted = b.region else { return true }
+        return a.region == wanted
+    }
 }

--- a/OpenSuperWhisperTests/AppleModelInstalledStateTests.swift
+++ b/OpenSuperWhisperTests/AppleModelInstalledStateTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// The Apple Speech model rows ask "are this language's assets on this Mac", and the answer
+/// is matched against the locale list Speech returns. Identifier formatting differs between
+/// call sites ("fr_FR" vs "fr-FR"), so the comparison has to go through language + region
+/// rather than string equality, or an installed model renders a Download button (#46).
+final class AppleModelInstalledStateTests: XCTestCase {
+
+    func testMatchesAcrossIdentifierSeparators() {
+        let installed = [Locale(identifier: "fr-FR"), Locale(identifier: "en_US")]
+        XCTAssertTrue(LanguageUtil.isInstalled(Locale(identifier: "fr_FR"), in: installed))
+        XCTAssertTrue(LanguageUtil.isInstalled(Locale(identifier: "en-US"), in: installed))
+    }
+
+    func testDistinguishesRegionalVariants() {
+        let installed = [Locale(identifier: "fr_FR")]
+        XCTAssertFalse(LanguageUtil.isInstalled(Locale(identifier: "fr_CH"), in: installed),
+                       "fr_CH is a separate download from fr_FR")
+    }
+
+    /// The language rows resolve to a full locale, but a bare code has to keep working: it
+    /// asks whether the language is available at all, so any region counts.
+    func testRegionlessLocaleMatchesAnyRegion() {
+        let installed = [Locale(identifier: "pt_BR")]
+        XCTAssertTrue(LanguageUtil.isInstalled(Locale(identifier: "pt"), in: installed))
+        XCTAssertFalse(LanguageUtil.isInstalled(Locale(identifier: "de"), in: installed))
+    }
+
+    func testEmptyInventoryInstallsNothing() {
+        XCTAssertFalse(LanguageUtil.isInstalled(Locale(identifier: "en_US"), in: []))
+    }
+}

--- a/OpenSuperWhisperTests/AudioLevelTests.swift
+++ b/OpenSuperWhisperTests/AudioLevelTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// The indicator's meter turns `averagePower` decibels into bar fills. Both steps are pure,
+/// so they're pinned here rather than judged by eye on a running bubble (#47).
+final class AudioLevelTests: XCTestCase {
+
+    func testSilenceAndFullScaleMapToTheEnds() {
+        XCTAssertEqual(AudioLevel.normalize(power: -160), 0, accuracy: 0.001)
+        XCTAssertEqual(AudioLevel.normalize(power: AudioLevel.floorDb), 0, accuracy: 0.001)
+        XCTAssertEqual(AudioLevel.normalize(power: 0), 1, accuracy: 0.001)
+    }
+
+    /// -160 dB is the documented floor, but a dead channel can report -infinity.
+    func testNonFinitePowerReadsAsSilence() {
+        XCTAssertEqual(AudioLevel.normalize(power: -.infinity), 0)
+        XCTAssertEqual(AudioLevel.normalize(power: .nan), 0)
+    }
+
+    func testLouderInputNeverReadsLower() {
+        let samples: [Float] = [-80, -55, -40, -30, -20, -10, -3, 0]
+        for (quiet, loud) in zip(samples, samples.dropFirst()) {
+            XCTAssertLessThanOrEqual(AudioLevel.normalize(power: quiet),
+                                     AudioLevel.normalize(power: loud),
+                                     "\(loud) dB should not read below \(quiet) dB")
+        }
+    }
+
+    /// A normal speaking voice sits near -30 dB. A linear dB rescale would leave it under
+    /// half a bar of five; the curve has to put it somewhere legible.
+    func testSpeakingVoiceLandsInTheMiddleOfTheMeter() {
+        let level = AudioLevel.normalize(power: -30)
+        XCTAssertGreaterThan(level, 0.4)
+        XCTAssertLessThan(level, 0.9)
+    }
+
+    func testBarsFillFromTheBottomUp() {
+        XCTAssertEqual(AudioLevel.barFill(index: 0, count: 5, level: 1), 1)
+        XCTAssertEqual(AudioLevel.barFill(index: 4, count: 5, level: 1), 1)
+        XCTAssertEqual(AudioLevel.barFill(index: 4, count: 5, level: 0.5), 0)
+        XCTAssertEqual(AudioLevel.barFill(index: 0, count: 5, level: 0.5), 1)
+        // Level 0.5 lands inside the third bar (0.4...0.6), half filled.
+        XCTAssertEqual(AudioLevel.barFill(index: 2, count: 5, level: 0.5), 0.5, accuracy: 0.001)
+    }
+
+    func testSilenceLeavesEveryBarEmpty() {
+        for index in 0..<5 {
+            XCTAssertEqual(AudioLevel.barFill(index: index, count: 5, level: 0), 0)
+        }
+    }
+}


### PR DESCRIPTION
Two small user-reported issues, one commit each.

## #46 — Apple models always offered a Download button

The rows called `AssetInventory.status(forModules:)`, which reports whether the assets are allocated to *this app*. macOS reserves at most 5 locales per app, so a language installed system-wide but not currently reserved returns `.supported` rather than `.installed`. Three symptoms, one cause:

- the row showed Download even though the model was on the machine
- pressing it completed instantly without downloading, because `assetInstallationRequest(supporting:)` had nothing to fetch and returned nil
- the optimistic local flip to "installed" was undone by the next refresh, which is the tab-switch reset in the report

Now the rows ask `SpeechTranscriber.installedLocales`, which reports what is on disk. Locale comparison goes through language and region instead of raw identifiers, because Speech returns `fr_FR` in some paths and `fr-FR` in others, and a string compare would call an installed model missing. That comparison lives in `LanguageUtil` (outside the macOS 26 gate) with 4 tests.

## #60 — System Default in the microphone picker

`MicrophoneService` already recorded from a fallback when no device was pinned, but nothing in the UI could return to that state, and the fallback preferred the built-in mic instead of the system input. Someone whose default input is a USB headset got the internal mic.

The fallback now reads `kAudioHardwarePropertyDefaultInputDevice`, and a CoreAudio listener on that property moves the app when the user switches input in Sound settings. Connect and disconnect notifications don't cover this: changing the default input alters no device list, so without the listener the app would keep recording from the previous mic while claiming to follow the system.

## Verification

`xcodebuild test`: 250 passed, 0 failed, including the 4 new locale-matching tests.

The #46 fix is checked by reasoning and tests rather than by reproducing on my machine, since it needs an Apple Speech language installed but outside the app's 5 reserved locales. @rpmcginty, if you're able to try a build from this branch, confirmation would be welcome.

## #47 — mic input level on the indicator

Added after the two above, same branch. Nothing on the bubble told you the mic was live, so a whole dictation could go into a muted or wrong device and only the empty transcription would say so.

Metering runs for every recording now (it was only on when watching for a Bluetooth connection), sampled at 20 Hz into `AudioRecorder.inputLevel`, drawn as five bars.

Two constraints shaped it. The meter keeps a **fixed frame**: `IndicatorWindowManager.resizeToContent` resizes the window by hand whenever content size changes, so a meter that grew with the level would resize the window twenty times a second. And the dB value goes through a square-root curve, because a straight rescale of -55...0 dB leaves a normal speaking voice (around -30 dB) at about a tenth of the meter.

`AudioLevel` is pure and covered by 6 tests (monotonic, silence and full scale, non-finite power, speaking voice legibility, bar fill boundaries). The visual result still wants a human glance, which is the one thing tests here can't give.

Suite after all three: **256 passed, 0 failed**.
