### PR TITLE
Put the recording bubble where you want it

### DIFF
--- a/OpenSuperWhisper/Indicator/IndicatorLayoutEditor.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorLayoutEditor.swift
@@ -34,13 +34,15 @@ struct IndicatorLayoutEditor: View {
     // MARK: - Position
 
     private var positionRow: some View {
-        SRow(title: "Position", hint: "Where the bubble appears while recording") {
+        SRow(title: "Position",
+             hint: "Where the bubble appears while recording. Drag the bubble itself to put it somewhere of your own, which also switches this to \"Where you drop it\". That one mode lets the bubble take clicks, so it stops being invisible to the app underneath.") {
             Picker("", selection: $viewModel.indicatorPosition) {
                 Text("Near cursor").tag("cursor")
                 Text("Notch").tag("notch")
                 Text("Top").tag("top")
                 Text("Center").tag("center")
                 Text("Bottom").tag("bottom")
+                Text("Where you drop it").tag("custom")
             }
             .pickerStyle(.menu)
             .labelsHidden()

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -65,8 +65,12 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             // `resizeToContent` (#19), and this also stops AppKit from animating the frame on
             // its own. Size changes should snap, never animate (macOS 26 recursion guard).
             panel.animationBehavior = .none
+            // Grabbing the bubble anywhere that is not a button moves it. Only reachable when the
+            // panel accepts mouse events at all, which is the opt-in below.
+            panel.isMovableByWindowBackground = true
 
             self.window = panel
+            observeDrag(of: panel)
         }
         
         // Host the SwiftUI content and size the window to it *ourselves* (see `resizeToContent`).
@@ -95,8 +99,10 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         // Accept clicks only when an on-bubble button is enabled (so it's tappable);
         // otherwise stay fully click-through (baseline). Re-evaluated each show() so
         // toggling the setting takes effect on the next recording.
-        window?.ignoresMouseEvents = !(AppPreferences.shared.showStopButtonOnIndicator
-            || AppPreferences.shared.showCancelButtonOnIndicator)
+        window?.ignoresMouseEvents = !Self.needsMouseEvents(
+            position: AppPreferences.shared.indicatorPosition,
+            showsStop: AppPreferences.shared.showStopButtonOnIndicator,
+            showsCancel: AppPreferences.shared.showCancelButtonOnIndicator)
 
         // Position window - use the screen containing the point, or main screen as fallback
         let targetScreen = point.flatMap { FocusUtils.screenContaining(point: $0) } ?? NSScreen.main
@@ -120,6 +126,12 @@ class IndicatorWindowManager: IndicatorViewDelegate {
             case "bottom":
                 anchorCenterX = screenFrame.midX
                 anchorBottomY = screenFrame.minY + 120
+            case "custom":
+                // Wherever it was last dropped. Falls back to the centre of the screen if the
+                // mode is set but nothing has been dragged yet, so it is never off-screen.
+                let dropped = AppPreferences.shared.indicatorCustomAnchor
+                anchorCenterX = dropped?.x ?? screenFrame.midX
+                anchorBottomY = dropped?.y ?? screenFrame.midY
             default: // "cursor": sit just above the caret, falling back to a band near the top
                 if let point = point {
                     anchorBottomY = point.y + 20
@@ -173,6 +185,49 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         }
     }
 
+    /// Whether the bubble should accept clicks instead of letting them through to the app below.
+    ///
+    /// Click-through is the baseline: the indicator never intercepts a click meant for what you
+    /// are dictating into. Two things override it. On-bubble buttons, which have to be tappable to
+    /// exist at all. And the draggable position, because a bubble you are meant to grab has to be
+    /// grabbable, which is the trade you accept by choosing that mode and no other.
+    nonisolated static func needsMouseEvents(position: String, showsStop: Bool,
+                                             showsCancel: Bool) -> Bool {
+        showsStop || showsCancel || position == "custom"
+    }
+
+    /// The origin `reposition` last asked for, so the window's own move notification is not
+    /// mistaken for the user dragging the bubble.
+    ///
+    /// Compared by value rather than guarded with a flag, because the move notification is not
+    /// guaranteed to arrive inside the `setFrameOrigin` call that caused it.
+    private var lastPlacedOrigin: NSPoint?
+
+    private var dragObserver: NSObjectProtocol?
+
+    /// Remembers where the bubble is dropped, and switches the position mode to match.
+    ///
+    /// Dragging something is a plainer statement of intent than picking from a menu, so a drop
+    /// wins: whatever preset was selected becomes "custom", and the bubble stays where it was put,
+    /// including across restarts.
+    private func observeDrag(of panel: NSWindow) {
+        dragObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification, object: panel, queue: .main
+        ) { [weak self, weak panel] _ in
+            guard let self, let panel else { return }
+            let origin = panel.frame.origin
+            if let placed = lastPlacedOrigin,
+               abs(placed.x - origin.x) < 1, abs(placed.y - origin.y) < 1 { return }
+
+            let anchor = CGPoint(x: panel.frame.midX, y: panel.frame.minY)
+            AppPreferences.shared.indicatorCustomAnchor = anchor
+            AppPreferences.shared.indicatorPosition = "custom"
+            anchorFromTop = false
+            anchorCenterX = anchor.x
+            anchorBottomY = anchor.y
+        }
+    }
+
     private func reposition(window: NSWindow, screen: NSScreen) {
         let w = window.frame.width
         let h = window.frame.height
@@ -182,7 +237,9 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         let y = anchorFromTop
             ? max(screenFrame.minY, anchorTopY - h)
             : max(screenFrame.minY, min(anchorBottomY, screenFrame.maxY - h))
-        window.setFrameOrigin(NSPoint(x: x, y: y))
+        let origin = NSPoint(x: x, y: y)
+        lastPlacedOrigin = origin
+        window.setFrameOrigin(origin)
     }
 
     /// Briefly shows the indicator at the configured position (without recording) so the user

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -384,6 +384,28 @@ final class AppPreferences {
     @UserDefault(key: "indicatorPosition", defaultValue: "cursor")
     var indicatorPosition: String
 
+    /// Where the bubble was last dragged to, as "x,y": the middle of its bottom edge in screen
+    /// coordinates.
+    ///
+    /// The same pair of anchors the preset positions produce, so a bubble you dropped somewhere
+    /// grows upward from that spot exactly as the presets do rather than drifting as its contents
+    /// change. nil until it has been dragged once.
+    @OptionalUserDefault(key: "indicatorCustomAnchor")
+    private var indicatorCustomAnchorRaw: String?
+
+    var indicatorCustomAnchor: CGPoint? {
+        get {
+            guard let raw = indicatorCustomAnchorRaw else { return nil }
+            let parts = raw.split(separator: ",").compactMap { Double($0) }
+            guard parts.count == 2 else { return nil }
+            return CGPoint(x: parts[0], y: parts[1])
+        }
+        set {
+            guard let newValue else { indicatorCustomAnchorRaw = nil; return }
+            indicatorCustomAnchorRaw = "\(newValue.x),\(newValue.y)"
+        }
+    }
+
     /// The bubble's contents as JSON (`IndicatorLayout`): which elements it shows and in
     /// what order. Empty until `migrateIndicatorLayout()` builds one from the old
     /// meter-mode / show-stop / show-cancel preferences.

--- a/OpenSuperWhisperTests/IndicatorCustomAnchorTests.swift
+++ b/OpenSuperWhisperTests/IndicatorCustomAnchorTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Where the bubble was dropped has to survive a restart, so it goes through UserDefaults as
+/// text. These cover that round trip and the states around it, which is the part that can be
+/// wrong without anyone noticing until the bubble reappears in the wrong place.
+final class IndicatorCustomAnchorTests: XCTestCase {
+
+    private var original: CGPoint?
+
+    override func setUp() {
+        super.setUp()
+        original = AppPreferences.shared.indicatorCustomAnchor
+    }
+
+    override func tearDown() {
+        AppPreferences.shared.indicatorCustomAnchor = original
+        super.tearDown()
+    }
+
+    func testAnchorSurvivesTheRoundTrip() {
+        AppPreferences.shared.indicatorCustomAnchor = CGPoint(x: 812.5, y: 431)
+
+        let stored = AppPreferences.shared.indicatorCustomAnchor
+        XCTAssertEqual(stored?.x ?? 0, 812.5, accuracy: 0.001)
+        XCTAssertEqual(stored?.y ?? 0, 431, accuracy: 0.001)
+    }
+
+    /// A second monitor puts the bubble at a negative x, and a dropped bubble there must come back
+    /// there rather than jumping to the main screen.
+    func testNegativeCoordinatesSurvive() {
+        AppPreferences.shared.indicatorCustomAnchor = CGPoint(x: -1440.25, y: -300)
+
+        let stored = AppPreferences.shared.indicatorCustomAnchor
+        XCTAssertEqual(stored?.x ?? 0, -1440.25, accuracy: 0.001)
+        XCTAssertEqual(stored?.y ?? 0, -300, accuracy: 0.001)
+    }
+
+    func testNeverDraggedReadsAsNothing() {
+        AppPreferences.shared.indicatorCustomAnchor = nil
+
+        XCTAssertNil(AppPreferences.shared.indicatorCustomAnchor)
+    }
+
+    /// Zero is a real screen point, so it must not be mistaken for "no anchor stored".
+    func testTheOriginIsAnAnchorLikeAnyOther() {
+        AppPreferences.shared.indicatorCustomAnchor = .zero
+
+        XCTAssertNotNil(AppPreferences.shared.indicatorCustomAnchor)
+        XCTAssertEqual(AppPreferences.shared.indicatorCustomAnchor?.x ?? 1, 0, accuracy: 0.001)
+    }
+
+    /// The bubble is click-through unless something needs it not to be. Dragging needs it not to
+    /// be, so this mode is the one place the trade is accepted, and the presets must not inherit it.
+    func testOnlyTheDraggableModeGivesUpClickThrough() {
+        let needs = IndicatorWindowManager.needsMouseEvents
+
+        XCTAssertTrue(needs("custom", false, false))
+        XCTAssertFalse(needs("cursor", false, false))
+        XCTAssertFalse(needs("notch", false, false))
+        XCTAssertFalse(needs("bottom", false, false))
+    }
+
+    func testOnBubbleButtonsStillNeedClicksOnAnyPosition() {
+        let needs = IndicatorWindowManager.needsMouseEvents
+
+        XCTAssertTrue(needs("cursor", true, false))
+        XCTAssertTrue(needs("notch", false, true))
+    }
+}


### PR DESCRIPTION
Asked for directly: the bubble sits where the position picker says, and sometimes that is over the thing you are reading.

## What it does

Grab it and move it. Dropping it stores the position and switches the picker to "Where you drop it", so dragging beats the menu without anyone having to find the menu first.

What gets stored is the middle of its bottom edge, which is the same pair of anchors the presets produce. That matters more than it sounds: the bubble changes size while it works, swapping the waveform for a spinner and growing for the cancel notice, and storing the anchor rather than the frame means a dropped bubble grows upward from where you put it instead of drifting. It comes back there after a restart.

## The trade, and where it is charged

The bubble is click-through by default, and the code is explicit that this is deliberate: it never intercepts a click meant for whatever you are dictating into. You cannot drag something that ignores the mouse.

Rather than spend that everywhere, **only the draggable position gives it up**. All five presets stay click-through exactly as before, so anyone not using this loses nothing. The cost is charged to the mode that needs it, and the picker's help text says so. On-bubble Stop and Cancel already required clicks, so a bubble carrying either can be dragged from any position.

## One thing that would have bitten

The window repositions itself whenever its content resizes, and that posts the same move notification a drag does. Left alone, every resize would have recorded itself as a deliberate drop and locked the bubble into custom mode on its own.

Told apart by comparing origins rather than with a flag around `setFrameOrigin`, because the notification is not guaranteed to arrive inside the call that caused it.

## Tested

Six tests on the parts that can be wrong quietly: the anchor's round trip through UserDefaults, negative coordinates for a second monitor, the difference between "never dragged" and "dropped at the origin" (zero is a real screen point), and that click-through is only surrendered by the one mode.

Dragging itself is confirmed by hand, including that Stop and Cancel stay clickable without starting a move. A synthetic drag is not a drag, so that part is not something I could automate honestly.