### PR TITLE
The CLI reads the right preferences through the Homebrew symlink

### DIFF
--- a/OpenSuperWhisper/Engines/SenseVoiceModelManager.swift
+++ b/OpenSuperWhisper/Engines/SenseVoiceModelManager.swift
@@ -14,7 +14,7 @@ final class SenseVoiceModelManager {
     var modelDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport
-            .appendingPathComponent(Bundle.main.bundleIdentifier!)
+            .appendingPathComponent(AppIdentity.bundleID)
             .appendingPathComponent(dirName)
     }
     var modelPath: URL { modelDirectory.appendingPathComponent("model.int8.onnx") }

--- a/OpenSuperWhisper/LLMModelManager.swift
+++ b/OpenSuperWhisper/LLMModelManager.swift
@@ -85,7 +85,7 @@ class LLMModelManager {
     var modelsDirectory: URL {
         let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return applicationSupport
-            .appendingPathComponent(Bundle.main.bundleIdentifier!)
+            .appendingPathComponent(AppIdentity.bundleID)
             .appendingPathComponent(modelsDirectoryName)
     }
 

--- a/OpenSuperWhisper/Models/Recording.swift
+++ b/OpenSuperWhisper/Models/Recording.swift
@@ -49,7 +49,7 @@ struct Recording: Identifiable, Codable, FetchableRecord, PersistableRecord, Equ
         let applicationSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
         ).first!
-        let appDirectory = applicationSupport.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        let appDirectory = applicationSupport.appendingPathComponent(AppIdentity.bundleID)
         return appDirectory.appendingPathComponent("recordings")
     }
 
@@ -97,7 +97,7 @@ class RecordingStore: ObservableObject {
         let applicationSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask
         ).first!
