### PR TITLE
The whole dashed capsule adds a dictionary rule

### DIFF
--- a/OpenSuperWhisper/Settings/DictionaryBadgeEditor.swift
+++ b/OpenSuperWhisper/Settings/DictionaryBadgeEditor.swift
@@ -74,6 +74,10 @@ struct DictionaryBadgeEditor: View {
                 .padding(.vertical, 6)
                 .background(Capsule().strokeBorder(STheme.controlBorder,
                                                    style: StrokeStyle(lineWidth: 1, dash: [3, 3])))
+                // The other badges are filled, so their whole capsule takes a click. This one is
+                // only a dashed outline, and an outline is hit-tested along the line itself, which
+                // left the inside of the capsule dead and forced people to hit the small glyph.
+                .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .help("Add a rule")


### PR DESCRIPTION
Reported directly: adding a rule needed a precise hit on the small plus glyph.

The add button is a dashed outline, and an outline is hit-tested along the line itself, so the inside of the capsule took no clicks at all. The filled badges beside it never had the problem, which is why it read as the button being unreliable rather than as it being smaller than it looks.

One `contentShape(Capsule())`, and the target is the size it appears to be.