### PR TITLE
fix(tests): give each test process its own UserDefaults suite (#59)

### DIFF
--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -28,12 +28,12 @@ enum AppleSpeechSupport {
 
     /// Whisper-style language codes ("en", "fr", …) the system model can transcribe.
     static var cachedSupportedLanguages: [String] {
-        UserDefaults.standard.stringArray(forKey: supportedKey) ?? []
+        DefaultsStore.current.stringArray(forKey: supportedKey) ?? []
     }
 
     /// Languages whose assets are installed on this Mac right now.
     static var cachedInstalledLanguages: [String] {
-        UserDefaults.standard.stringArray(forKey: installedKey) ?? []
+        DefaultsStore.current.stringArray(forKey: installedKey) ?? []
     }
 
     /// The engine is usable without triggering a download (the catalog's rule:
@@ -44,8 +44,8 @@ enum AppleSpeechSupport {
     static func refreshCaches() async {
         let supported = languageCodes(from: await SpeechTranscriber.supportedLocales)
         let installed = languageCodes(from: await SpeechTranscriber.installedLocales)
-        UserDefaults.standard.set(supported, forKey: supportedKey)
-        UserDefaults.standard.set(installed, forKey: installedKey)
+        DefaultsStore.current.set(supported, forKey: supportedKey)
+        DefaultsStore.current.set(installed, forKey: installedKey)
     }
 
     /// Locale list → deduplicated language codes, keeping the framework's order.
@@ -91,8 +91,8 @@ enum AppleSpeechSupport {
     /// Models pane. Absent = the canonical CLDR resolution below.
     private static let overridesKey = "appleSpeechLocaleOverrides"
     static var localeOverrides: [String: String] {
-        get { UserDefaults.standard.dictionary(forKey: overridesKey) as? [String: String] ?? [:] }
-        set { UserDefaults.standard.set(newValue, forKey: overridesKey) }
+        get { DefaultsStore.current.dictionary(forKey: overridesKey) as? [String: String] ?? [:] }
+        set { DefaultsStore.current.set(newValue, forKey: overridesKey) }
     }
 
     /// The effective language code for the app's language setting ("auto" = system).

--- a/OpenSuperWhisper/Indicator/NotchTuning.swift
+++ b/OpenSuperWhisper/Indicator/NotchTuning.swift
@@ -11,7 +11,7 @@ final class NotchTuning: ObservableObject {
     @Published var bottomRadius: Double { didSet { save(bottomRadius, "notchBottomRadius") } }
 
     private init() {
-        let d = UserDefaults.standard
+        let d = DefaultsStore.current
         width = d.object(forKey: "notchWidth") as? Double ?? 220
         height = d.object(forKey: "notchHeight") as? Double ?? 42
         topRadius = d.object(forKey: "notchTopRadius") as? Double ?? 10
@@ -19,6 +19,6 @@ final class NotchTuning: ObservableObject {
     }
 
     private func save(_ value: Double, _ key: String) {
-        UserDefaults.standard.set(value, forKey: key)
+        DefaultsStore.current.set(value, forKey: key)
     }
 }

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -12,8 +12,8 @@ struct UserDefault<T> {
     let defaultValue: T
     
     var wrappedValue: T {
-        get { UserDefaults.standard.object(forKey: key) as? T ?? defaultValue }
-        set { UserDefaults.standard.set(newValue, forKey: key) }
+        get { DefaultsStore.current.object(forKey: key) as? T ?? defaultValue }
+        set { DefaultsStore.current.set(newValue, forKey: key) }
     }
 }
 
@@ -22,8 +22,8 @@ struct OptionalUserDefault<T> {
     let key: String
     
     var wrappedValue: T? {
-        get { UserDefaults.standard.object(forKey: key) as? T }
-        set { UserDefaults.standard.set(newValue, forKey: key) }
+        get { DefaultsStore.current.object(forKey: key) as? T }
+        set { DefaultsStore.current.set(newValue, forKey: key) }
     }
 }
 
@@ -48,9 +48,9 @@ final class AppPreferences {
     }
 
     private func migrateOldPreferences() {
-        if let oldPath = UserDefaults.standard.string(forKey: "selectedModelPath"),
-           UserDefaults.standard.string(forKey: "selectedWhisperModelPath") == nil {
-            UserDefaults.standard.set(oldPath, forKey: "selectedWhisperModelPath")
+        if let oldPath = DefaultsStore.current.string(forKey: "selectedModelPath"),
+           DefaultsStore.current.string(forKey: "selectedWhisperModelPath") == nil {
+            DefaultsStore.current.set(oldPath, forKey: "selectedWhisperModelPath")
         }
     }
 
@@ -78,7 +78,7 @@ final class AppPreferences {
     /// had picked "remote" isn't silently dropped back onto the "ollama" default. Idempotent: it
     /// only runs while the new key is unset, and the old key is never read again afterwards.
     private func migrateAIProviderToBackend() {
-        let defaults = UserDefaults.standard
+        let defaults = DefaultsStore.current
         guard defaults.object(forKey: "aiBackend") == nil,
               let old = defaults.string(forKey: "aiProvider"),
               !old.isEmpty

--- a/OpenSuperWhisper/Utils/DefaultsStore.swift
+++ b/OpenSuperWhisper/Utils/DefaultsStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Where every preference in the app is read and written.
+///
+/// In the app this is `UserDefaults.standard`, unchanged. Under XCTest it becomes a suite
+/// private to the running process, because the macOS scheme runs its testables in parallel and
+/// they all share the app's bundle identifier — so `.standard` is *one on-disk domain shared
+/// between test processes*. A write in one is visible in another, and a background task that
+/// outlives its test can read those restored preferences and act on a shared singleton while a
+/// test in a different process is asserting on it. That produced failures that were green on
+/// isolated rerun and impossible to trust. (#59)
+///
+/// The switch is automatic rather than opt-in: a channel that has to be remembered will be
+/// forgotten by the next test that starts background work.
+enum DefaultsStore {
+    static let current: UserDefaults = {
+        guard isRunningTests else { return .standard }
+        let name = testSuiteName(for: ProcessInfo.processInfo.processIdentifier)
+        guard let suite = UserDefaults(suiteName: name) else { return .standard }
+        // Start from nothing: a suite left behind by a crashed run would otherwise seed this one.
+        suite.removePersistentDomain(forName: name)
+        sweepSuitesFromPreviousRuns(keeping: name)
+        return suite
+    }()
+
+    /// True while the process is hosting XCTest. `XCTestConfigurationFilePath` is set by the
+    /// test runner and absent in a normal launch, including a Debug build the user runs.
+    static var isRunningTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
+    static var testSuitePrefix: String {
+        "\(Bundle.main.bundleIdentifier ?? "fr.my-monkey.opensuperwhisper").tests."
+    }
+
+    static func testSuiteName(for pid: Int32) -> String { "\(testSuitePrefix)\(pid)" }
+
+    /// Empties suites left by earlier test processes. Done on the way in rather than at exit:
+    /// `atexit` never ran here, because the test host is killed rather than allowed to return
+    /// from `main`.
+    ///
+    /// It clears contents, not files: cfprefsd caches the domain and writes an empty plist back
+    /// after the delete, so Preferences keeps a handful of ~40-byte stubs. Harmless, and not
+    /// worth fighting the daemon over — what matters is that no stale *value* survives to be
+    /// read by a later run.
+    static func sweepSuitesFromPreviousRuns(keeping current: String) {
+        let preferences = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+            .first?.appendingPathComponent("Preferences")
+        guard let preferences,
+              let entries = try? FileManager.default.contentsOfDirectory(atPath: preferences.path)
+        else { return }
+
+        for entry in entries where entry.hasPrefix(testSuitePrefix) && entry.hasSuffix(".plist") {
+            let name = String(entry.dropLast(".plist".count))
+            guard name != current, isAbandoned(name) else { continue }
+            UserDefaults.standard.removePersistentDomain(forName: name)
+            try? FileManager.default.removeItem(at: preferences.appendingPathComponent(entry))
+        }
+    }
+
+    /// Whether a suite belongs to a process that is gone. The scheme runs testables in
+    /// parallel, so a live sibling's suite must survive the sweep — deleting it would recreate
+    /// the very cross-process interference this file exists to stop.
+    static func isAbandoned(_ suiteName: String) -> Bool {
+        guard let pid = Int32(suiteName.dropFirst(testSuitePrefix.count)) else { return false }
+        // kill(pid, 0) probes for existence without signalling; ESRCH means no such process.
+        return kill(pid, 0) != 0 && errno == ESRCH
+    }
+}

--- a/OpenSuperWhisper/Utils/Diag.swift
+++ b/OpenSuperWhisper/Utils/Diag.swift
@@ -22,7 +22,7 @@ enum Diag {
         #if DEBUG
         return true
         #else
-        return UserDefaults.standard.bool(forKey: "diagnosticLogging")
+        return DefaultsStore.current.bool(forKey: "diagnosticLogging")
         #endif
     }
 

--- a/OpenSuperWhisper/Utils/LanguageManager.swift
+++ b/OpenSuperWhisper/Utils/LanguageManager.swift
@@ -7,13 +7,13 @@ import Foundation
 enum LanguageManager {
     /// "system" (follow the Mac), "en", or "fr".
     static var selected: String {
-        get { UserDefaults.standard.string(forKey: "appLanguageOverride") ?? "system" }
+        get { DefaultsStore.current.string(forKey: "appLanguageOverride") ?? "system" }
         set {
-            UserDefaults.standard.set(newValue, forKey: "appLanguageOverride")
+            DefaultsStore.current.set(newValue, forKey: "appLanguageOverride")
             if newValue == "system" {
-                UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                DefaultsStore.current.removeObject(forKey: "AppleLanguages")
             } else {
-                UserDefaults.standard.set([newValue], forKey: "AppleLanguages")
+                DefaultsStore.current.set([newValue], forKey: "AppleLanguages")
             }
         }
     }

--- a/OpenSuperWhisperTests/DefaultsStoreTests.swift
+++ b/OpenSuperWhisperTests/DefaultsStoreTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Preferences must not leak between parallel test processes. The scheme runs three testables
+/// in parallel under one bundle identifier, so `UserDefaults.standard` is a single on-disk
+/// domain shared between them (#59).
+final class DefaultsStoreTests: XCTestCase {
+
+    /// The whole fix rests on this: if the switch didn't happen, every other guarantee here is
+    /// void and the suite is back to sharing one domain.
+    func testTestsRunAgainstAPrivateSuite() {
+        XCTAssertTrue(DefaultsStore.isRunningTests,
+                      "XCTestConfigurationFilePath should be set while testing")
+        XCTAssertNotEqual(DefaultsStore.current, UserDefaults.standard,
+                          "tests must not write to the app's real domain")
+    }
+
+    /// Each process gets its own suite, which is what stops one host reading another's writes.
+    func testSuiteNameIsPerProcess() {
+        let mine = DefaultsStore.testSuiteName(for: ProcessInfo.processInfo.processIdentifier)
+        let other = DefaultsStore.testSuiteName(for: ProcessInfo.processInfo.processIdentifier + 1)
+        XCTAssertNotEqual(mine, other)
+        XCTAssertTrue(mine.contains("\(ProcessInfo.processInfo.processIdentifier)"))
+    }
+
+    /// The sweep that cleans up old suites must not touch a sibling still running: the scheme
+    /// runs testables in parallel, so deleting a live suite would recreate the interference
+    /// this whole file exists to prevent.
+    func testSweepSparesLiveProcesses() {
+        let mine = DefaultsStore.testSuiteName(for: ProcessInfo.processInfo.processIdentifier)
+        XCTAssertFalse(DefaultsStore.isAbandoned(mine),
+                       "this process is alive, so its suite must never be swept")
+    }
+
+    func testSweepClaimsSuitesOfDeadProcesses() {
+        // PID 0 is the kernel's scheduler entry; no test host will ever own it, and it is not
+        // a live process this call could match.
+        let stale = "\(DefaultsStore.testSuitePrefix)999999"
+        XCTAssertTrue(DefaultsStore.isAbandoned(stale))
+    }
+
+    /// A name that isn't a PID must not be mistaken for an abandoned suite.
+    func testMalformedSuiteNameIsNotSwept() {
+        XCTAssertFalse(DefaultsStore.isAbandoned("\(DefaultsStore.testSuitePrefix)notapid"))
+    }
+
+    /// The sweep has to actually remove the file, not merely intend to. cfprefsd caches domains
+    /// and can write them back after a plain file delete, so this asserts the observable result.
+    func testSweepRemovesAnAbandonedSuiteForReal() throws {
+        let deadPID: Int32 = 999998
+        let name = DefaultsStore.testSuiteName(for: deadPID)
+        try XCTSkipUnless(DefaultsStore.isAbandoned(name), "PID \(deadPID) unexpectedly alive")
+
+        let stale = try XCTUnwrap(UserDefaults(suiteName: name))
+        stale.set("left behind", forKey: "sentinel")
+        XCTAssertEqual(UserDefaults(suiteName: name)?.string(forKey: "sentinel"), "left behind")
+
+        DefaultsStore.sweepSuitesFromPreviousRuns(
+            keeping: DefaultsStore.testSuiteName(for: ProcessInfo.processInfo.processIdentifier))
+
+        XCTAssertNil(UserDefaults(suiteName: name)?.string(forKey: "sentinel"),
+                     "an abandoned suite must be gone after the sweep")
+    }
+
+    /// A preference written here must be invisible to the app's real domain, or the suite is
+    /// decorative and a test run would still edit the user's own settings.
+    func testWritesDoNotReachTheStandardDomain() {
+        let key = "osw.defaultsStoreTests.\(UUID().uuidString)"
+        defer { DefaultsStore.current.removeObject(forKey: key) }
+
+        DefaultsStore.current.set("written-by-test", forKey: key)
+
+        XCTAssertEqual(DefaultsStore.current.string(forKey: key), "written-by-test")
+        XCTAssertNil(UserDefaults.standard.string(forKey: key),
+                     "the app's domain must not see anything a test wrote")
+    }
+
+    /// AppPreferences goes through the same store, so setting one must not touch `.standard`.
+    /// This is the path that actually mattered: a background task reading a restored preference
+    /// is what kicked real engine work on a shared singleton mid-test.
+    func testAppPreferencesWritesStayInTheSuite() {
+        let original = AppPreferences.shared.selectedEngine
+        defer { AppPreferences.shared.selectedEngine = original }
+
+        let standardBefore = UserDefaults.standard.string(forKey: "selectedEngine")
+        AppPreferences.shared.selectedEngine = "osw-test-sentinel"
+
+        XCTAssertEqual(AppPreferences.shared.selectedEngine, "osw-test-sentinel")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "selectedEngine"), standardBefore,
+                       "AppPreferences must not write through to the real domain during tests")
+    }
+}


### PR DESCRIPTION
Closes #59.

## The channel

The scheme runs three testables with `parallelizable="YES"`, all under the app's bundle identifier, so `UserDefaults.standard` is **one on-disk domain shared between the test processes**. That's the cross-process channel @michael-wojcik described: a write in one host is visible in another, and a background task that outlives its test can read those restored preferences and kick real work on a shared singleton while a test in a different process is asserting on it.

Of the directions listed at triage, this takes the first one. Per-test `await`-hardening fixes the two known victims but leaves the channel open for the next test that starts async work, and turning off parallelisation pays for the problem with wall-clock time on every run.

Note for whoever reads the issue later: it mentions AppPreferences already having a `forTesting` seam. There isn't one — both property wrappers hardcoded `UserDefaults.standard`, as did 21 call sites across five files.

## The fix

Everything now reads and writes through `DefaultsStore.current`: `UserDefaults.standard` in the app, a per-process suite under XCTest.

The switch is automatic, keyed off `XCTestConfigurationFilePath`, rather than something each test opts into. A channel you have to remember to close is one the next test will leave open — which is precisely how this one survived.

**A side effect worth naming: test runs had been editing the developer's real settings.** Any test touching `AppPreferences` wrote straight through to the app's domain. I noticed because a run of mine flipped `selectedEngine` to `remote` in my own install. That stops now, and there's a test asserting it.

## Cleanup, and what it honestly does

Abandoned suites are emptied on the way in, skipping any whose PID is still alive — sweeping a live sibling would recreate the exact interference this fixes, so that case has its own test.

It clears contents, not files: cfprefsd caches the domain and writes an empty plist back after the delete, leaving ~40-byte stubs in Preferences. I left it there and said so in the comment rather than claiming a full cleanup. What matters is that no stale *value* survives; fighting the daemon for the file isn't worth it.

## Verification

300 tests pass. Beyond the isolation assertions, one test creates a real suite for a dead PID, sweeps, and checks the value is actually gone — the sweep intending to work isn't the same as it working.
