### PR TITLE
fix(a11y): apply the text size slider without a restart

### DIFF
--- a/OpenSuperWhisper/OpenSuperWhisperApp.swift
+++ b/OpenSuperWhisper/OpenSuperWhisperApp.swift
@@ -60,7 +60,6 @@ struct OpenSuperWhisperApp: App {
         // Dedicated, movable & closable settings window (sidebar layout).
         Window("Settings", id: "settings") {
             SettingsView()
-                .environment(\.appTextScale, AppPreferences.shared.textScale)
         }
         .windowResizability(.contentMinSize)
         .defaultSize(width: 780, height: 600)

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1566,6 +1566,10 @@ struct SettingsView: View {
                 }
             }
         }
+        // Injected from the view model rather than read from preferences at window
+        // construction: preferences aren't observed, so the slider wrote a value nothing
+        // ever re-read and the setting appeared to do nothing until the app restarted.
+        .environment(\.appTextScale, viewModel.textScale)
     }
     
     /// Compact engine card (design 1b): name + one-line subtitle, copper when browsed.


### PR DESCRIPTION
Shipped broken in 0.10.1.

The scale was injected into the environment from `AppPreferences` at window construction. Preferences aren't a source SwiftUI observes, so it was read once: the slider wrote the value, nothing re-read it, and the setting appeared to do nothing until relaunch. It now comes from the settings view model, which is observed.

Following the system text size worked throughout, so the case the original report (#80) was about was fine. The control that shipped alongside it was not.

Worth noting for anyone adding to this area: the six `TextScale` tests all passed through this. They cover the arithmetic, which was right. Nothing covered preference → environment → view, which is where the fault was, and that's the third SwiftUI refresh bug of this kind found by hand today rather than by the suite.