### PR TITLE
A failed accessibility query is not proof there is no text field

### DIFF
--- a/OpenSuperWhisper/Utils/FocusUtils.swift
+++ b/OpenSuperWhisper/Utils/FocusUtils.swift
@@ -186,8 +186,20 @@ class FocusUtils {
         return true
     }
 
+    /// Whether an accessibility error means "nothing is focused" rather than "the question
+    /// could not be answered".
+    ///
+    /// Only the first is evidence. `cannotComplete` is what a target that did not reply in
+    /// time returns, and the system-wide element returns it in situations where asking the
+    /// application directly succeeds, so treating it as an answer is how a working text field
+    /// gets mistaken for none at all.
+    static func reportsNothingFocused(_ error: AXError) -> Bool {
+        error == .noValue || error == .attributeUnsupported
+    }
+
     /// Best-effort check of whether the system-wide focused element can receive
-    /// pasted text. Returns `nil` when undeterminable (no Accessibility trust).
+    /// pasted text. Returns `nil` when undeterminable (no Accessibility trust, or a query
+    /// that failed for a reason that says nothing about whether a text field is there).
     static func focusedElementIsEditable() -> Bool? {
         guard AXIsProcessTrusted() else { return nil }
 
@@ -198,6 +210,11 @@ class FocusUtils {
                                                 kAXFocusedUIElementAttribute as CFString,
                                                 &focused)
         guard err == .success, let focusedCF = focused else {
+            // Reported as "no editable target" only when the system actually said nothing is
+            // focused. Anything else leaves us unable to tell, and the caller must go ahead and
+            // type: a failed question used to silently downgrade the dictation to the clipboard,
+            // and it stayed that way until the user opened and closed Settings.
+            guard reportsNothingFocused(err) else { return nil }
             return classifyEditability(hasFocusedElement: false, valueIsSettable: false, role: nil)
         }
         let element = focusedCF as! AXUIElement

--- a/OpenSuperWhisperTests/PasteTargetDetectionTests.swift
+++ b/OpenSuperWhisperTests/PasteTargetDetectionTests.swift
@@ -56,4 +56,38 @@ final class PasteTargetDetectionTests: XCTestCase {
         XCTAssertTrue(
             FocusUtils.classifyEditability(hasFocusedElement: true, valueIsSettable: false, role: nil))
     }
+
+    // MARK: - A question that failed is not an answer
+
+    /// Reported by a user: dictation stopped inserting and only left the text on the clipboard,
+    /// and stayed that way until Settings was opened and closed again. The accessibility query
+    /// had failed, and a failure was being read as "there is no text field here".
+    func testOnlyTheSystemSayingNothingIsFocusedCountsAsAbsence() {
+        XCTAssertTrue(FocusUtils.reportsNothingFocused(.noValue))
+        XCTAssertTrue(FocusUtils.reportsNothingFocused(.attributeUnsupported))
+    }
+
+    /// What a target that did not reply in time returns, and what the system-wide element
+    /// returns in cases where asking the application directly works.
+    func testATimedOutQueryIsNotAbsence() {
+        XCTAssertFalse(FocusUtils.reportsNothingFocused(.cannotComplete))
+    }
+
+    func testOtherFailuresAreNotAbsence() {
+        for error in [AXError.failure, .invalidUIElement, .notImplemented,
+                      .apiDisabled, .invalidUIElementObserver] {
+            XCTAssertFalse(FocusUtils.reportsNothingFocused(error),
+                           "\(error) was treated as proof that no text field is focused")
+        }
+    }
+
+    /// The fix relies on `nil` not tripping the caller's `== false` test, which is how typing
+    /// proceeds when we cannot tell. Pinned here because the whole repair rests on it.
+    func testUndeterminableDoesNotCountAsNoTarget() {
+        let undeterminable: Bool? = nil
+        let definitelyNoTarget: Bool? = false
+
+        XCTAssertFalse(undeterminable == false)
+        XCTAssertTrue(definitelyNoTarget == false)
+    }
 }


### PR DESCRIPTION
Reported by a user: dictation stopped inserting and only left the text on the clipboard, and kept doing it until they opened and closed Settings.

## What was happening

In typing mode the insertion is gated on `focusedElementIsEditable()`:

```swift
let targetMissing = prefs.notifyWhenNoPasteTarget
    && FocusUtils.focusedElementIsEditable() == false
```

That function answered `false` whenever its accessibility query failed, whatever the reason. `false` means "there is definitely nowhere to type", so the dictation was downgraded to the clipboard and the ⌘V notice. Its own comment said it was "biased toward `true`: only returns `false` when we are confident there is no editable text target", and a query that failed is not confidence.

This is reachable rather than theoretical. `cannotComplete` is what a target that did not reply in time returns, and while working on something unrelated I watched the system-wide element return it in a case where asking the application directly answered fine.

## The change

Only `noValue` and `attributeUnsupported` actually say nothing is focused. Everything else now answers `nil`, which the caller already treats as "cannot tell" and types anyway.

Failing toward typing is the right way round. Typing into the wrong place is visible and undoable. Silently keeping the words on the clipboard looks like the app ignoring you, which is exactly how it was reported.

Paste mode was never affected: it deliberately has no such gate.

## What I can and cannot claim

The gate is the only thing that was broken. Typing itself goes through `CGEvent` and never consulted accessibility, so with the gate corrected the text lands whether or not the underlying accessibility trouble is still there.

What I have not explained is why opening and closing Settings recovered it, rather than it clearing on the next dictation. A transient timeout should not have been sticky. My guess is that changing the frontmost app renews the accessibility connection to the target, but it is a guess, and I could not reproduce the failure on demand. The fix removes the failure mode regardless of which accessibility fault triggered it.

Tests cover the classification of each error, and pin the caller semantics the repair rests on: `nil` must not trip the `== false` test.