### PR TITLE
feat(trigger): any number of recording triggers, of any kind (#48)

### DIFF
--- a/OpenSuperWhisper/RecordingTrigger.swift
+++ b/OpenSuperWhisper/RecordingTrigger.swift
@@ -25,7 +25,7 @@ enum RecorderCombo {
 /// the mode could disagree with what was stored, leaving a configured key stranded behind a
 /// picker (the reason `lastModifierOnlyHotkey` had to exist). Here the mode is simply whatever
 /// was recorded, so the two can't drift.
-enum RecordingTrigger: Equatable {
+enum RecordingTrigger: Equatable, Codable {
     case none
     case keyCombo(KeyboardShortcuts.Shortcut)
     case modifier(ModifierKey)
@@ -53,9 +53,20 @@ enum RecordingTrigger: Equatable {
         (.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘"),
     ]
 
-    /// Which trigger a set of stored preferences describes. Mouse wins over a single modifier,
-    /// which wins over the key combination, matching how `ShortcutManager` has always resolved
-    /// them, so an install upgrading into this type keeps the trigger it had.
+    /// Every trigger the stored preferences describe. More than one can be live at a time — a
+    /// thumb button at the desk and a shortcut on the move — so this returns all of them rather
+    /// than picking a winner (#48).
+    static func resolveAll(mouseRaw: String, modifierRaw: String,
+                           shortcut: KeyboardShortcuts.Shortcut?) -> [RecordingTrigger] {
+        var triggers: [RecordingTrigger] = []
+        if let shortcut { triggers.append(.keyCombo(shortcut)) }
+        if let key = ModifierKey(rawValue: modifierRaw), key != .none { triggers.append(.modifier(key)) }
+        if let button = MouseButton(rawValue: mouseRaw), button != .none { triggers.append(.mouse(button)) }
+        return triggers
+    }
+
+    /// The single trigger these preferences describe, for the fields that only ever hold one
+    /// (cancel, submit, paste-last). Mouse wins over a modifier, which wins over the shortcut.
     static func resolve(mouseRaw: String, modifierRaw: String,
                         shortcut: KeyboardShortcuts.Shortcut?) -> RecordingTrigger {
         if let button = MouseButton(rawValue: mouseRaw), button != .none {
@@ -68,6 +79,87 @@ enum RecordingTrigger: Equatable {
             return .keyCombo(shortcut)
         }
         return .none
+    }
+
+    /// Two triggers of the same kind can't coexist: there is one shortcut slot, one modifier
+    /// preference and one mouse-button preference, so recording a new one of a kind replaces it.
+    var kind: Kind {
+        switch self {
+        case .none: return .keyCombo
+        case .keyCombo: return .keyCombo
+        case .modifier: return .modifier
+        case .mouse: return .mouse
+        }
+    }
+
+    enum Kind { case keyCombo, modifier, mouse }
+}
+
+/// The recording triggers, in the order they were added. Any number of each kind: the old shape
+/// held one slot per kind (one shortcut, one modifier preference, one mouse-button preference),
+/// which capped it at three however the UI was drawn (#48).
+struct RecordingTriggerSet: Equatable, Codable {
+    var triggers: [RecordingTrigger]
+
+    static let empty = RecordingTriggerSet(triggers: [])
+
+    var modifiers: [ModifierKey] {
+        triggers.compactMap { if case .modifier(let key) = $0 { return key } else { return nil } }
+    }
+
+    var mouseButtons: [MouseButton] {
+        triggers.compactMap { if case .mouse(let button) = $0 { return button } else { return nil } }
+    }
+
+    var keyCombos: [KeyboardShortcuts.Shortcut] {
+        triggers.compactMap { if case .keyCombo(let combo) = $0 { return combo } else { return nil } }
+    }
+
+    /// Appends unless an identical trigger is already there — recording the same key twice
+    /// should be a no-op, not a duplicate row that fires once.
+    mutating func add(_ trigger: RecordingTrigger) {
+        guard trigger != .none, !triggers.contains(trigger) else { return }
+        triggers.append(trigger)
+    }
+
+    mutating func remove(_ trigger: RecordingTrigger) {
+        triggers.removeAll { $0 == trigger }
+    }
+
+    /// The modifier and mouse button bound to a different action, if either collides with this
+    /// list. One key can only mean one thing: bound twice, whicheverthe router checks first
+    /// wins and the other binding looks broken with nothing on screen to explain it.
+    func conflicts(modifier: ModifierKey, mouse: MouseButton) -> (modifier: Bool, mouse: Bool) {
+        (modifier != .none && modifiers.contains(modifier),
+         mouse != .none && mouseButtons.contains(mouse))
+    }
+
+    // MARK: - Persistence
+
+    static func load(from json: String) -> RecordingTriggerSet {
+        guard let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(RecordingTriggerSet.self, from: data)
+        else { return .empty }
+        return decoded
+    }
+
+    var json: String {
+        guard let data = try? JSONEncoder().encode(self),
+              let string = String(data: data, encoding: .utf8)
+        else { return "" }
+        return string
+    }
+
+    /// Carries the three single-slot preferences into the list, so an existing install keeps
+    /// the trigger it had.
+    static func migrated(mouseRaw: String, modifierRaw: String,
+                         shortcut: KeyboardShortcuts.Shortcut?) -> RecordingTriggerSet {
+        var set = RecordingTriggerSet.empty
+        for trigger in RecordingTrigger.resolveAll(mouseRaw: mouseRaw, modifierRaw: modifierRaw,
+                                                   shortcut: shortcut) {
+            set.add(trigger)
+        }
+        return set
     }
 }
 

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -2227,13 +2227,21 @@ struct SettingsView: View {
     private var dictationSettings: some View {
         SPane(title: "Dictation") {
             SSection(title: "Trigger") {
-                SRow(title: "Recording trigger",
-                     hint: "Click, then do it: press a combination with ⌘ ⌥ ⌃, tap a single modifier on its own, or click a spare mouse button. ⌫ clears it") {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Recording trigger")
+                        .font(.system(size: 13))
+                        .foregroundColor(STheme.text)
+                    Text("Click Add, then do the thing: press a combination with ⌘ ⌥ ⌃, tap a single modifier on its own, or click a spare mouse button. Keep several and use whichever suits the moment.")
+                        .font(.system(size: 11))
+                        .foregroundColor(STheme.hint)
+                        .fixedSize(horizontal: false, vertical: true)
                     TriggerRecorderField(name: .toggleRecord,
                                          mouseButton: $viewModel.mouseButtonHotkey,
-                                         modifierKey: $viewModel.modifierOnlyHotkey)
-                        .frame(width: 168)
+                                         modifierKey: $viewModel.modifierOnlyHotkey,
+                                         allowsMultiple: true)
+                        .padding(.top, 2)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 SRow(title: "Latch with Space",
                      hint: "While recording, Space (or a double-tap of the trigger) pins it so you can let go and keep talking. Space again stops it — so Space won't type into other apps during a recording") {
                     SToggle(isOn: $viewModel.latchRecordingWithSpace)

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -17,6 +17,14 @@ extension KeyboardShortcuts.Name {
     /// mouse button. Unbound by default: claiming a global combination for everyone isn't
     /// ours to do. (#50)
     static let toggleRecordAndSubmit = Self("toggleRecordAndSubmit")
+
+    /// One registration handle per recorded key combination. Names are dynamic because the
+    /// number of triggers is: the combinations themselves live in `recordingTriggers`, and
+    /// these slots are only how the library is told about them. (#48)
+    static func recordTriggerSlot(_ index: Int) -> Self { Self("recordTriggerSlot\(index)") }
+    /// Slots are cleared up to this index when the list shrinks, so a removed combination
+    /// can't stay bound. Well above any realistic number of triggers.
+    static let recordTriggerSlotLimit = 16
 }
 
 class ShortcutManager {
@@ -157,12 +165,11 @@ class ShortcutManager {
             KeyboardShortcuts.setShortcut(.init(.escape), for: .escape)
         }
 
-        KeyboardShortcuts.onKeyDown(for: .toggleRecord) { [weak self] in
-            self?.handleKeyDown()
-        }
-
-        KeyboardShortcuts.onKeyUp(for: .toggleRecord) { [weak self] in
-            self?.handleKeyUp()
+        // One pair of handlers per slot, registered once for the process lifetime.
+        for index in 0..<KeyboardShortcuts.Name.recordTriggerSlotLimit {
+            let slot = KeyboardShortcuts.Name.recordTriggerSlot(index)
+            KeyboardShortcuts.onKeyDown(for: slot) { [weak self] in self?.handleKeyDown() }
+            KeyboardShortcuts.onKeyUp(for: slot) { [weak self] in self?.handleKeyUp() }
         }
 
         // Ends the running take and submits it. Works alongside every trigger mode, since it is
@@ -194,28 +201,17 @@ class ShortcutManager {
     }
     
     private func setupRecordingTrigger() {
-        let modifierKey = ModifierKey(rawValue: AppPreferences.shared.modifierOnlyHotkey) ?? .none
-        let mouseButton = MouseButton(rawValue: AppPreferences.shared.mouseButtonHotkey) ?? .none
-        // Optional second button that dictates and then submits. It works alongside whichever
-        // trigger is active, including the keyboard ones, so it is set up separately. (#50)
+        let set = RecordingTriggerSet.load(from: AppPreferences.shared.recordingTriggers)
+        // Optional second bindings that dictate and then submit. Separate from the trigger list:
+        // they end a take rather than starting one. (#50)
         let submitButton = MouseButton(rawValue: AppPreferences.shared.submitMouseButtonHotkey) ?? .none
         let submitModifier = ModifierKey(rawValue: AppPreferences.shared.submitModifierOnlyHotkey) ?? .none
 
-        // The three trigger modes are mutually exclusive. Tear all of them down
-        // first, then enable exactly one. A configured mouse button takes priority
-        // over a modifier key, which takes priority over the regular shortcut.
         ModifierKeyMonitor.shared.stop()
         MouseButtonMonitor.shared.stop()
 
-        if mouseButton != .none || submitButton != .none {
-            useMouseButtonHotkey = mouseButton != .none
-            if mouseButton != .none {
-                useModifierOnlyHotkey = false
-                // Only the plain record shortcut is exclusive with the other trigger modes;
-                // toggleRecordAndSubmit is a separate action and stays live.
-                KeyboardShortcuts.disable(.toggleRecord)
-            }
-
+        let mouseButtons = set.mouseButtons + (submitButton == .none ? [] : [submitButton])
+        if !mouseButtons.isEmpty {
             MouseButtonMonitor.shared.onButtonDown = { [weak self] button in
                 guard let self else { return }
                 if submitButton != .none, button == submitButton {
@@ -224,26 +220,15 @@ class ShortcutManager {
                     self.handleKeyDown()
                 }
             }
-
             MouseButtonMonitor.shared.onButtonUp = { [weak self] button in
                 guard submitButton == .none || button != submitButton else { return }
                 self?.handleKeyUp()
             }
-
-            MouseButtonMonitor.shared.start(mouseButtons: [mouseButton, submitButton])
+            MouseButtonMonitor.shared.start(mouseButtons: mouseButtons)
         }
 
-        if mouseButton != .none {
-            print("ShortcutManager: Using mouse-button hotkey: \(mouseButton.displayName)")
-        }
-
-        if modifierKey != .none || submitModifier != .none {
-            useModifierOnlyHotkey = modifierKey != .none
-            if modifierKey != .none && mouseButton == .none {
-                useMouseButtonHotkey = false
-                KeyboardShortcuts.disable(.toggleRecord)
-            }
-
+        let modifiers = set.modifiers + (submitModifier == .none ? [] : [submitModifier])
+        if !modifiers.isEmpty {
             ModifierKeyMonitor.shared.onKeyDown = { [weak self] key in
                 guard let self else { return }
                 if submitModifier != .none, key == submitModifier {
@@ -252,29 +237,41 @@ class ShortcutManager {
                     self.handleKeyDown()
                 }
             }
-
             ModifierKeyMonitor.shared.onKeyUp = { [weak self] key in
-                // The submit key already stopped the take on key-down; a release must not
-                // stop a fresh recording started right after.
                 guard submitModifier == .none || key != submitModifier else { return }
                 self?.handleKeyUp()
             }
-
-            ModifierKeyMonitor.shared.start(modifierKeys: [modifierKey, submitModifier])
+            ModifierKeyMonitor.shared.start(modifierKeys: modifiers)
         }
 
-        if mouseButton != .none {
-            print("ShortcutManager: Using mouse-button hotkey: \(mouseButton.displayName)")
-        } else if modifierKey != .none {
-            print("ShortcutManager: Using modifier-only hotkey: \(modifierKey.displayName)")
-        } else {
-            useMouseButtonHotkey = false
-            useModifierOnlyHotkey = false
-            KeyboardShortcuts.enable(.toggleRecord)
-            print("ShortcutManager: Using regular keyboard shortcut")
+        bindKeyComboSlots(set.keyCombos)
+
+        useMouseButtonHotkey = !set.mouseButtons.isEmpty
+        useModifierOnlyHotkey = !set.modifiers.isEmpty
+        print("ShortcutManager: \(set.triggers.count) recording trigger(s) armed")
+    }
+
+    /// Points one library slot at each recorded combination and clears the rest, so removing a
+    /// trigger actually unbinds it rather than leaving a stale slot listening.
+    ///
+    /// Only the bindings move here. The handlers are registered once at launch, because
+    /// `KeyboardShortcuts.onKeyDown` appends to a list rather than replacing: re-registering on
+    /// every settings change stacked duplicates, and one key press then ran the toggle twice —
+    /// starting a recording and immediately ending it, which looked like the mic firing with no
+    /// indicator.
+    private func bindKeyComboSlots(_ combos: [KeyboardShortcuts.Shortcut]) {
+        for index in 0..<KeyboardShortcuts.Name.recordTriggerSlotLimit {
+            let slot = KeyboardShortcuts.Name.recordTriggerSlot(index)
+            if index < combos.count {
+                KeyboardShortcuts.setShortcut(combos[index], for: slot)
+                KeyboardShortcuts.enable(slot)
+            } else {
+                KeyboardShortcuts.setShortcut(nil, for: slot)
+                KeyboardShortcuts.disable(slot)
+            }
         }
     }
-    
+
     /// Stops the running take and asks for Return once its text lands. Deliberately cannot
     /// START a recording: one key begins a dictation, the others only end it. Both keys being
     /// able to do both made the outcome depend on which one you happened to press first, which

--- a/OpenSuperWhisper/TriggerRecorderField.swift
+++ b/OpenSuperWhisper/TriggerRecorderField.swift
@@ -23,21 +23,134 @@ struct TriggerRecorderField: View {
     /// Cancel is normally bound to bare Esc, so that field has to be able to record it. Esc then
     /// can't also mean "abort the capture" there; clicking outside does that instead.
     var allowsBareEscape = false
+    /// The record trigger keeps a list: any number of combinations, modifiers and buttons, all
+    /// live at once (#48). The other actions hold one binding, so recording replaces it.
+    var allowsMultiple = false
 
+    /// Mirrors the stored shortcut. `KeyboardShortcuts.getShortcut` is not something SwiftUI
+    /// observes, so reading it straight from the body left a newly recorded combination
+    /// invisible until something else redrew the view — the whole list looked broken.
+    @State private var shortcut: KeyboardShortcuts.Shortcut?
     @State private var isRecording = false
     @State private var heldModifiers: NSEvent.ModifierFlags = []
     @State private var isHovering = false
     @State private var monitors: [Any] = []
     @State private var detector = SingleModifierDetector()
 
-    private var trigger: RecordingTrigger {
-        RecordingTrigger.resolve(
-            mouseRaw: mouseButton.rawValue,
-            modifierRaw: modifierKey.rawValue,
-            shortcut: KeyboardShortcuts.getShortcut(for: name))
+    /// The stored list, for the multi-trigger field. Mirrored in state so a change redraws:
+    /// preferences are not something SwiftUI observes.
+    @State private var set = RecordingTriggerSet.empty
+
+    private var triggers: [RecordingTrigger] {
+        guard allowsMultiple else {
+            let single = RecordingTrigger.resolve(mouseRaw: mouseButton.rawValue,
+                                                  modifierRaw: modifierKey.rawValue,
+                                                  shortcut: shortcut)
+            return single == .none ? [] : [single]
+        }
+        return set.triggers
     }
 
-    var body: some View {
+    private func loadShortcut() {
+        shortcut = KeyboardShortcuts.getShortcut(for: name)
+        if allowsMultiple {
+            set = RecordingTriggerSet.load(from: AppPreferences.shared.recordingTriggers)
+        }
+    }
+
+    private func persistSet() {
+        AppPreferences.shared.recordingTriggers = set.json
+        NotificationCenter.default.post(name: .hotkeySettingsChanged, object: nil)
+    }
+
+    @ViewBuilder var body: some View {
+        if allowsMultiple {
+            listBody
+        } else {
+            singleField
+        }
+    }
+
+    /// One row per configured trigger, plus an explicit row to add another. The compact field
+    /// couldn't show two bindings side by side without cramming, and its "+" was decoration
+    /// rather than a control — clicking it armed the recorder by accident rather than by design.
+    private var listBody: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(triggers.enumerated()), id: \.offset) { _, configured in
+                triggerRow(configured)
+            }
+            addRow
+        }
+    }
+
+    private func triggerRow(_ trigger: RecordingTrigger) -> some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 3) {
+                ForEach(Array(trigger.caps.enumerated()), id: \.offset) { _, cap in
+                    TriggerCap(label: cap)
+                }
+            }
+            Spacer(minLength: 8)
+            Button { remove(trigger) } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(STheme.hint)
+            }
+            .buttonStyle(.plain)
+            .pointerCursorOnHover()
+            .help("Remove this trigger")
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 30)
+        .background(RoundedRectangle(cornerRadius: 7).fill(STheme.inputBg))
+        .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.controlBorder, lineWidth: 1))
+    }
+
+    /// Doubles as the capture surface: idle it invites a new trigger, armed it shows the
+    /// modifiers being held, so the thing you click is the thing that records.
+    private var addRow: some View {
+        HStack(spacing: 8) {
+            if isRecording {
+                ForEach(RecordingTrigger.modifierBadges, id: \.symbol) { badge in
+                    let held = heldModifiers.contains(badge.flag)
+                    Text(badge.symbol)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(held ? .white : STheme.hint)
+                        .frame(width: 18, height: 18)
+                        .background(RoundedRectangle(cornerRadius: 4)
+                            .fill(held ? STheme.accent : STheme.controlBg))
+                }
+                Text(placeholder)
+                    .font(.system(size: 11))
+                    .foregroundColor(STheme.hint)
+            } else {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(STheme.hint)
+                Text(triggers.isEmpty ? "Add a trigger" : "Add another")
+                    .font(.system(size: 11))
+                    .foregroundColor(STheme.hint)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 30)
+        .background(RoundedRectangle(cornerRadius: 7)
+            .fill(isRecording ? STheme.accentSoft : Color.clear))
+        .overlay(RoundedRectangle(cornerRadius: 7)
+            .strokeBorder(isRecording ? STheme.accent : STheme.controlBorder,
+                          style: StrokeStyle(lineWidth: 1, dash: isRecording ? [] : [4, 3])))
+        .contentShape(RoundedRectangle(cornerRadius: 7))
+        .onTapGesture { if isRecording { disarm() } else { arm() } }
+        .onHover { isHovering = $0 }
+        .pointerCursorOnHover()
+        .onAppear { loadShortcut() }
+        .onDisappear { disarm() }
+        .animation(.easeOut(duration: 0.12), value: heldModifiers.rawValue)
+        .animation(.easeOut(duration: 0.12), value: isRecording)
+    }
+
+    private var singleField: some View {
         HStack(spacing: 8) {
             if isRecording { recordingBody } else { idleBody }
         }
@@ -50,22 +163,18 @@ struct TriggerRecorderField: View {
         .contentShape(RoundedRectangle(cornerRadius: 7))
         .onTapGesture { if isRecording { disarm() } else { arm() } }
         .onHover { isHovering = $0 }
+        .onAppear { loadShortcut() }
         .onDisappear { disarm() }
         .animation(.easeOut(duration: 0.12), value: heldModifiers.rawValue)
         .animation(.easeOut(duration: 0.12), value: isRecording)
     }
 
+    /// The single-binding presentation: one trigger, replaced on each recording.
     private var idleBody: some View {
         HStack(spacing: 6) {
-            let caps = trigger.caps
-            if caps.isEmpty {
-                Text("Click to record")
-                    .font(.system(size: 11))
-                    .foregroundColor(STheme.hint)
-                Spacer(minLength: 0)
-            } else {
+            if let configured = triggers.first {
                 HStack(spacing: 3) {
-                    ForEach(Array(caps.enumerated()), id: \.offset) { _, cap in
+                    ForEach(Array(configured.caps.enumerated()), id: \.offset) { _, cap in
                         TriggerCap(label: cap)
                     }
                 }
@@ -79,8 +188,23 @@ struct TriggerRecorderField: View {
                     .buttonStyle(.plain)
                     .help("Clear trigger")
                 }
+            } else {
+                Text("Click to record")
+                    .font(.system(size: 11))
+                    .foregroundColor(STheme.hint)
+                Spacer(minLength: 0)
             }
         }
+    }
+
+    /// Clears one trigger without touching the others.
+    private func remove(_ trigger: RecordingTrigger) {
+        guard allowsMultiple else {
+            clear()
+            return
+        }
+        set.remove(trigger)
+        persistSet()
     }
 
     private var recordingBody: some View {
@@ -193,29 +317,73 @@ struct TriggerRecorderField: View {
     /// Stores the trigger, clearing the other two kinds: exactly one is active at a time, which
     /// is what makes the mode implicit.
     private func save(_ trigger: RecordingTrigger) {
+        if allowsMultiple {
+            set.add(trigger)
+            releaseFromOtherActions(trigger)
+            persistSet()
+            disarm()
+            return
+        }
+        // The reverse direction: binding a key to this action takes it off the trigger list, or
+        // the router would route it here and the trigger would silently stop starting anything.
+        takeOverFromRecordingTriggers(trigger)
         switch trigger {
         case .none:
             clear()
         case .keyCombo(let shortcut):
-            mouseButton = .none
-            modifierKey = .none
+            if !allowsMultiple { mouseButton = .none; modifierKey = .none }
             KeyboardShortcuts.setShortcut(shortcut, for: name)
+            self.shortcut = shortcut
         case .modifier(let key):
-            mouseButton = .none
+            if !allowsMultiple {
+                mouseButton = .none
+                KeyboardShortcuts.setShortcut(nil, for: name)
+                self.shortcut = nil
+            }
             modifierKey = key
-            KeyboardShortcuts.setShortcut(nil, for: name)
         case .mouse(let button):
-            modifierKey = .none
+            if !allowsMultiple {
+                modifierKey = .none
+                KeyboardShortcuts.setShortcut(nil, for: name)
+                self.shortcut = nil
+            }
             mouseButton = button
-            KeyboardShortcuts.setShortcut(nil, for: name)
         }
         disarm()
+    }
+
+    /// Frees a key that another action already claims. The newest assignment wins, which is what
+    /// every shortcut editor does — the alternative is a key bound twice where the loser fails
+    /// silently, which is exactly how a working modifier looked broken.
+    private func releaseFromOtherActions(_ trigger: RecordingTrigger) {
+        let prefs = AppPreferences.shared
+        switch trigger {
+        case .modifier(let key):
+            if prefs.submitModifierOnlyHotkey == key.rawValue {
+                prefs.submitModifierOnlyHotkey = ModifierKey.none.rawValue
+            }
+        case .mouse(let button):
+            if prefs.submitMouseButtonHotkey == button.rawValue {
+                prefs.submitMouseButtonHotkey = MouseButton.none.rawValue
+            }
+        case .keyCombo, .none:
+            break
+        }
+    }
+
+    /// Same rule, applied when a single-binding field claims something the trigger list holds.
+    private func takeOverFromRecordingTriggers(_ trigger: RecordingTrigger) {
+        var triggerSet = RecordingTriggerSet.load(from: AppPreferences.shared.recordingTriggers)
+        guard triggerSet.triggers.contains(trigger) else { return }
+        triggerSet.remove(trigger)
+        AppPreferences.shared.recordingTriggers = triggerSet.json
     }
 
     private func clear() {
         mouseButton = .none
         modifierKey = .none
         KeyboardShortcuts.setShortcut(nil, for: name)
+        shortcut = nil
     }
 
     private func disarm() {

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyboardShortcuts
 
 enum TranscriptionResult {
     /// Returned by the engines when nothing intelligible was transcribed. It is shown to the
@@ -35,6 +36,31 @@ final class AppPreferences {
         migrateGroqToRemote()
         migrateAIProviderToBackend()
         migrateIndicatorLayout()
+        migrateRecordingTriggers()
+        resolveTriggerConflicts()
+    }
+
+    /// A key bound both as a recording trigger and as stop-and-submit can only do one of them:
+    /// the router checks submit first, so the trigger silently stops starting anything. Installs
+    /// that reached that state before the editor prevented it get the submit binding cleared,
+    /// since the trigger list is the one the user sees as a list. (#48)
+    private func resolveTriggerConflicts() {
+        let set = RecordingTriggerSet.load(from: recordingTriggers)
+        let clash = set.conflicts(
+            modifier: ModifierKey(rawValue: submitModifierOnlyHotkey) ?? .none,
+            mouse: MouseButton(rawValue: submitMouseButtonHotkey) ?? .none)
+        if clash.modifier { submitModifierOnlyHotkey = ModifierKey.none.rawValue }
+        if clash.mouse { submitMouseButtonHotkey = MouseButton.none.rawValue }
+    }
+
+    /// Carries the three single-slot trigger preferences into the list. Idempotent: only runs
+    /// while the new key is unset. The old keys stay readable so a downgrade still finds them.
+    private func migrateRecordingTriggers() {
+        guard recordingTriggers.isEmpty else { return }
+        recordingTriggers = RecordingTriggerSet.migrated(
+            mouseRaw: mouseButtonHotkey,
+            modifierRaw: modifierOnlyHotkey,
+            shortcut: KeyboardShortcuts.getShortcut(for: .toggleRecord)).json
     }
 
     /// Carry the old independent indicator switches into one ordered layout, so an existing
@@ -305,6 +331,12 @@ final class AppPreferences {
     /// "press enter" command, without saying it. "none" disables it. (#50)
     @UserDefault(key: "submitMouseButtonHotkey", defaultValue: "none")
     var submitMouseButtonHotkey: String
+
+    /// Recording triggers as JSON (`RecordingTriggerSet`): any number of key combinations,
+    /// single modifiers and mouse buttons, all live at once. Empty until
+    /// `migrateRecordingTriggers()` builds it from the three single-slot preferences. (#48)
+    @UserDefault(key: "recordingTriggers", defaultValue: "")
+    var recordingTriggers: String
 
     /// Single modifier for the same dictate-and-submit action. (#50)
     @UserDefault(key: "submitModifierOnlyHotkey", defaultValue: "none")

--- a/OpenSuperWhisperTests/RecordingTriggerTests.swift
+++ b/OpenSuperWhisperTests/RecordingTriggerTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KeyboardShortcuts
 import XCTest
 
 @testable import OpenSuperWhisper
@@ -89,5 +90,187 @@ final class RecordingTriggerResolveTests: XCTestCase {
     func testUnknownStoredValuesAreIgnored() {
         XCTAssertEqual(RecordingTrigger.resolve(mouseRaw: "button99", modifierRaw: "hyper", shortcut: nil),
                        .none)
+    }
+}
+
+/// Keyboard and mouse triggers coexist: a thumb button at the desk and a shortcut on the move,
+/// without a trip through Settings between them (#48).
+final class MultipleRecordingTriggersTests: XCTestCase {
+
+    @MainActor
+    private func combo() -> KeyboardShortcuts.Shortcut {
+        KeyboardShortcuts.Shortcut(.d, modifiers: [.command, .option])
+    }
+
+    @MainActor
+    func testAllConfiguredTriggersAreReturned() {
+        let triggers = RecordingTrigger.resolveAll(mouseRaw: "button4",
+                                                   modifierRaw: "rightOption",
+                                                   shortcut: combo())
+        XCTAssertEqual(triggers.count, 3)
+        XCTAssertTrue(triggers.contains(.mouse(.button4)))
+        XCTAssertTrue(triggers.contains(.modifier(.rightOption)))
+    }
+
+    /// The old resolver picked one by precedence, which is what made the modes exclusive.
+    /// Keeping it for the single-binding fields means both behaviours have to stay distinct.
+    @MainActor
+    func testSingleResolverStillPicksOneByPrecedence() {
+        let single = RecordingTrigger.resolve(mouseRaw: "button4",
+                                              modifierRaw: "rightOption",
+                                              shortcut: combo())
+        XCTAssertEqual(single, .mouse(.button4))
+    }
+
+    @MainActor
+    func testNothingConfiguredYieldsNoTriggers() {
+        XCTAssertTrue(RecordingTrigger.resolveAll(mouseRaw: "none", modifierRaw: "none",
+                                                  shortcut: nil).isEmpty)
+    }
+
+    @MainActor
+    func testPartialConfigurationReturnsOnlyWhatIsSet() {
+        let triggers = RecordingTrigger.resolveAll(mouseRaw: "none",
+                                                   modifierRaw: "fn",
+                                                   shortcut: nil)
+        XCTAssertEqual(triggers, [.modifier(.fn)])
+    }
+
+    /// Two triggers of the same kind can't coexist — there is one slot per kind — so recording a
+    /// second mouse button has to replace the first rather than accumulate.
+    @MainActor
+    func testKindsAreDistinctSoSameKindReplaces() {
+        XCTAssertEqual(RecordingTrigger.mouse(.button4).kind, RecordingTrigger.mouse(.button5).kind)
+        XCTAssertNotEqual(RecordingTrigger.mouse(.button4).kind, RecordingTrigger.modifier(.fn).kind)
+        XCTAssertNotEqual(RecordingTrigger.modifier(.fn).kind, RecordingTrigger.keyCombo(combo()).kind)
+    }
+
+    /// An unknown stored value must not become a phantom trigger the app can't act on.
+    @MainActor
+    func testUnknownStoredValuesAreSkipped() {
+        let triggers = RecordingTrigger.resolveAll(mouseRaw: "button99",
+                                                   modifierRaw: "hyper",
+                                                   shortcut: nil)
+        XCTAssertTrue(triggers.isEmpty)
+    }
+}
+
+/// The trigger list holds any number of each kind. The previous shape had one slot per kind —
+/// one shortcut, one modifier, one mouse button — so three was the ceiling however the UI was
+/// drawn (#48).
+final class RecordingTriggerSetTests: XCTestCase {
+
+    @MainActor
+    private func combo(_ key: KeyboardShortcuts.Key) -> KeyboardShortcuts.Shortcut {
+        KeyboardShortcuts.Shortcut(key, modifiers: [.command, .option])
+    }
+
+    @MainActor
+    func testHoldsSeveralOfTheSameKind() {
+        var set = RecordingTriggerSet.empty
+        set.add(.keyCombo(combo(.d)))
+        set.add(.keyCombo(combo(.k)))
+        set.add(.mouse(.button4))
+        set.add(.mouse(.button5))
+        set.add(.modifier(.rightOption))
+        set.add(.modifier(.fn))
+
+        XCTAssertEqual(set.keyCombos.count, 2)
+        XCTAssertEqual(set.mouseButtons, [.button4, .button5])
+        XCTAssertEqual(set.modifiers, [.rightOption, .fn])
+    }
+
+    /// Recording the same key twice should change nothing, not add a row that fires once.
+    @MainActor
+    func testDuplicatesAreIgnored() {
+        var set = RecordingTriggerSet.empty
+        set.add(.mouse(.button4))
+        set.add(.mouse(.button4))
+        XCTAssertEqual(set.triggers.count, 1)
+    }
+
+    func testEmptyTriggerIsNeverStored() {
+        var set = RecordingTriggerSet.empty
+        set.add(.none)
+        XCTAssertTrue(set.triggers.isEmpty)
+    }
+
+    @MainActor
+    func testRemoveTakesOnlyTheOneAskedFor() {
+        var set = RecordingTriggerSet.empty
+        set.add(.mouse(.button4))
+        set.add(.modifier(.fn))
+        set.add(.keyCombo(combo(.d)))
+
+        set.remove(.modifier(.fn))
+
+        XCTAssertEqual(set.triggers, [.mouse(.button4), .keyCombo(combo(.d))])
+    }
+
+    @MainActor
+    func testRoundTripsThroughJSON() {
+        var set = RecordingTriggerSet.empty
+        set.add(.keyCombo(combo(.d)))
+        set.add(.modifier(.rightCommand))
+        set.add(.mouse(.button7))
+        XCTAssertEqual(RecordingTriggerSet.load(from: set.json), set)
+    }
+
+    func testUnreadableStoredValueYieldsNoTriggers() {
+        XCTAssertEqual(RecordingTriggerSet.load(from: "not json"), .empty)
+        XCTAssertEqual(RecordingTriggerSet.load(from: ""), .empty)
+    }
+
+    /// Upgrading must keep whatever was configured before the list existed.
+    @MainActor
+    func testMigrationCarriesTheOldSlots() {
+        let set = RecordingTriggerSet.migrated(mouseRaw: "button4", modifierRaw: "rightOption",
+                                               shortcut: combo(.d))
+        XCTAssertEqual(set.triggers.count, 3)
+        XCTAssertTrue(set.mouseButtons.contains(.button4))
+        XCTAssertTrue(set.modifiers.contains(.rightOption))
+        XCTAssertEqual(set.keyCombos.count, 1)
+    }
+
+    func testMigrationOfAnUnconfiguredInstallIsEmpty() {
+        XCTAssertEqual(RecordingTriggerSet.migrated(mouseRaw: "none", modifierRaw: "none",
+                                                    shortcut: nil), .empty)
+    }
+}
+
+/// A key can only mean one thing. Bound as both a recording trigger and stop-and-submit, the
+/// router checks submit first, so the trigger silently stops starting anything — a working
+/// binding that looks broken with nothing on screen to explain it.
+final class TriggerConflictTests: XCTestCase {
+
+    private func set(modifier: ModifierKey? = nil, mouse: MouseButton? = nil) -> RecordingTriggerSet {
+        var set = RecordingTriggerSet.empty
+        if let modifier { set.add(.modifier(modifier)) }
+        if let mouse { set.add(.mouse(mouse)) }
+        return set
+    }
+
+    func testDetectsAModifierClaimedByBoth() {
+        let clash = set(modifier: .rightCommand).conflicts(modifier: .rightCommand, mouse: .none)
+        XCTAssertTrue(clash.modifier)
+        XCTAssertFalse(clash.mouse)
+    }
+
+    func testDetectsAMouseButtonClaimedByBoth() {
+        let clash = set(mouse: .button4).conflicts(modifier: .none, mouse: .button4)
+        XCTAssertTrue(clash.mouse)
+    }
+
+    func testDifferentKeysDoNotClash() {
+        let clash = set(modifier: .rightOption, mouse: .button4)
+            .conflicts(modifier: .rightCommand, mouse: .button5)
+        XCTAssertFalse(clash.modifier)
+        XCTAssertFalse(clash.mouse)
+    }
+
+    /// "none" means unbound on both sides and must never register as a collision.
+    func testUnboundNeverClashes() {
+        XCTAssertFalse(set(modifier: .rightOption).conflicts(modifier: .none, mouse: .none).modifier)
+        XCTAssertFalse(RecordingTriggerSet.empty.conflicts(modifier: .none, mouse: .none).mouse)
     }
 }


### PR DESCRIPTION
Closes #48.

## Beyond what the issue asked

@wolfkevin asked for a keyboard shortcut and a mouse button at the same time. Lifting the mutual exclusion covered that, and I shipped it that way first — then hit the real ceiling while testing: **storage held one slot per kind.** One `KeyboardShortcuts` name, one `modifierOnlyHotkey`, one `mouseButtonHotkey`. Three triggers maximum, one of each, however the UI was drawn.

Triggers are a list now, persisted as JSON. Two key combinations, three mouse buttons, whatever suits. Both monitors already accepted several inputs (they were widened for the submit key in #50); key combinations get one library registration slot each, and unused slots are unbound so a removed trigger stops listening rather than staying quietly live.

A migration carries the three old preferences into the list, so nothing configured is lost.

## Two bugs found while testing, both of the same shape

Each made a *working* binding look broken, which is the worst failure mode: nothing on screen suggests where to look.

**`KeyboardShortcuts.onKeyDown` appends handlers, it doesn't replace them** — literally `legacyKeyDownHandlers[name, default: []].append(action)`. I was re-registering inside `setupRecordingTrigger()`, which runs on every settings change. After two edits, one key press ran the toggle twice: start a recording, end it immediately. The reported symptom was "the mic fires but no interface", which is exactly that. Handlers are now registered once for the process lifetime; setup only binds and unbinds.

**A key bound to two actions goes to whichever the router checks first.** Right ⌘ was in the trigger list *and* set as stop-and-submit; submit is checked first and does nothing outside a recording, so the trigger never started anything. Assigning a key to either action now frees it from the other — last assignment wins, as in any shortcut editor — and installs already in that state are repaired at launch, since the fix would otherwise only apply to future assignments.

## Verification

319 tests, including 13 new ones on the list, its persistence and migration, and collision detection. Everything here was also exercised by hand on a signed build at the real app path, which is the only way these triggers can be tested at all — accessibility permissions are per-bundle-path.