-        let appDirectory = applicationSupport.appendingPathComponent(Bundle.main.bundleIdentifier!)
+        let appDirectory = applicationSupport.appendingPathComponent(AppIdentity.bundleID)
         let dbPath = appDirectory.appendingPathComponent("recordings.sqlite")
 
         do {

--- a/OpenSuperWhisper/Utils/AppIdentity.swift
+++ b/OpenSuperWhisper/Utils/AppIdentity.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Who we are, resolved so that it survives being launched through a symlink.
+///
+/// `Bundle.main` is derived from the path the process was launched by, and that path is the
+/// symlink rather than what it points at. Homebrew installs the CLI as
+/// `/opt/homebrew/bin/opensuperwhisper` pointing into the app bundle, so invoking it that way
+/// makes the main bundle `/opt/homebrew/bin`, which has no Info.plist. The identifier then comes
+/// back nil, and everything keyed on it goes somewhere else: the preferences domain, the model
+/// directory, the recordings directory. The CLI reported loading an engine nobody had selected
+/// because it was reading an empty set of preferences (#88).
+enum AppIdentity {
+
+    /// Last resort, used only when neither the main bundle nor the resolved executable can say.
+    /// A fork that renames the bundle gets the right answer from the resolution above this.
+    static let fallbackBundleID = "fr.my-monkey.opensuperwhisper"
+
+    /// The app's bundle identifier. Never nil, and the same value whichever path was used to
+    /// start the process.
+    static let bundleID: String = {
+        if let identifier = Bundle.main.bundleIdentifier { return identifier }
+
+        if let executable = Bundle.main.executableURL,
+           let bundleURL = enclosingBundleURL(forExecutableAt: executable),
+           let identifier = Bundle(url: bundleURL)?.bundleIdentifier {
+            return identifier
+        }
+
+        return fallbackBundleID
+    }()
+
+    /// The `.app` containing an executable, given the path it was launched by.
+    ///
+    /// Resolves symlinks first, since the whole point is that the launch path is a link, then
+    /// climbs `Contents/MacOS` to reach the bundle. Returns nil for an executable that is not
+    /// inside an app bundle at all, which is the case under `swift test` and for a bare binary.
+    static func enclosingBundleURL(forExecutableAt executable: URL) -> URL? {
+        let resolved = executable.resolvingSymlinksInPath()
+        let macOS = resolved.deletingLastPathComponent()
+        let contents = macOS.deletingLastPathComponent()
+        let bundle = contents.deletingLastPathComponent()
+
+        guard macOS.lastPathComponent == "MacOS",
+              contents.lastPathComponent == "Contents",
+              bundle.pathExtension == "app"
+        else { return nil }
+
+        return bundle
+    }
+
+    /// The app's directory inside Application Support, where models and recordings live.
+    ///
+    /// Named after the bundle identifier, which is why resolving that identifier properly matters
+    /// beyond the preferences: launched through the symlink this used to be a different directory,
+    /// and the five places that built it force-unwrapped the identifier, so they were one step
+    /// away from trapping rather than merely looking in the wrong place.
+    static func applicationSupportDirectory() -> URL? {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent(bundleID)
+    }
+}

--- a/OpenSuperWhisper/Utils/DefaultsStore.swift
+++ b/OpenSuperWhisper/Utils/DefaultsStore.swift
@@ -14,7 +14,7 @@ import Foundation
 /// forgotten by the next test that starts background work.
 enum DefaultsStore {
     static let current: UserDefaults = {
-        guard isRunningTests else { return .standard }
+        guard isRunningTests else { return normalRunStore }
         let name = testSuiteName(for: ProcessInfo.processInfo.processIdentifier)
         guard let suite = UserDefaults(suiteName: name) else { return .standard }
         // Start from nothing: a suite left behind by a crashed run would otherwise seed this one.
@@ -23,6 +23,18 @@ enum DefaultsStore {
         return suite
     }()
 
+    /// `UserDefaults.standard` chooses its domain from the main bundle's identifier, and that
+    /// identifier is nil when the process was launched through a symlink sitting outside the
+    /// bundle — which is exactly how the Homebrew CLI is meant to be run. The app's own settings
+    /// were then invisible, so the CLI reported loading an engine nobody had selected. Naming the
+    /// domain gets the same preferences the app writes, whichever path started the process (#88).
+    private static var normalRunStore: UserDefaults {
+        guard Bundle.main.bundleIdentifier == nil,
+              let suite = UserDefaults(suiteName: AppIdentity.bundleID)
+        else { return .standard }
+        return suite
+    }
+
     /// True while the process is hosting XCTest. `XCTestConfigurationFilePath` is set by the
     /// test runner and absent in a normal launch, including a Debug build the user runs.
     static var isRunningTests: Bool {
@@ -30,7 +42,7 @@ enum DefaultsStore {
     }
 
     static var testSuitePrefix: String {
-        "\(Bundle.main.bundleIdentifier ?? "fr.my-monkey.opensuperwhisper").tests."
+        "\(AppIdentity.bundleID).tests."
     }
 
     static func testSuiteName(for pid: Int32) -> String { "\(testSuitePrefix)\(pid)" }

--- a/OpenSuperWhisper/WhisperModelManager.swift
+++ b/OpenSuperWhisper/WhisperModelManager.swift
@@ -49,7 +49,7 @@ class WhisperModelManager {
     
     var modelsDirectory: URL {
         let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let modelsDirectory = applicationSupport.appendingPathComponent(Bundle.main.bundleIdentifier!).appendingPathComponent(modelsDirectoryName)
+        let modelsDirectory = applicationSupport.appendingPathComponent(AppIdentity.bundleID).appendingPathComponent(modelsDirectoryName)
         return modelsDirectory
     }
     

--- a/OpenSuperWhisperTests/AppIdentityTests.swift
+++ b/OpenSuperWhisperTests/AppIdentityTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Finding our own bundle when the path we were launched by is a symlink pointing into it.
+///
+/// The path arithmetic is what is testable here. The rest depends on how the process was started,
+/// which a test cannot stage, so these cover the shape of the walk rather than a live launch.
+final class AppIdentityTests: XCTestCase {
+
+    private func url(_ path: String) -> URL { URL(fileURLWithPath: path) }
+
+    // MARK: - Climbing out of the bundle
+
+    func testAnExecutableInsideABundleFindsIt() {
+        let found = AppIdentity.enclosingBundleURL(
+            forExecutableAt: url("/Applications/OpenSuperWhisper.app/Contents/MacOS/OpenSuperWhisper"))
+
+        XCTAssertEqual(found?.path, "/Applications/OpenSuperWhisper.app")
+    }
+
+    func testABareBinaryHasNoBundle() {
+        XCTAssertNil(AppIdentity.enclosingBundleURL(forExecutableAt: url("/usr/local/bin/whatever")))
+    }
+
+    /// The layout has to be the real one, not merely deep enough. Three levels up from anywhere
+    /// lands on *something*, and returning it would name a directory that is not a bundle.
+    func testADeepPathThatIsNotABundleIsRejected() {
+        XCTAssertNil(AppIdentity.enclosingBundleURL(
+            forExecutableAt: url("/opt/homebrew/Cellar/thing/bin/thing")))
+    }
+
+    func testTheContentsAndMacOSLevelsMustBeNamedThat() {
+        XCTAssertNil(AppIdentity.enclosingBundleURL(
+            forExecutableAt: url("/Applications/Foo.app/Resources/bin/Foo")))
+    }
+
+    func testAnyAppBundleWorksNotJustOurs() {
+        let found = AppIdentity.enclosingBundleURL(
+            forExecutableAt: url("/Applications/Some Other.app/Contents/MacOS/Some Other"))
+
+        XCTAssertEqual(found?.lastPathComponent, "Some Other.app")
+    }
+
+    // MARK: - The identifier itself
+
+    /// Whatever happens, callers get a string. Five places used to force-unwrap this to build a
+    /// directory path, so nil was not merely wrong, it was a trap waiting for the CLI.
+    func testTheIdentifierIsNeverNil() {
+        XCTAssertFalse(AppIdentity.bundleID.isEmpty)
+    }
+
+    /// Under the test host the main bundle is present, so the real identifier must win over the
+    /// hardcoded fallback. If this ever fails, the resolution order got inverted.
+    func testTheRealBundleWinsOverTheFallback() throws {
+        let identifier = try XCTUnwrap(Bundle.main.bundleIdentifier)
+
+        XCTAssertEqual(AppIdentity.bundleID, identifier)
+    }
+
+    func testApplicationSupportIsNamedAfterTheIdentifier() throws {
+        let directory = try XCTUnwrap(AppIdentity.applicationSupportDirectory())
+
+        XCTAssertEqual(directory.lastPathComponent, AppIdentity.bundleID)
+        XCTAssertTrue(directory.path.contains("Application Support"))
+    }
+}


### PR DESCRIPTION
Closes #88.

@ForksApps found that the CLI behaved differently depending on whether the executable was run from inside the bundle or through the `/opt/homebrew/bin/opensuperwhisper` symlink, and did the work of establishing that the engine was not the variable: the symlink was.

## Why

`Bundle.main` resolves from the path the process was launched by, and that path is the symlink rather than what it points at. Launched through the link, the main bundle is `/opt/homebrew/bin`, which has no Info.plist, so `bundleIdentifier` is nil.

`UserDefaults.standard` takes its domain from that identifier. So every setting the app had written was invisible and the defaults answered instead: hence an engine nobody selected, and no model path, and `contextInitializationFailed`.

Confirmed rather than assumed: a test binary launched through a link reports the link's directory as its bundle path, not the target's.

## What the report could not see

Five places built directories by force-unwrapping that same identifier, for Whisper models, the built-in LLM, SenseVoice and recordings. Through the symlink those were not merely wrong paths, they were traps. The reported failure happens earlier in the sequence, which is the only reason it surfaced as an error message instead of a crash.

## The fix

`AppIdentity` resolves the identifier once. The main bundle when it can answer; otherwise the launch path is resolved through the symlink and the enclosing `.app` is read for its real identifier. The hardcoded string is a last resort only, so a fork that renames its bundle still gets its own rather than ours.

Everything that was force-unwrapping goes through it, and the preferences domain is named explicitly when the identifier is missing.

## Verified end to end

With the engine set to `fluidaudio`, against a real recording:

- through a Homebrew-style symlink: `Loading engine: fluidaudio`, transcribes
- directly from the bundle: `Loading engine: fluidaudio`, transcribes

Both produce the same text. Before the fix the symlink path loaded `whisper`.

Eight unit tests cover the path arithmetic, including the two cases that would make it quietly wrong: a bare binary has no bundle, and a merely deep path is not one either, since climbing three levels from anywhere lands on something and returning it would name a directory that is not a bundle.