### PR TITLE
Add Vietnamese language option

### DIFF
--- a/OpenSuperWhisper/Utils/LanguageUtil.swift
+++ b/OpenSuperWhisper/Utils/LanguageUtil.swift
@@ -3,7 +3,7 @@ class LanguageUtil {
 
     static let availableLanguages = [
         "auto", "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-        "he", "sv", "it", "id", "hi", "fi",
+        "he", "sv", "it", "id", "hi", "fi", "vi",
     ]
 
     static let languageNames = [
@@ -28,6 +28,7 @@ class LanguageUtil {
         "id": "Indonesian",
         "hi": "Hindi",
         "fi": "Finnish",
+        "vi": "Vietnamese",
     ]
 
     static func getSystemLanguage() -> String {

--- a/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
+++ b/OpenSuperWhisperTests/OpenSuperWhisperTests.swift
@@ -331,6 +331,8 @@ final class EngineCapabilitiesTests: XCTestCase {
     func testLanguages_whisperUsesFullSet() {
         XCTAssertEqual(EngineCapabilities.supportedLanguages(engine: "whisper", fluidAudioModelVersion: ""),
                        LanguageUtil.availableLanguages)
+        XCTAssertTrue(LanguageUtil.availableLanguages.contains("vi"))
+        XCTAssertEqual(LanguageUtil.languageNames["vi"], "Vietnamese")
     }
 }
 


### PR DESCRIPTION
## Summary

- add Vietnamese (`vi`) to the language picker
- expose the display name `Vietnamese`
- add regression assertions for the Whisper language list

## Why

Whisper supports Vietnamese, but `LanguageUtil.availableLanguages` omitted the `vi` language code. Users could only rely on automatic language detection and could not explicitly select Vietnamese in the app.

## Impact

Users can now select Vietnamese when using the Whisper engine, which avoids incorrect automatic language detection for Vietnamese dictation.

## Validation

- `./run.sh build`
- `xcodebuild test -project OpenSuperWhisper.xcodeproj -scheme OpenSuperWhisper -destination 'platform=macOS,arch=arm64' -derivedDataPath build -clonedSourcePackagesDirPath SourcePackages -skipPackagePluginValidation -skipMacroValidation CODE_SIGNING_ALLOWED=NO -only-testing:OpenSuperWhisperTests`
