### PR TITLE
feat(a11y): scale text with the system setting, adjustable on top (#80)

### DIFF
--- a/OpenSuperWhisper/AppContextSettingsView.swift
+++ b/OpenSuperWhisper/AppContextSettingsView.swift
@@ -26,7 +26,7 @@ struct AppContextSettingsView: View {
                 SSection(title: "Model switching") {
                     HStack(spacing: 5) {
                         Text("When the front app changes")
-                            .font(.system(size: 13)).foregroundColor(STheme.text)
+                            .scaledFont(size: 13).foregroundColor(STheme.text)
                         InfoButton(text: "Bind a transcription model to an app (or a website, in supported browsers) so it switches automatically when you dictate there. Add a rule below (＋), or from the menu-bar “Model” submenu while that app is focused.\n\n• Ask on change — auto-switch by app, and ask the scope (System Default / this app / just once / forget) whenever you pick a model in the menu.\n• Auto · no prompt — auto-switch by app, but picking a model just sets the system default (no prompt). Set rules up in “Ask”, then switch here.\n• Off — no auto-switch and no prompts.")
                         Spacer()
                         Picker("", selection: $viewModel.contextAwareModelMode) {
@@ -47,7 +47,7 @@ struct AppContextSettingsView: View {
                             (Text("No rules yet.\n").foregroundColor(STheme.hint)
                                 + Text("Click ＋ to add an app, or bind a model from the menu-bar “Model” submenu while an app is focused.")
                                     .foregroundColor(STheme.hint.opacity(0.75)))
-                                .font(.system(size: 11.5))
+                                .scaledFont(size: 11.5)
                                 .multilineTextAlignment(.center)
                                 .lineSpacing(3)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -120,7 +120,7 @@ struct AppContextSettingsView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     if viewModel.appContextProfiles.isEmpty {
                         Text("No apps yet. Add one below.")
-                            .font(.system(size: 11)).foregroundColor(STheme.hint)
+                            .scaledFont(size: 11).foregroundColor(STheme.hint)
                             .padding(.vertical, 4)
                     }
                     ForEach($viewModel.appContextProfiles) { $profile in
@@ -136,16 +136,16 @@ struct AppContextSettingsView: View {
                                             .frame(width: 20, height: 20)
                                         VStack(alignment: .leading, spacing: 1) {
                                             Text(profile.appName.isEmpty ? "Choose an app…" : profile.appName)
-                                                .font(.system(size: 12))
+                                                .scaledFont(size: 12)
                                                 .foregroundColor(profile.appName.isEmpty ? STheme.hint : STheme.text)
                                             if !profile.bundleIdentifier.isEmpty {
                                                 Text(profile.bundleIdentifier)
-                                                    .font(.system(size: 10))
+                                                    .scaledFont(size: 10)
                                                     .foregroundColor(STheme.hint)
                                             }
                                         }
                                         Image(systemName: "chevron.up.chevron.down")
-                                            .font(.system(size: 9))
+                                            .scaledFont(size: 9)
                                             .foregroundColor(STheme.hint)
                                         Spacer()
                                     }
@@ -158,7 +158,7 @@ struct AppContextSettingsView: View {
                                     viewModel.appContextProfiles.removeAll { $0.id == profile.id }
                                 } label: {
                                     Image(systemName: "trash")
-                                        .font(.system(size: 11))
+                                        .scaledFont(size: 11)
                                         .foregroundColor(STheme.hint)
                                 }
                                 .buttonStyle(.plain)
@@ -174,7 +174,7 @@ struct AppContextSettingsView: View {
                         showingAppPicker = true
                     } label: {
                         Label("Add App", systemImage: "plus")
-                            .font(.system(size: 11.5, weight: .medium))
+                            .scaledFont(size: 11.5, weight: .medium)
                     }
                     .controlSize(.small)
                 }

--- a/OpenSuperWhisper/AppleSpeechModelSection.swift
+++ b/OpenSuperWhisper/AppleSpeechModelSection.swift
@@ -42,7 +42,7 @@ struct AppleSpeechModelSection: View {
                 HStack(spacing: 8) {
                     ProgressView().controlSize(.small)
                     Text("Checking the system speech model…")
-                        .font(.system(size: 11.5))
+                        .scaledFont(size: 11.5)
                         .foregroundColor(STheme.hint)
                 }
             } else {
@@ -54,7 +54,7 @@ struct AppleSpeechModelSection: View {
             }
 
             if let errorMessage {
-                Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
+                Text(errorMessage).scaledFont(size: 11).foregroundColor(.red)
             }
 
             if variants.count > 1 {
@@ -79,7 +79,7 @@ struct AppleSpeechModelSection: View {
             }
 
             Text("The model is built into macOS: downloaded per language by the system, shared across apps, and updated with the OS — nothing is stored in the app. Selecting a language here also sets the transcription language. macOS keeps up to 5 languages reserved per app; beyond that the app rotates automatically.")
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(STheme.hint)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/OpenSuperWhisper/ContentView.swift
+++ b/OpenSuperWhisper/ContentView.swift
@@ -483,7 +483,7 @@ struct ContentView: View {
                                 if !debouncedSearchText.isEmpty {
                                     // Show "no results" for search
                                     Image(systemName: "magnifyingglass")
-                                        .font(.system(size: 40))
+                                        .scaledFont(size: 40)
                                         .foregroundColor(.secondary)
                                         .padding(.top, 40)
 
@@ -499,7 +499,7 @@ struct ContentView: View {
                                 } else {
                                     // Show "start recording" tip
                                     Image(systemName: "arrow.down.circle")
-                                        .font(.system(size: 40))
+                                        .scaledFont(size: 40)
                                         .foregroundColor(.secondary)
                                         .padding(.top, 40)
 
@@ -524,7 +524,7 @@ struct ContentView: View {
                                                     .font(.subheadline)
                                                     .foregroundColor(.secondary)
                                                 Text(shortcut.description)
-                                                    .font(.system(size: 16, weight: .medium))
+                                                    .scaledFont(size: 16, weight: .medium)
                                                     .padding(.horizontal, 6)
                                                     .padding(.vertical, 3)
                                                     .background(Color.secondary.opacity(0.2))
@@ -1142,7 +1142,7 @@ struct RecordingRow: View {
                             }
                         }) {
                             Image(systemName: isPlaying ? "stop.circle.fill" : "play.circle.fill")
-                                .font(.system(size: 20))
+                                .scaledFont(size: 20)
                                 .foregroundColor(isPlaying ? .red : ThemePalette.iconAccent(colorScheme))
                                 .contentTransition(.symbolEffect(.replace))
                         }
@@ -1156,7 +1156,7 @@ struct RecordingRow: View {
                             )
                         }) {
                             Image(systemName: "doc.on.doc.fill")
-                                .font(.system(size: 18))
+                                .scaledFont(size: 18)
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(.plain)
@@ -1171,7 +1171,7 @@ struct RecordingRow: View {
                         HStack(spacing: 1) {
                             Button(action: { onRegenerate(nil) }) {
                                 Image(systemName: "arrow.clockwise")
-                                    .font(.system(size: 18))
+                                    .scaledFont(size: 18)
                                     .foregroundColor(.secondary)
                             }
                             .buttonStyle(.plain)
@@ -1187,7 +1187,7 @@ struct RecordingRow: View {
                                 }
                             } label: {
                                 Image(systemName: "chevron.down")
-                                    .font(.system(size: 9, weight: .semibold))
+                                    .scaledFont(size: 9, weight: .semibold)
                                     .foregroundColor(.secondary)
                             }
                             .menuStyle(.button)
@@ -1207,7 +1207,7 @@ struct RecordingRow: View {
                             onDelete()
                         }) {
                             Image(systemName: "trash.fill")
-                                .font(.system(size: 18))
+                                .scaledFont(size: 18)
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(.plain)

--- a/OpenSuperWhisper/FileDropHandler.swift
+++ b/OpenSuperWhisper/FileDropHandler.swift
@@ -61,7 +61,7 @@ struct FileDropOverlay: ViewModifier {
                             .opacity(0.95)
                         VStack(spacing: 16) {
                             Image(systemName: "arrow.down.circle")
-                                .font(.system(size: 48))
+                                .scaledFont(size: 48)
                                 .foregroundColor(.accentColor)
                                 .symbolEffect(.bounce, value: handler.isDragging)
                             Text("Drop audio files to transcribe")

--- a/OpenSuperWhisper/Indicator/IndicatorElementView.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorElementView.swift
@@ -23,7 +23,7 @@ struct IndicatorElementView: View {
             InputLevelMeter(bands: bands, height: meterHeight)
         case .label:
             Text(queued > 0 ? "Recording… · \(queued) queued" : "Recording…")
-                .font(.system(size: 13, weight: .semibold))
+                .scaledFont(size: 13, weight: .semibold)
                 .foregroundColor(.secondary)
                 // The bubble is a fixed width, so the label would wrap rather than widen it.
                 // One line always: a two-line "Recording…" is worse than a truncated one.
@@ -45,7 +45,7 @@ struct IndicatorElementView: View {
                         action: @escaping () -> Void) -> some View {
         Button { if isInteractive { action() } } label: {
             Image(systemName: symbol)
-                .font(.system(size: size, weight: .regular))
+                .scaledFont(size: size, weight: .regular)
                 .foregroundColor(.red)
                 .frame(width: 24, height: 24)
                 .contentShape(Rectangle())

--- a/OpenSuperWhisper/Indicator/IndicatorLayoutEditor.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorLayoutEditor.swift
@@ -65,7 +65,7 @@ struct IndicatorLayoutEditor: View {
     private var preview: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Preview")
-                .font(.system(size: 11, weight: .medium))
+                .scaledFont(size: 11, weight: .medium)
                 .foregroundColor(STheme.hint)
             ZStack {
                 RoundedRectangle(cornerRadius: 10).fill(STheme.inputBg)
@@ -121,10 +121,10 @@ struct IndicatorLayoutEditor: View {
     private var elementList: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Elements")
-                .font(.system(size: 11, weight: .medium))
+                .scaledFont(size: 11, weight: .medium)
                 .foregroundColor(STheme.hint)
             Text("Drag the handle to reorder, including elements that are switched off. Buttons always sit at the trailing edge, so they have no handle.")
-                .font(.system(size: 10.5))
+                .scaledFont(size: 10.5)
                 .foregroundColor(STheme.hint)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -155,7 +155,7 @@ struct IndicatorLayoutEditor: View {
                 Color.clear.frame(width: 16, height: 20)
             } else {
                 Image(systemName: "line.3.horizontal")
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.hint)
                     .frame(width: 16, height: 20)
                     .contentShape(Rectangle())
@@ -166,15 +166,15 @@ struct IndicatorLayoutEditor: View {
                     .pointerCursorOnHover()
             }
             Image(systemName: element.symbol)
-                .font(.system(size: 12))
+                .scaledFont(size: 12)
                 .foregroundColor(visible ? STheme.accent : STheme.hint)
                 .frame(width: 18)
             VStack(alignment: .leading, spacing: 1) {
                 Text(element.title)
-                    .font(.system(size: 12, weight: .medium))
+                    .scaledFont(size: 12, weight: .medium)
                     .foregroundColor(visible ? STheme.textBright : STheme.hint)
                 Text(element.subtitle)
-                    .font(.system(size: 10.5))
+                    .scaledFont(size: 10.5)
                     .foregroundColor(STheme.hint)
             }
             Spacer(minLength: 8)
@@ -204,7 +204,7 @@ struct IndicatorLayoutEditor: View {
                         .frame(width: 150)
                         .tint(STheme.accent)
                     Text("\(Int(layout.waveformHeight))pt")
-                        .font(.system(size: 11, design: .monospaced))
+                        .scaledFont(size: 11, design: .monospaced)
                         .foregroundColor(STheme.hint)
                         .frame(width: 34, alignment: .trailing)
                 }

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -497,7 +497,7 @@ struct IndicatorWindow: View {
                 Button { IndicatorWindowManager.shared.stopRecording() } label: {
                     // A red ring with a red stop square inside (transparent interior).
                     Image(systemName: "stop.circle")
-                        .font(.system(size: 19, weight: .regular))
+                        .scaledFont(size: 19, weight: .regular)
                         .foregroundColor(.red)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
@@ -510,7 +510,7 @@ struct IndicatorWindow: View {
                 Button { IndicatorWindowManager.shared.stopForce() } label: {
                     // A plain red trash can — discard without transcribing.
                     Image(systemName: "trash")
-                        .font(.system(size: 16, weight: .regular))
+                        .scaledFont(size: 16, weight: .regular)
                         .foregroundColor(.red)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
@@ -538,7 +538,7 @@ struct IndicatorWindow: View {
                         .frame(width: 24)
                     
                     Text("Connecting...")
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                 }                
             case .recording:
                 if streaming.confirmedText.isEmpty && streaming.volatileText.isEmpty {
@@ -546,7 +546,7 @@ struct IndicatorWindow: View {
                     HStack(alignment: .center, spacing: 10) {
                         if viewModel.isConfirmingCancel {
                             Text("Press Esc to cancel")
-                                .font(.system(size: 12, weight: .semibold))
+                                .scaledFont(size: 12, weight: .semibold)
                                 .foregroundColor(.orange)
                                 .transition(.opacity)
                         } else {
@@ -585,7 +585,7 @@ struct IndicatorWindow: View {
                         (Text(streaming.confirmedText).foregroundColor(.primary)
                             + Text(streaming.confirmedText.isEmpty ? "" : " ")
                             + Text(streaming.volatileText).foregroundColor(.secondary))
-                            .font(.system(size: 14))
+                            .scaledFont(size: 14)
                             .fixedSize(horizontal: false, vertical: true)
                             .frame(width: 300, alignment: .leading)
                         if anyIndicatorButton {
@@ -604,7 +604,7 @@ struct IndicatorWindow: View {
                         .frame(width: 24, height: 16)
 
                     Text("Transcribing...")
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                 }                
             case .busy:
                 HStack(spacing: 8) {
@@ -613,7 +613,7 @@ struct IndicatorWindow: View {
                         .frame(width: 24)
                     
                     Text("Processing...")
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                         .foregroundColor(.orange)
                 }                
             case .error(let message):
@@ -623,7 +623,7 @@ struct IndicatorWindow: View {
                         .frame(width: 24)
 
                     Text(message)
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                         .foregroundColor(.red)
                 }
             case .info(let message):
@@ -633,7 +633,7 @@ struct IndicatorWindow: View {
                         .frame(width: 24)
 
                     Text(message)
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                         .foregroundColor(.primary)
                 }
             case .idle:

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -70,6 +70,9 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             rootView: IndicatorWindow(viewModel: newViewModel) { [weak self] size in
                 self?.resizeToContent(size)
             }
+            // Read once per presentation rather than observed: the bubble is short-lived, and a
+            // size change mid-recording would resize the window under the user (#80).
+            .environment(\.appTextScale, AppPreferences.shared.textScale)
         )
         hostingController.sizingOptions = Self.hostingSizingOptions
         window?.contentViewController = hostingController

--- a/OpenSuperWhisper/Onboarding/OnboardingView.swift
+++ b/OpenSuperWhisper/Onboarding/OnboardingView.swift
@@ -341,7 +341,7 @@ struct OnboardingView: View {
                         .foregroundColor(.secondary)
                     
                     Text("OpenSuperWhisper")
-                        .font(.system(size: 32, weight: .bold))
+                        .scaledFont(size: 32, weight: .bold)
                         .foregroundStyle(
                             .white
                         )
@@ -451,11 +451,11 @@ struct OnboardingView: View {
                         Button(action: { viewModel.selectRemote() }) {
                             HStack(spacing: 10) {
                                 Image(systemName: "cloud")
-                                    .font(.system(size: 18))
+                                    .scaledFont(size: 18)
                                     .foregroundColor(.accentColor)
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text("Use a remote server")
-                                        .font(.system(size: 13, weight: .semibold))
+                                        .scaledFont(size: 13, weight: .semibold)
                                     Text("OpenAI-compatible API (Groq, or your own server). Set the endpoint and key in Settings after setup.")
                                         .font(.caption2)
                                         .foregroundColor(.secondary)
@@ -493,7 +493,7 @@ struct OnboardingView: View {
                     HStack(spacing: 6) {
                         Text("Continue")
                         Image(systemName: "arrow.right")
-                            .font(.system(size: 12, weight: .semibold))
+                            .scaledFont(size: 12, weight: .semibold)
                     }
                     .frame(minWidth: 100)
                 }
@@ -653,7 +653,7 @@ private struct KeyCap: View {
     
     var body: some View {
         Text(label)
-            .font(.system(size: w > 20 ? 9 : 7, weight: .medium))
+            .scaledFont(size: w > 20 ? 9 : 7, weight: .medium)
             .lineLimit(2)
             .multilineTextAlignment(.center)
             .frame(width: w, height: h)

--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -60,6 +60,7 @@ struct OpenSuperWhisperApp: App {
         // Dedicated, movable & closable settings window (sidebar layout).
         Window("Settings", id: "settings") {
             SettingsView()
+                .environment(\.appTextScale, AppPreferences.shared.textScale)
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 780, height: 600)

--- a/OpenSuperWhisper/RemoteCleanupSettingsView.swift
+++ b/OpenSuperWhisper/RemoteCleanupSettingsView.swift
@@ -21,7 +21,7 @@ struct RemoteCleanupSettingsView: View {
                 TextField("", text: $viewModel.aiRemoteEndpoint,
                           prompt: Text("https://api.groq.com/openai/v1"))
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12, design: .monospaced))
+                    .scaledFont(size: 12, design: .monospaced)
                     .autocorrectionDisabled(true)
                     .padding(.horizontal, 9).padding(.vertical, 5)
                     .frame(width: 260)
@@ -39,7 +39,7 @@ struct RemoteCleanupSettingsView: View {
                         }
                     }
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12, design: .monospaced))
+                    .scaledFont(size: 12, design: .monospaced)
                     .autocorrectionDisabled(true)
                     .padding(.horizontal, 9).padding(.vertical, 5)
                     .frame(width: 220)
@@ -47,7 +47,7 @@ struct RemoteCleanupSettingsView: View {
                     .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.controlBorder, lineWidth: 1))
                     Button { revealKey.toggle() } label: {
                         Image(systemName: revealKey ? "eye.slash" : "eye")
-                            .font(.system(size: 11))
+                            .scaledFont(size: 11)
                             .foregroundColor(STheme.hint)
                     }
                     .buttonStyle(.plain)
@@ -70,7 +70,7 @@ struct RemoteCleanupSettingsView: View {
             .padding(.leading, 16)
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Model").font(.system(size: 11)).foregroundColor(STheme.hint)
+                Text("Model").scaledFont(size: 11).foregroundColor(STheme.hint)
                 RemoteModelListBox(
                     models: availableModels,
                     isCustom: $isCustomModel,

--- a/OpenSuperWhisper/RemoteModelListBox.swift
+++ b/OpenSuperWhisper/RemoteModelListBox.swift
@@ -91,16 +91,16 @@ struct RemoteModelListBox: View {
             if models.count > 5 {
                 HStack(spacing: 6) {
                     Image(systemName: "magnifyingglass")
-                        .font(.system(size: 10))
+                        .scaledFont(size: 10)
                         .foregroundColor(STheme.hint)
                     TextField("", text: $modelSearchText, prompt: Text("Filter models…"))
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12))
+                        .scaledFont(size: 12)
                         .autocorrectionDisabled(true)
                     if !modelSearchText.isEmpty {
                         Button { modelSearchText = "" } label: {
                             Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 10))
+                                .scaledFont(size: 10)
                                 .foregroundColor(STheme.hint)
                         }
                         .buttonStyle(.plain)
@@ -117,7 +117,7 @@ struct RemoteModelListBox: View {
                 VStack(spacing: 0) {
                     if visibleModels.isEmpty && !modelSearchText.isEmpty {
                         Text("No models match \"\(modelSearchText)\"")
-                            .font(.system(size: 11)).foregroundColor(STheme.hint)
+                            .scaledFont(size: 11).foregroundColor(STheme.hint)
                             .frame(maxWidth: .infinity, alignment: .center)
                             .padding(.vertical, 14)
                     }
@@ -156,7 +156,7 @@ struct RemoteModelListBox: View {
                                 .foregroundColor(STheme.hint)
                         }
                     }
-                    .font(.system(size: 11.5))
+                    .scaledFont(size: 11.5)
                 }
                 .buttonStyle(.plain)
             }
@@ -166,14 +166,14 @@ struct RemoteModelListBox: View {
                 // GET /v1/models without credentials, so the list stays empty until
                 // a key is set and Test Connection runs.
                 Text("The server's models are listed here after a successful Test Connection — most providers (e.g. Groq) need the API key set first.")
-                    .font(.system(size: 11)).foregroundColor(STheme.hint)
+                    .scaledFont(size: 11).foregroundColor(STheme.hint)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             if isCustom {
                 TextField("", text: $customText, prompt: Text(customPrompt))
                     .textFieldStyle(.plain)
-                    .font(.system(size: 12, design: .monospaced))
+                    .scaledFont(size: 12, design: .monospaced)
                     .autocorrectionDisabled(true)
                     .padding(.horizontal, 9).padding(.vertical, 5)
                     .background(RoundedRectangle(cornerRadius: 7).fill(STheme.inputBg))
@@ -191,12 +191,12 @@ struct RemoteModelListBox: View {
                     .overlay(Circle().stroke(selected ? STheme.accent : STheme.controlBorder, lineWidth: 1.5))
                     .frame(width: 8, height: 8)
                 Text(name)
-                    .font(.system(size: 12.5, design: .monospaced))
+                    .scaledFont(size: 12.5, design: .monospaced)
                     .foregroundColor(selected ? STheme.textBright : STheme.text)
                 Spacer()
                 if selected {
                     Text("ACTIVE")
-                        .font(.system(size: 10, weight: .bold))
+                        .scaledFont(size: 10, weight: .bold)
                         .tracking(0.5)
                         .foregroundColor(STheme.accent)
                 }

--- a/OpenSuperWhisper/RemoteServerSettingsView.swift
+++ b/OpenSuperWhisper/RemoteServerSettingsView.swift
@@ -37,7 +37,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                     TextField("", text: $viewModel.remoteServerURL,
                               prompt: Text("http://localhost:11434"))
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12, design: .monospaced))
+                        .scaledFont(size: 12, design: .monospaced)
                         .autocorrectionDisabled(true)
                         .padding(.horizontal, 9).padding(.vertical, 5)
                         .frame(width: 280)
@@ -56,7 +56,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                             }
                         }
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12, design: .monospaced))
+                        .scaledFont(size: 12, design: .monospaced)
                         .autocorrectionDisabled(true)
                         .padding(.horizontal, 9).padding(.vertical, 5)
                         .frame(width: 240)
@@ -64,7 +64,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.controlBorder, lineWidth: 1))
                         Button { revealKey.toggle() } label: {
                             Image(systemName: revealKey ? "eye.slash" : "eye")
-                                .font(.system(size: 11))
+                                .scaledFont(size: 11)
                                 .foregroundColor(STheme.hint)
                         }
                         .buttonStyle(.plain)
@@ -91,13 +91,13 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                         if viewModel.remoteServerTimeoutEnabled {
                             TextField("", value: $viewModel.remoteServerTimeoutSeconds, format: .number)
                                 .textFieldStyle(.plain)
-                                .font(.system(size: 12, design: .monospaced))
+                                .scaledFont(size: 12, design: .monospaced)
                                 .multilineTextAlignment(.trailing)
                                 .padding(.horizontal, 9).padding(.vertical, 4)
                                 .frame(width: 56)
                                 .background(RoundedRectangle(cornerRadius: 7).fill(STheme.inputBg))
                                 .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.controlBorder, lineWidth: 1))
-                            Text("s").font(.system(size: 11)).foregroundColor(STheme.hint)
+                            Text("s").scaledFont(size: 11).foregroundColor(STheme.hint)
                         }
                         SToggle(isOn: $viewModel.remoteServerTimeoutEnabled)
                     }
@@ -155,7 +155,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
         Group {
             if !hasAnyLocalModel {
                 Text("To enable local fallback, download an on-device model first (Models → Whisper or Parakeet).")
-                    .font(.system(size: 11)).foregroundColor(STheme.hint)
+                    .scaledFont(size: 11).foregroundColor(STheme.hint)
                     .fixedSize(horizontal: false, vertical: true)
             } else {
                 SRow(title: "Local fallback", hint: "Transcribe locally if the server is unreachable") {
@@ -165,7 +165,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                     let models = localFallbackModels
                     if models.isEmpty {
                         Text("Translate to English is on, but no Whisper model is downloaded — only Whisper supports translation. Download one under Models.")
-                            .font(.system(size: 11)).foregroundColor(STheme.warn)
+                            .scaledFont(size: 11).foregroundColor(STheme.warn)
                             .fixedSize(horizontal: false, vertical: true)
                             .padding(.leading, 16)
                     } else {
@@ -180,7 +180,7 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
                         }
                         if viewModel.translateToEnglish {
                             Text("Translate to English is on, so only Whisper models are offered — Parakeet and SenseVoice can't translate.")
-                                .font(.system(size: 11)).foregroundColor(STheme.warn)
+                                .scaledFont(size: 11).foregroundColor(STheme.warn)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .padding(.leading, 16)
                         }
@@ -234,13 +234,13 @@ struct RemoteServerSettingsView<PresetRow: View>: View {
             ProgressView().controlSize(.small)
         case .success(let message):
             Text("✓ \(message)")
-                .font(.system(size: 11, weight: .semibold))
+                .scaledFont(size: 11, weight: .semibold)
                 .foregroundColor(STheme.ok)
                 .padding(.horizontal, 9).padding(.vertical, 2)
                 .background(Capsule().fill(STheme.okBg))
         case .failure(let message):
             Text("✕ \(message)")
-                .font(.system(size: 11, weight: .semibold))
+                .scaledFont(size: 11, weight: .semibold)
                 .foregroundColor(.red)
                 .padding(.horizontal, 9).padding(.vertical, 2)
                 .background(Capsule().fill(Color.red.opacity(0.12)))

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -302,6 +302,10 @@ class SettingsViewModel: ObservableObject {
     @Published var pasteMouseButtonUnused: MouseButton = .none
     @Published var pasteModifierUnused: ModifierKey = .none
 
+    @Published var textScale: Double {
+        didSet { AppPreferences.shared.textScale = TextScale.clamped(textScale) }
+    }
+
     @Published var indicatorMeterMode: String {
         didSet {
             AppPreferences.shared.indicatorMeterMode = indicatorMeterMode
@@ -702,6 +706,7 @@ class SettingsViewModel: ObservableObject {
         self.startHidden = prefs.startHidden
         self.indicatorPosition = prefs.indicatorPosition
         self.indicatorMeterMode = prefs.indicatorMeterMode
+        self.textScale = prefs.textScale
         self.submitMouseButtonHotkey = MouseButton(rawValue: prefs.submitMouseButtonHotkey) ?? .none
         self.submitModifierOnlyHotkey = ModifierKey(rawValue: prefs.submitModifierOnlyHotkey) ?? .none
         self.showStopButtonOnIndicator = prefs.showStopButtonOnIndicator
@@ -1201,7 +1206,7 @@ struct InfoButton: View {
             isShown.toggle()
         } label: {
             Image(systemName: "info.circle")
-                .font(.system(size: 12))
+                .scaledFont(size: 12)
                 .foregroundColor(.secondary)
         }
         .buttonStyle(.plain)
@@ -1338,7 +1343,7 @@ struct SettingsView: View {
     private var feedbackSettings: some View {
         SPane(title: "Feedback", subtitle: "Help us improve") {
             Text("OpenSuperWhisper gets better with your feedback. Hit a bug, or have an idea? Tell us — every report helps make it more stable.")
-                .font(.system(size: 12))
+                .scaledFont(size: 12)
                 .foregroundColor(STheme.hint)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -1368,21 +1373,21 @@ struct SettingsView: View {
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: icon)
-                    .font(.system(size: 15))
+                    .scaledFont(size: 15)
                     .foregroundColor(STheme.accent)
                     .frame(width: 28)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .font(.system(size: 13, weight: .semibold))
+                        .scaledFont(size: 13, weight: .semibold)
                         .foregroundColor(STheme.textBright)
                     Text(subtitle)
-                        .font(.system(size: 11))
+                        .scaledFont(size: 11)
                         .foregroundColor(STheme.hint)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer()
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 10))
+                    .scaledFont(size: 10)
                     .foregroundColor(STheme.hint)
             }
             .padding(12)
@@ -1401,11 +1406,11 @@ struct SettingsView: View {
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: tab.icon)
-                    .font(.system(size: compact ? 11 : 12, weight: .medium))
+                    .scaledFont(size: compact ? 11 : 12, weight: .medium)
                     .frame(width: 18, alignment: .center)
                     .foregroundColor(selectedTab == tab ? STheme.accent : STheme.hint)
                 Text(tab.title)
-                    .font(.system(size: compact ? 12 : 13, weight: .medium))
+                    .scaledFont(size: compact ? 12 : 13, weight: .medium)
                 Spacer(minLength: 0)
                 if tab == .updates && availableUpdateTag != nil {
                     Circle().fill(STheme.accent).frame(width: 6, height: 6)
@@ -1436,15 +1441,15 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Image(systemName: "magnifyingglass")
-                        .font(.system(size: 10))
+                        .scaledFont(size: 10)
                         .foregroundColor(STheme.hint)
                     TextField("Search…", text: $sidebarSearch)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 12))
+                        .scaledFont(size: 12)
                         .foregroundColor(STheme.text)
                         .focused($sidebarSearchFocused)
                     Text("⌘F")
-                        .font(.system(size: 10, design: .monospaced))
+                        .scaledFont(size: 10, design: .monospaced)
                         .foregroundColor(STheme.hint)
                         .padding(.horizontal, 5).padding(.vertical, 1)
                         .background(RoundedRectangle(cornerRadius: 4).fill(STheme.controlBg))
@@ -1473,10 +1478,10 @@ struct SettingsView: View {
                 } label: {
                     HStack(spacing: 10) {
                         Image(systemName: "heart")
-                            .font(.system(size: 11, weight: .medium))
+                            .scaledFont(size: 11, weight: .medium)
                             .frame(width: 18, alignment: .center)
                             .foregroundColor(STheme.hint)
-                        Text("Support us").font(.system(size: 12, weight: .medium))
+                        Text("Support us").scaledFont(size: 12, weight: .medium)
                         Spacer(minLength: 0)
                     }
                     .padding(.horizontal, 10).padding(.vertical, 5)
@@ -1492,7 +1497,7 @@ struct SettingsView: View {
                                 .renderingMode(.template)
                                 .frame(width: 13, height: 13)
                             Text("v\(UpdateChecker.currentVersion)")
-                                .font(.system(size: 10.5, design: .monospaced))
+                                .scaledFont(size: 10.5, design: .monospaced)
                         }
                         .foregroundColor(STheme.hint.opacity(0.8))
                         .contentShape(Rectangle())
@@ -1501,7 +1506,7 @@ struct SettingsView: View {
                     Spacer()
                     Link(destination: URL(string: "https://github.com/my-monkeys/OpenSuperWhisper")!) {
                         Image(systemName: "star")
-                            .font(.system(size: 10))
+                            .scaledFont(size: 10)
                             .foregroundColor(STheme.hint.opacity(0.8))
                     }
                     .help("Star us on GitHub")
@@ -1568,11 +1573,11 @@ struct SettingsView: View {
         Button { browseEngine = tag } label: {
             VStack(alignment: .leading, spacing: 1) {
                 Text(name)
-                    .font(.system(size: 13, weight: .semibold))
+                    .scaledFont(size: 13, weight: .semibold)
                     .foregroundColor(browseEngine == tag ? STheme.accent : STheme.text)
                     .lineLimit(1)
                 Text(sub)
-                    .font(.system(size: 10.5))
+                    .scaledFont(size: 10.5)
                     .foregroundColor(STheme.hint)
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
@@ -1592,7 +1597,7 @@ struct SettingsView: View {
     private var activeModelPill: some View {
         let model = ModelCatalog.activeOption()?.displayName
         return Text("● Active · \(engineDisplayName(viewModel.selectedEngine))\(model.map { " / \($0)" } ?? "")")
-            .font(.system(size: 11, weight: .semibold))
+            .scaledFont(size: 11, weight: .semibold)
             .foregroundColor(STheme.ok)
             .lineLimit(1)
             .truncationMode(.middle)
@@ -1614,7 +1619,7 @@ struct SettingsView: View {
                 }
                 if let downloadingName = viewModel.downloadingModelName {
                     Text(downloadingName)
-                        .font(.system(size: 11, design: .monospaced))
+                        .scaledFont(size: 11, design: .monospaced)
                         .foregroundColor(STheme.hint)
                         .lineLimit(1)
                 }
@@ -1641,7 +1646,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("Models")
-                    .font(.system(size: 16, weight: .bold))
+                    .scaledFont(size: 16, weight: .bold)
                     .foregroundColor(STheme.textBright)
                 Spacer()
                 activeModelPill
@@ -1666,7 +1671,7 @@ struct SettingsView: View {
                     Text("⚠︎")
                     Text("Audio is uploaded to the remote server — not necessarily on-device.")
                 }
-                .font(.system(size: 11.5))
+                .scaledFont(size: 11.5)
                 .foregroundColor(STheme.warn)
                 .padding(.horizontal, 11).padding(.vertical, 7)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -1731,7 +1736,7 @@ struct SettingsView: View {
     private func sInput(_ text: Binding<String>, prompt: String, width: CGFloat, mono: Bool = false) -> some View {
         TextField("", text: text, prompt: Text(prompt))
             .textFieldStyle(.plain)
-            .font(.system(size: 12, design: mono ? .monospaced : .default))
+            .scaledFont(size: 12, design: mono ? .monospaced : .default)
             .autocorrectionDisabled(true)
             .padding(.horizontal, 9).padding(.vertical, 5)
             .frame(width: width)
@@ -1762,21 +1767,21 @@ struct SettingsView: View {
         HStack(spacing: 8) {
             if viewModel.builtInModelDownloaded {
                 Text("✓ Model ready — runs on-device")
-                    .font(.system(size: 11, weight: .semibold))
+                    .scaledFont(size: 11, weight: .semibold)
                     .foregroundColor(STheme.ok)
                     .padding(.horizontal, 9).padding(.vertical, 2)
                     .background(Capsule().fill(STheme.okBg))
                 Text("Loads on first use (a few seconds), then frees its ~1 GB after 5 minutes idle.")
-                    .font(.system(size: 11)).foregroundColor(STheme.hint)
+                    .scaledFont(size: 11).foregroundColor(STheme.hint)
                     .fixedSize(horizontal: false, vertical: true)
             } else if let progress = viewModel.builtInModelDownloadProgress {
                 ProgressView(value: progress).frame(width: 160).controlSize(.small)
-                Text("\(Int(progress * 100))%").font(.system(size: 11)).foregroundColor(STheme.hint)
+                Text("\(Int(progress * 100))%").scaledFont(size: 11).foregroundColor(STheme.hint)
             } else {
                 Button("Download model (~1 GB)") { viewModel.downloadBuiltInModel() }
                     .controlSize(.small)
                 Text("Qwen2.5 1.5B, Apache-2.0. One-time download; no server needed.")
-                    .font(.system(size: 11)).foregroundColor(STheme.hint)
+                    .scaledFont(size: 11).foregroundColor(STheme.hint)
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
@@ -1784,7 +1789,7 @@ struct SettingsView: View {
         .padding(.leading, 16)
         if let err = viewModel.builtInModelDownloadError {
             Text("✕ \(err)")
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(.red)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.leading, 16)
@@ -1800,7 +1805,7 @@ struct SettingsView: View {
             ProgressView().controlSize(.small)
         case .ok:
             Text("✓ Connected — model ready")
-                .font(.system(size: 11, weight: .semibold))
+                .scaledFont(size: 11, weight: .semibold)
                 .foregroundColor(STheme.ok)
                 .padding(.horizontal, 9).padding(.vertical, 2)
                 .background(Capsule().fill(STheme.okBg))
@@ -1808,19 +1813,19 @@ struct SettingsView: View {
             Text(isRemote
                 ? "Reachable, but “\(model)” isn't in the server's model list"
                 : "Reachable, but “\(model)” isn't pulled — run: ollama pull \(model)")
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(STheme.warn)
                 .fixedSize(horizontal: false, vertical: true)
         case .authFailed:
             Text("✕ The server rejected the API key")
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(.red)
                 .fixedSize(horizontal: false, vertical: true)
         case .unreachable:
             Text(isRemote
                 ? "✕ Can't reach the server — check the URL"
                 : "✕ Can't reach Ollama — is it running? (ollama serve)")
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(.red)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -1873,13 +1878,13 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         sEditor($viewModel.fillerWordsPattern, height: 48)
                         Text("Case-insensitive regex, applied before pasting.")
-                            .font(.system(size: 11)).foregroundColor(STheme.hint)
+                            .scaledFont(size: 11).foregroundColor(STheme.hint)
                     }
                     .padding(.leading, 16)
                 }
                 HStack(spacing: 8) {
                     Text("Clean up with an LLM")
-                        .font(.system(size: 13)).foregroundColor(STheme.text)
+                        .scaledFont(size: 13).foregroundColor(STheme.text)
                     Spacer()
                     SToggle(isOn: $viewModel.aiPostProcessingEnabled)
                 }
@@ -1900,7 +1905,7 @@ struct SettingsView: View {
                     }
                     if !viewModel.aiPostProcessingEnabled {
                         Text("Used by the per-app formatting rules in Rules.")
-                            .font(.system(size: 11)).foregroundColor(STheme.hint)
+                            .scaledFont(size: 11).foregroundColor(STheme.hint)
                             .padding(.leading, 16)
                     }
 
@@ -1920,7 +1925,7 @@ struct SettingsView: View {
                 }
                 if viewModel.aiPostProcessingEnabled {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Instruction").font(.system(size: 11)).foregroundColor(STheme.hint)
+                        Text("Instruction").scaledFont(size: 11).foregroundColor(STheme.hint)
                         sEditor($viewModel.aiPostProcessingPrompt, height: 64)
                     }
                     .padding(.leading, 16)
@@ -1934,7 +1939,7 @@ struct SettingsView: View {
                 if viewModel.customDictionaryEnabled {
                     HStack(spacing: 8) {
                         Text("Boost recognition")
-                            .font(.system(size: 12)).foregroundColor(STheme.text)
+                            .scaledFont(size: 12).foregroundColor(STheme.text)
                         STag("Advanced")
                         InfoButton(text: "Also bias the model toward these terms while listening, not just fix them afterward. Helps rare, distinctive words (e.g. “Kubernetes”) — but can over-correct short, common ones. Leave off if it replaces too much.")
                         Spacer()
@@ -1949,7 +1954,7 @@ struct SettingsView: View {
                             Text("Replace with").frame(maxWidth: .infinity, alignment: .leading)
                             Color.clear.frame(width: 24, height: 1)
                         }
-                        .font(.system(size: 10, weight: .bold))
+                        .scaledFont(size: 10, weight: .bold)
                         .tracking(0.6)
                         .textCase(.uppercase)
                         .foregroundColor(STheme.sectionTitle)
@@ -1958,7 +1963,7 @@ struct SettingsView: View {
 
                         if viewModel.customDictionaryEntries.isEmpty {
                             Text("No words yet. Add one below.")
-                                .font(.system(size: 11)).foregroundColor(STheme.hint)
+                                .scaledFont(size: 11).foregroundColor(STheme.hint)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding(.vertical, 14)
                         }
@@ -1966,18 +1971,18 @@ struct SettingsView: View {
                             HStack(spacing: 10) {
                                 TextField("", text: $entry.original, prompt: Text("git hub"))
                                     .textFieldStyle(.plain)
-                                    .font(.system(size: 12))
+                                    .scaledFont(size: 12)
                                     .frame(maxWidth: .infinity)
-                                Text("→").font(.system(size: 11)).foregroundColor(STheme.hint)
+                                Text("→").scaledFont(size: 11).foregroundColor(STheme.hint)
                                 TextField("", text: $entry.replacement, prompt: Text("GitHub"))
                                     .textFieldStyle(.plain)
-                                    .font(.system(size: 12))
+                                    .scaledFont(size: 12)
                                     .frame(maxWidth: .infinity)
                                 Button {
                                     viewModel.customDictionaryEntries.removeAll { $0.id == entry.id }
                                 } label: {
                                     Image(systemName: "trash")
-                                        .font(.system(size: 11))
+                                        .scaledFont(size: 11)
                                         .foregroundColor(STheme.hint)
                                 }
                                 .buttonStyle(.plain)
@@ -1997,7 +2002,7 @@ struct SettingsView: View {
                         viewModel.customDictionaryEntries.append(CustomDictionaryEntry())
                     } label: {
                         Label("Add word", systemImage: "plus")
-                            .font(.system(size: 11.5, weight: .medium))
+                            .scaledFont(size: 11.5, weight: .medium)
                     }
                     .controlSize(.small)
                     .padding(.leading, 16)
@@ -2060,7 +2065,7 @@ struct SettingsView: View {
                         HStack(spacing: 6) {
                             TextField("", value: $viewModel.retentionMaxCount, format: .number)
                                 .textFieldStyle(.plain)
-                                .font(.system(size: 12, design: .monospaced))
+                                .scaledFont(size: 12, design: .monospaced)
                                 .multilineTextAlignment(.trailing)
                                 .padding(.horizontal, 9).padding(.vertical, 4)
                                 .frame(width: 64)
@@ -2068,7 +2073,7 @@ struct SettingsView: View {
                                 .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.controlBorder, lineWidth: 1))
                             Stepper("", value: $viewModel.retentionMaxCount, in: 1...100000)
                                 .labelsHidden()
-                            Text("recordings").font(.system(size: 11)).foregroundColor(STheme.hint)
+                            Text("recordings").scaledFont(size: 11).foregroundColor(STheme.hint)
                         }
                     }
                 }
@@ -2081,7 +2086,7 @@ struct SettingsView: View {
                         HStack(spacing: 6) {
                             TextField("", value: $viewModel.retentionMaxAgeValue, format: .number)
                                 .textFieldStyle(.plain)
-                                .font(.system(size: 12, design: .monospaced))
+                                .scaledFont(size: 12, design: .monospaced)
                                 .multilineTextAlignment(.trailing)
                                 .padding(.horizontal, 9).padding(.vertical, 4)
                                 .frame(width: 56)
@@ -2101,7 +2106,7 @@ struct SettingsView: View {
                     }
                 }
                 Text("Both limits combine — whichever is hit first wins. Cleanup runs automatically, never while a transcription is being processed.")
-                    .font(.system(size: 11)).foregroundColor(STheme.hint)
+                    .scaledFont(size: 11).foregroundColor(STheme.hint)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
@@ -2112,6 +2117,20 @@ struct SettingsView: View {
     private var advancedSettings: some View {
         SPane(title: "Advanced") {
             SSection(title: "App") {
+                SRow(title: "Text size",
+                     hint: "Applied on top of the system text size (System Settings → Accessibility → Display). Leave at 100% to follow macOS exactly.") {
+                    HStack(spacing: 10) {
+                        Slider(value: $viewModel.textScale,
+                               in: TextScale.minimum...TextScale.maximum, step: 0.05)
+                            .controlSize(.small)
+                            .frame(width: 150)
+                            .tint(STheme.accent)
+                        Text("\(Int(viewModel.textScale * 100))%")
+                            .scaledFont(size: 11, design: .monospaced)
+                            .foregroundColor(STheme.hint)
+                            .frame(width: 40, alignment: .trailing)
+                    }
+                }
                 SRow(title: "App language", hint: "Relaunch to apply.") {
                     Picker("", selection: $appLanguage) {
                         Text("System").tag("system")
@@ -2155,7 +2174,7 @@ struct SettingsView: View {
                 if viewModel.useBeamSearch {
                     SRow(title: "Beam size", indented: true) {
                         Stepper("\(viewModel.beamSize)", value: $viewModel.beamSize, in: 1...10)
-                            .font(.system(size: 12, design: .monospaced))
+                            .scaledFont(size: 12, design: .monospaced)
                             .foregroundColor(STheme.text)
                             .frame(width: 90)
                     }
@@ -2166,7 +2185,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     SRow(title: "Temperature", hint: "Higher values make decoding more random.") {
                         Text(String(format: "%.2f", viewModel.temperature))
-                            .font(.system(size: 11.5, design: .monospaced))
+                            .scaledFont(size: 11.5, design: .monospaced)
                             .foregroundColor(STheme.hint)
                     }
                     Slider(value: $viewModel.temperature, in: 0.0...1.0, step: 0.1)
@@ -2175,7 +2194,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     SRow(title: "No speech threshold", hint: "How confident the model must be to call a segment silence.") {
                         Text(String(format: "%.2f", viewModel.noSpeechThreshold))
-                            .font(.system(size: 11.5, design: .monospaced))
+                            .scaledFont(size: 11.5, design: .monospaced)
                             .foregroundColor(STheme.hint)
                     }
                     Slider(value: $viewModel.noSpeechThreshold, in: 0.0...1.0, step: 0.1)
@@ -2194,16 +2213,16 @@ struct SettingsView: View {
                     sEditor($viewModel.postRecordHookCommand, height: 56)
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Available in your command (also piped as JSON on stdin):")
-                            .font(.system(size: 11))
+                            .scaledFont(size: 11)
                             .foregroundColor(STheme.hint)
                             .fixedSize(horizontal: false, vertical: true)
                         ForEach(Self.postRecordHookVariables, id: \.name) { variable in
                             HStack(alignment: .firstTextBaseline, spacing: 6) {
                                 Text(variable.name)
-                                    .font(.system(size: 11, design: .monospaced))
+                                    .scaledFont(size: 11, design: .monospaced)
                                     .foregroundColor(STheme.text)
                                 Text("— \(variable.description)")
-                                    .font(.system(size: 11))
+                                    .scaledFont(size: 11)
                                     .foregroundColor(STheme.hint)
                                     .fixedSize(horizontal: false, vertical: true)
                             }
@@ -2229,10 +2248,10 @@ struct SettingsView: View {
             SSection(title: "Trigger") {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Recording trigger")
-                        .font(.system(size: 13))
+                        .scaledFont(size: 13)
                         .foregroundColor(STheme.text)
                     Text("Click Add, then do the thing: press a combination with ⌘ ⌥ ⌃, tap a single modifier on its own, or click a spare mouse button. Keep several and use whichever suits the moment.")
-                        .font(.system(size: 11))
+                        .scaledFont(size: 11)
                         .foregroundColor(STheme.hint)
                         .fixedSize(horizontal: false, vertical: true)
                     TriggerRecorderField(name: .toggleRecord,
@@ -2255,7 +2274,7 @@ struct SettingsView: View {
                             }
                         }
                         .buttonStyle(.plain)
-                        .font(.system(size: 11.5, weight: .semibold))
+                        .scaledFont(size: 11.5, weight: .semibold)
                         .foregroundColor(STheme.warn)
                         .padding(.horizontal, 10).padding(.vertical, 4)
                         .overlay(RoundedRectangle(cornerRadius: 7).stroke(STheme.warnBorder, lineWidth: 1))
@@ -2303,7 +2322,7 @@ struct SettingsView: View {
                 }
                 HStack(spacing: 8) {
                     Text("Live transcription")
-                        .font(.system(size: 13))
+                        .scaledFont(size: 13)
                         .foregroundColor(STheme.text)
                         .opacity(viewModel.selectedEngine == "fluidaudio" ? 1 : 0.45)
                     STag("Parakeet only")
@@ -2327,7 +2346,7 @@ struct SettingsView: View {
                                 .frame(width: 150)
                                 .tint(STheme.accent)
                             Text("\(Int(viewModel.reduceVolumeLevel * 100))%")
-                                .font(.system(size: 11, design: .monospaced))
+                                .scaledFont(size: 11, design: .monospaced)
                                 .foregroundColor(STheme.hint)
                                 .frame(width: 34, alignment: .trailing)
                         }

--- a/OpenSuperWhisper/SettingsTheme.swift
+++ b/OpenSuperWhisper/SettingsTheme.swift
@@ -49,7 +49,7 @@ struct SSectionHeader: View {
     var body: some View {
         HStack(spacing: 8) {
             Text(title)
-                .font(.system(size: 11, weight: .bold))
+                .scaledFont(size: 11, weight: .bold)
                 .tracking(0.8)
                 .textCase(.uppercase)
                 .foregroundColor(STheme.sectionTitle)
@@ -70,11 +70,11 @@ struct SRow<Trailing: View>: View {
         HStack(alignment: .center, spacing: 14) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.system(size: 13))
+                    .scaledFont(size: 13)
                     .foregroundColor(STheme.text)
                 if let hint {
                     Text(hint)
-                        .font(.system(size: 11))
+                        .scaledFont(size: 11)
                         .foregroundColor(hintColor)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -93,7 +93,7 @@ struct STag: View {
     init(_ label: LocalizedStringKey) { self.label = label }
     var body: some View {
         Text(label)
-            .font(.system(size: 9.5, weight: .bold))
+            .scaledFont(size: 9.5, weight: .bold)
             .tracking(0.5)
             .textCase(.uppercase)
             .foregroundColor(STheme.hint)
@@ -107,7 +107,7 @@ struct SWarnBox<Content: View>: View {
     @ViewBuilder let content: () -> Content
     var body: some View {
         VStack(alignment: .leading, spacing: 8) { content() }
-            .font(.system(size: 11.5))
+            .scaledFont(size: 11.5)
             .foregroundColor(STheme.warn)
             .padding(.horizontal, 12).padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -140,11 +140,11 @@ struct SPane<Content: View>: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text(title)
-                    .font(.system(size: 16, weight: .bold))
+                    .scaledFont(size: 16, weight: .bold)
                     .foregroundColor(STheme.textBright)
                 Spacer()
                 if let subtitle {
-                    Text(subtitle).font(.system(size: 11)).foregroundColor(STheme.hint)
+                    Text(subtitle).scaledFont(size: 11).foregroundColor(STheme.hint)
                 }
             }
             .padding(.horizontal, 24).padding(.top, 16).padding(.bottom, 4)
@@ -165,7 +165,7 @@ struct SEditor: View {
 
     var body: some View {
         TextEditor(text: $text)
-            .font(.system(size: 11.5, design: .monospaced))
+            .scaledFont(size: 11.5, design: .monospaced)
             .scrollContentBackground(.hidden)
             .padding(6)
             .frame(height: height)

--- a/OpenSuperWhisper/TriggerRecorderField.swift
+++ b/OpenSuperWhisper/TriggerRecorderField.swift
@@ -93,7 +93,7 @@ struct TriggerRecorderField: View {
             Spacer(minLength: 8)
             Button { remove(trigger) } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 12))
+                    .scaledFont(size: 12)
                     .foregroundColor(STheme.hint)
             }
             .buttonStyle(.plain)
@@ -114,21 +114,21 @@ struct TriggerRecorderField: View {
                 ForEach(RecordingTrigger.modifierBadges, id: \.symbol) { badge in
                     let held = heldModifiers.contains(badge.flag)
                     Text(badge.symbol)
-                        .font(.system(size: 11, weight: .semibold))
+                        .scaledFont(size: 11, weight: .semibold)
                         .foregroundColor(held ? .white : STheme.hint)
                         .frame(width: 18, height: 18)
                         .background(RoundedRectangle(cornerRadius: 4)
                             .fill(held ? STheme.accent : STheme.controlBg))
                 }
                 Text(placeholder)
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.hint)
             } else {
                 Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .semibold))
+                    .scaledFont(size: 10, weight: .semibold)
                     .foregroundColor(STheme.hint)
                 Text(triggers.isEmpty ? "Add a trigger" : "Add another")
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.hint)
             }
             Spacer(minLength: 0)
@@ -182,7 +182,7 @@ struct TriggerRecorderField: View {
                 if isHovering {
                     Button { clear() } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 11))
+                            .scaledFont(size: 11)
                             .foregroundColor(STheme.hint)
                     }
                     .buttonStyle(.plain)
@@ -190,7 +190,7 @@ struct TriggerRecorderField: View {
                 }
             } else {
                 Text("Click to record")
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.hint)
                 Spacer(minLength: 0)
             }
@@ -212,14 +212,14 @@ struct TriggerRecorderField: View {
             ForEach(RecordingTrigger.modifierBadges, id: \.symbol) { badge in
                 let held = heldModifiers.contains(badge.flag)
                 Text(badge.symbol)
-                    .font(.system(size: 11, weight: .semibold))
+                    .scaledFont(size: 11, weight: .semibold)
                     .foregroundColor(held ? .white : STheme.hint)
                     .frame(width: 18, height: 18)
                     .background(RoundedRectangle(cornerRadius: 4)
                         .fill(held ? STheme.accent : STheme.controlBg))
             }
             Text(placeholder)
-                .font(.system(size: 11))
+                .scaledFont(size: 11)
                 .foregroundColor(STheme.hint)
                 .padding(.leading, 2)
             Spacer(minLength: 0)
@@ -405,7 +405,7 @@ private struct TriggerCap: View {
 
     var body: some View {
         Text(label)
-            .font(.system(size: 11.5, weight: .semibold))
+            .scaledFont(size: 11.5, weight: .semibold)
             .foregroundColor(STheme.textBright)
             .lineLimit(1)
             .frame(minWidth: 18, minHeight: 18)

--- a/OpenSuperWhisper/UpdatesView.swift
+++ b/OpenSuperWhisper/UpdatesView.swift
@@ -36,12 +36,12 @@ struct UpdatesView: View {
             }
             if let statusMessage {
                 Label(statusMessage, systemImage: "checkmark.circle.fill")
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.ok)
             }
             if let errorMessage {
                 Text(errorMessage)
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(.red)
             }
         }
@@ -53,12 +53,12 @@ struct UpdatesView: View {
                 .foregroundColor(STheme.accent)
             VStack(alignment: .leading, spacing: 1) {
                 Text("Update available: \(update.tagName)")
-                    .font(.system(size: 12.5, weight: .semibold))
+                    .scaledFont(size: 12.5, weight: .semibold)
                     .foregroundColor(STheme.textBright)
                 // The release page on GitHub, for those who want to read it first.
                 Button("View on GitHub") { NSWorkspace.shared.open(update.htmlURL) }
                     .buttonStyle(.link)
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
             }
             Spacer()
             // Install in place via Sparkle (download + verify + relaunch), not a web page.
@@ -75,7 +75,7 @@ struct UpdatesView: View {
         SSection(title: "What's new") {
             if releases.isEmpty {
                 Text("Loading release notes…")
-                    .font(.system(size: 11))
+                    .scaledFont(size: 11)
                     .foregroundColor(STheme.hint)
             } else {
                 ForEach(releases) { release in
@@ -89,18 +89,18 @@ struct UpdatesView: View {
         VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .firstTextBaseline) {
                 Text(release.displayName)
-                    .font(.system(size: 12.5, weight: .semibold))
+                    .scaledFont(size: 12.5, weight: .semibold)
                     .foregroundColor(STheme.textBright)
                 Spacer()
                 if let date = release.publishedAt {
                     Text(date, style: .date)
-                        .font(.system(size: 11))
+                        .scaledFont(size: 11)
                         .foregroundColor(STheme.hint)
                 }
             }
             if let body = release.body, !body.isEmpty {
                 Text(renderedNotes(body))
-                    .font(.system(size: 12))
+                    .scaledFont(size: 12)
                     .foregroundColor(STheme.text.opacity(0.85))
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -375,6 +375,12 @@ final class AppPreferences {
     var postRecordHookCommand: String
 
     /// Where the recording indicator appears: "cursor" (default), "top", "center", "bottom".
+    /// Multiplier applied on top of the system text size. 1.0 means "exactly what macOS asks
+    /// for"; the control exists because following the system alone leaves no room for wanting
+    /// this one app bigger than the rest. (#80)
+    @UserDefault(key: "textScale", defaultValue: TextScale.default)
+    var textScale: Double
+
     @UserDefault(key: "indicatorPosition", defaultValue: "cursor")
     var indicatorPosition: String
 

--- a/OpenSuperWhisper/Utils/TextScale.swift
+++ b/OpenSuperWhisper/Utils/TextScale.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// How much larger or smaller the app's text is than its designed size.
+///
+/// Every size in the app used to be a fixed point value, which meant macOS's own text-size
+/// setting did nothing and there was no way to read the settings window if 10pt hints are too
+/// small for you (#80). Sizes now pass through here, and get multiplied by two things: what the
+/// system asks for, and what the user asked for on top.
+///
+/// The system comes first because it is already configured and applies everywhere else; the
+/// app-level control exists because "follow the system" alone leaves no room for someone who
+/// wants this one app bigger than the rest.
+enum TextScale {
+    /// Bounds chosen so the layout still holds: below 0.85 the key caps stop fitting their
+    /// glyphs, and above 1.6 the recording bubble grows past a comfortable overlay size.
+    static let minimum: Double = 0.85
+    static let maximum: Double = 1.6
+    static let `default`: Double = 1.0
+
+    static func clamped(_ value: Double) -> Double {
+        min(max(value, minimum), maximum)
+    }
+
+    /// The system's contribution. `dynamicTypeSize` reflects System Settings → Accessibility →
+    /// Display → Text size on macOS 14+, and sits at `.large` when untouched.
+    static func systemMultiplier(_ size: DynamicTypeSize) -> Double {
+        switch size {
+        case .xSmall: return 0.8
+        case .small: return 0.9
+        case .medium: return 0.95
+        case .large: return 1.0
+        case .xLarge: return 1.1
+        case .xxLarge: return 1.2
+        case .xxxLarge: return 1.3
+        case .accessibility1: return 1.5
+        case .accessibility2: return 1.7
+        case .accessibility3: return 1.9
+        case .accessibility4: return 2.1
+        case .accessibility5: return 2.3
+        @unknown default: return 1.0
+        }
+    }
+
+    /// Point size to actually render, given both contributions.
+    static func resolve(_ size: CGFloat, appScale: Double, system: DynamicTypeSize) -> CGFloat {
+        size * CGFloat(clamped(appScale) * systemMultiplier(system))
+    }
+}
+
+private struct TextScaleKey: EnvironmentKey {
+    static let defaultValue: Double = TextScale.default
+}
+
+extension EnvironmentValues {
+    /// Set once near the root of each window; every `scaledFont` below reads it.
+    var appTextScale: Double {
+        get { self[TextScaleKey.self] }
+        set { self[TextScaleKey.self] = newValue }
+    }
+}
+
+private struct ScaledFont: ViewModifier {
+    @Environment(\.appTextScale) private var appScale
+    @Environment(\.dynamicTypeSize) private var systemSize
+
+    let size: CGFloat
+    let weight: Font.Weight
+    let design: Font.Design
+
+    func body(content: Content) -> some View {
+        content.font(.system(size: TextScale.resolve(size, appScale: appScale, system: systemSize),
+                             weight: weight, design: design))
+    }
+}
+
+extension View {
+    /// Replaces `.font(.system(size:))`. The number stays the designed size; what reaches the
+    /// screen is that size scaled by the system setting and the user's own adjustment.
+    func scaledFont(size: CGFloat,
+                    weight: Font.Weight = .regular,
+                    design: Font.Design = .default) -> some View {
+        modifier(ScaledFont(size: size, weight: weight, design: design))
+    }
+}

--- a/OpenSuperWhisperTests/TextScaleTests.swift
+++ b/OpenSuperWhisperTests/TextScaleTests.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Text sizes are multiplied by what macOS asks for and by what the user asked for on top.
+/// Both contributions matter: the app used to ignore the system entirely, which is why its
+/// settings window was unreadable for someone who had already made text bigger everywhere
+/// else (#80).
+final class TextScaleTests: XCTestCase {
+
+    func testUntouchedSystemAndAppLeaveSizesAlone() {
+        XCTAssertEqual(TextScale.resolve(11, appScale: TextScale.default, system: .large), 11,
+                       accuracy: 0.001)
+    }
+
+    /// The point of the default: a user who set a larger text size in macOS gets it here too,
+    /// without configuring anything in this app.
+    func testSystemSettingAloneEnlarges() {
+        let resolved = TextScale.resolve(11, appScale: TextScale.default, system: .accessibility1)
+        XCTAssertGreaterThan(resolved, 11)
+    }
+
+    func testBothContributionsCompound() {
+        let systemOnly = TextScale.resolve(10, appScale: 1.0, system: .xLarge)
+        let both = TextScale.resolve(10, appScale: 1.3, system: .xLarge)
+        XCTAssertGreaterThan(both, systemOnly)
+    }
+
+    func testLargerSystemSizesNeverShrinkText() {
+        let sizes: [DynamicTypeSize] = [.xSmall, .small, .medium, .large, .xLarge, .xxLarge,
+                                        .xxxLarge, .accessibility1, .accessibility5]
+        for (smaller, larger) in zip(sizes, sizes.dropFirst()) {
+            XCTAssertLessThanOrEqual(TextScale.resolve(12, appScale: 1, system: smaller),
+                                     TextScale.resolve(12, appScale: 1, system: larger),
+                                     "\(larger) must not render smaller than \(smaller)")
+        }
+    }
+
+    /// Bounds exist because the layout does: key caps stop fitting their glyphs below the
+    /// minimum, and the recording bubble outgrows a comfortable overlay above the maximum.
+    func testAppScaleIsClamped() {
+        XCTAssertEqual(TextScale.clamped(0.1), TextScale.minimum)
+        XCTAssertEqual(TextScale.clamped(99), TextScale.maximum)
+        XCTAssertEqual(TextScale.clamped(1.2), 1.2)
+    }
+
+    func testOutOfRangeStoredValueCannotBreakLayout() {
+        let tiny = TextScale.resolve(11, appScale: -5, system: .large)
+        let huge = TextScale.resolve(11, appScale: 100, system: .large)
+        XCTAssertEqual(tiny, 11 * CGFloat(TextScale.minimum), accuracy: 0.001)
+        XCTAssertEqual(huge, 11 * CGFloat(TextScale.maximum), accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
Closes #80.

## The report

> Is there a way to make the text larger? I can barely read your settings popup, and the dictated text is small!

No, and there was nothing to point her to. All 151 font sizes were fixed point values, so macOS's text-size setting did nothing here, and most settings hints sit at 10 and 11pt.

## What changed

Sizes go through a `scaledFont` modifier now, multiplied by two things: what the system asks for, and what the user asked for on top.

**At 100% the app follows macOS exactly.** That's the part that was missing entirely, and it's the default. Someone who already made text bigger for every other app gets it here without touching anything.

**The slider is in Settings → App → Text size**, 85% to 160%. Following the system alone leaves no room for wanting one app bigger than the rest, which is the case that made this worth a control rather than just semantic styles.

## Notes

The conversion is mechanical: the numbers stay the *designed* sizes, so the visual hierarchy is untouched and only a factor is added. Six call sites had conditional sizes (`compact ? 11 : 12`) and were done by hand.

Bounds come from the layout, not taste. Below 85% the key caps stop fitting their glyphs; above 160% the recording bubble outgrows a comfortable overlay. A stored value outside the range is clamped, so hand-editing preferences can't break the layout — there's a test for that.

The recording bubble reads the scale once per presentation rather than observing it. It's short-lived, and a change mid-recording would resize the window under the pointer, which is a class of bug this indicator has produced before.

## Verification

325 tests, 6 new. The one worth naming asserts that no larger system size can ever render smaller text, since that ordering is easy to break silently when adding a case to the multiplier table.

Still open from the report: she said "dictated text", which could mean the history list or the live caption on the bubble. Both scale now, but I've asked her which she meant before calling it done from her side.
