### PR TITLE
Dictionary rules apply to remote transcriptions too

### DIFF
--- a/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
+++ b/OpenSuperWhisper/Engines/AppleSpeechEngine.swift
@@ -177,14 +177,7 @@ final class AppleSpeechEngine: TranscriptionEngine {
         try await analyzer.analyzeSequence(from: file)
         try await analyzer.finalizeAndFinishThroughEndOfInput()
 
-        var text = try await collected.trimmingCharacters(in: .whitespacesAndNewlines)
-        if settings.shouldApplyAsianAutocorrect && !text.isEmpty {
-            text = AutocorrectWrapper.format(text)
-        }
-        if settings.shouldApplyCustomDictionary {
-            text = CustomDictionary.apply(text, entries: settings.customDictionaryEntries)
-        }
-        return text.isEmpty ? TranscriptionResult.noSpeech : text
+        return TranscriptionPostProcessing.finish(try await collected, settings: settings)
     }
 
     private static func collectFinalText(from transcriber: SpeechTranscriber) async throws -> String {

--- a/OpenSuperWhisper/Engines/FluidAudioEngine.swift
+++ b/OpenSuperWhisper/Engines/FluidAudioEngine.swift
@@ -104,19 +104,11 @@ class FluidAudioEngine: TranscriptionEngine {
         // Finalize
         onProgressUpdate?(0.95)
 
-        var processedText = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        if settings.shouldApplyAsianAutocorrect && !processedText.isEmpty {
-            processedText = AutocorrectWrapper.format(processedText)
-        }
-
-        if settings.shouldApplyCustomDictionary {
-            processedText = CustomDictionary.apply(processedText, entries: settings.customDictionaryEntries)
-        }
+        let processedText = TranscriptionPostProcessing.finish(rawText, settings: settings)
 
         onProgressUpdate?(1.0)
-        
-        return processedText.isEmpty ? TranscriptionResult.noSpeech : processedText
+
+        return processedText
     }
     
     func cancelTranscription() {

--- a/OpenSuperWhisper/Engines/RemoteEngine.swift
+++ b/OpenSuperWhisper/Engines/RemoteEngine.swift
@@ -137,7 +137,9 @@ final class RemoteEngine: TranscriptionEngine {
         defer { currentTask = nil }
 
         do {
-            return try await task.value
+            // The server hands back raw text; everything the local engines do afterwards has to
+            // happen here too, or dictionary rules quietly stop existing on Remote (#101).
+            return TranscriptionPostProcessing.finish(try await task.value, settings: settings)
         } catch let error as RemoteError {
             throw error
         } catch is CancellationError {

--- a/OpenSuperWhisper/Engines/SenseVoiceEngine.swift
+++ b/OpenSuperWhisper/Engines/SenseVoiceEngine.swift
@@ -44,14 +44,7 @@ final class SenseVoiceEngine: TranscriptionEngine {
         let result = recognizer.decode(samples: samples, sampleRate: 16000)
         guard !isCancelled else { throw CancellationError() }
 
-        var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if settings.shouldApplyAsianAutocorrect && !text.isEmpty {
-            text = AutocorrectWrapper.format(text)
-        }
-        if settings.shouldApplyCustomDictionary {
-            text = CustomDictionary.apply(text, entries: settings.customDictionaryEntries)
-        }
-        return text.isEmpty ? TranscriptionResult.noSpeech : text
+        return TranscriptionPostProcessing.finish(result.text, settings: settings)
     }
 
     func cancelTranscription() { isCancelled = true }

--- a/OpenSuperWhisper/Engines/TranscriptionPostProcessing.swift
+++ b/OpenSuperWhisper/Engines/TranscriptionPostProcessing.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The steps every engine owes a transcription before it is handed back.
+///
+/// This existed as the same eight lines copied into each of the four local engines, which is
+/// exactly why the fifth never got them: transcriptions from a remote server came back raw, so
+/// dictionary rules and Asian autocorrect silently did nothing there while working everywhere
+/// else. Reported on #101 by someone using Groq through the Remote engine.
+///
+/// Having one implementation does not by itself stop a sixth engine from forgetting to call it,
+/// so `EveryEngineFinishesTests` checks that they all do.
+enum TranscriptionPostProcessing {
+
+    /// Trims, applies Asian autocorrect and the custom dictionary, and reports silence.
+    ///
+    /// The order is not arbitrary: autocorrect rewrites spacing inside CJK text, and dictionary
+    /// rules match on word boundaries, so running the dictionary first would have it matching
+    /// against spacing that is about to change.
+    static func finish(_ text: String, settings: Settings) -> String {
+        var processed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if settings.shouldApplyAsianAutocorrect && !processed.isEmpty {
+            processed = AutocorrectWrapper.format(processed)
+        }
+
+        if settings.shouldApplyCustomDictionary {
+            processed = CustomDictionary.apply(processed, entries: settings.customDictionaryEntries)
+        }
+
+        return processed.isEmpty ? TranscriptionResult.noSpeech : processed
+    }
+}

--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -258,16 +258,7 @@ class WhisperEngine: TranscriptionEngine {
             .replacingOccurrences(of: "[BLANK_AUDIO]", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         
-        var processedText = cleanedText
-        if settings.shouldApplyAsianAutocorrect && !cleanedText.isEmpty {
-            processedText = AutocorrectWrapper.format(cleanedText)
-        }
-
-        if settings.shouldApplyCustomDictionary {
-            processedText = CustomDictionary.apply(processedText, entries: settings.customDictionaryEntries)
-        }
-
-        return processedText.isEmpty ? TranscriptionResult.noSpeech : processedText
+        return TranscriptionPostProcessing.finish(cleanedText, settings: settings)
     }
     
     func cancelTranscription() {

--- a/OpenSuperWhisperTests/TranscriptionPostProcessingTests.swift
+++ b/OpenSuperWhisperTests/TranscriptionPostProcessingTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// What every engine owes a transcription before handing it back.
+///
+/// These exist because the steps were copied into four engines and missing from the fifth, so
+/// dictionary rules silently did nothing for anyone using a remote server (#101). The last test
+/// is the one that matters most: it checks the omission cannot happen again.
+final class TranscriptionPostProcessingTests: XCTestCase {
+
+    private func settingsWithDictionary(_ entries: [CustomDictionaryEntry]) -> Settings {
+        var settings = Settings()
+        settings.customDictionaryEnabled = true
+        settings.customDictionaryEntries = entries
+        return settings
+    }
+
+    func testTheDictionaryIsApplied() {
+        let settings = settingsWithDictionary([
+            CustomDictionaryEntry(original: "git hub", replacement: "GitHub")
+        ])
+
+        XCTAssertEqual(TranscriptionPostProcessing.finish("push it to git hub", settings: settings),
+                       "push it to GitHub")
+    }
+
+    func testARegexRuleIsAppliedToo() {
+        let settings = settingsWithDictionary([
+            CustomDictionaryEntry(original: "deep[\\s-]+\\w+[\\s-]+\\w+",
+                                  replacement: "deepseek harness", isRegex: true)
+        ])
+
+        XCTAssertEqual(TranscriptionPostProcessing.finish("run the deep seek harness now",
+                                                          settings: settings),
+                       "run the deepseek harness now")
+    }
+
+    func testTheTextIsTrimmed() {
+        XCTAssertEqual(TranscriptionPostProcessing.finish("  hello  ", settings: Settings()),
+                       "hello")
+    }
+
+    func testNothingHeardIsReportedAsSilence() {
+        XCTAssertEqual(TranscriptionPostProcessing.finish("   \n ", settings: Settings()),
+                       TranscriptionResult.noSpeech)
+    }
+
+    func testADisabledDictionaryChangesNothing() {
+        var settings = Settings()
+        settings.customDictionaryEnabled = false
+        settings.customDictionaryEntries = [
+            CustomDictionaryEntry(original: "git hub", replacement: "GitHub")
+        ]
+
+        XCTAssertEqual(TranscriptionPostProcessing.finish("git hub", settings: settings), "git hub")
+    }
+
+    // MARK: - The omission that started this
+
+    /// Every engine has to run the shared step, and having one implementation does not by itself
+    /// make that happen. The bug was not a wrong line, it was a missing one in the fifth copy of
+    /// something duplicated four times, and nothing in the type system notices that.
+    ///
+    /// Reads the sources rather than the built product, so a new engine that forgets fails here
+    /// with its own filename rather than in somebody's dictation weeks later.
+    func testEveryEngineRunsTheSharedStep() throws {
+        let engines = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()      // OpenSuperWhisperTests
+            .deletingLastPathComponent()      // repo root
+            .appendingPathComponent("OpenSuperWhisper/Engines")
+
+        let files = try FileManager.default.contentsOfDirectory(atPath: engines.path)
+            .filter { $0.hasSuffix(".swift") }
+        XCTAssertFalse(files.isEmpty, "no engine sources found at \(engines.path)")
+
+        var checked = 0
+        for name in files {
+            let source = try String(contentsOf: engines.appendingPathComponent(name),
+                                    encoding: .utf8)
+            // Conformances only: the protocol itself and helpers are not engines.
+            guard source.contains(": TranscriptionEngine"),
+                  !name.hasPrefix("TranscriptionEngine") else { continue }
+            checked += 1
+            XCTAssertTrue(source.contains("TranscriptionPostProcessing.finish"),
+                          "\(name) returns a transcription without the shared post-processing, "
+                          + "so the dictionary and autocorrect do nothing there")
+        }
+        XCTAssertGreaterThanOrEqual(checked, 5, "expected every engine to be checked")
+    }
+}


### PR DESCRIPTION
Closes #101.

@alchemicwebstudio's reading was right, and it did not need reproducing: four engines end by applying the custom dictionary and Asian autocorrect, and `RemoteEngine` returned the server's text untouched.

It is a little broader than reported. Remote skipped autocorrect as well, so this was a missing post-processing step rather than a dictionary bug specifically.

## The cause is the shape

The same eight lines were copied into each local engine. That is exactly how a fifth ends up without them: nothing about writing a new engine makes you notice what the other four happen to do at the end, and the compiler has no opinion about it.

They now share one implementation, which also fixes an ordering detail that was only ever correct by coincidence: autocorrect rewrites spacing inside CJK text and dictionary rules match on word boundaries, so the dictionary has to run second or it matches against spacing that is about to change.

## The part worth arguing about

One implementation does not stop a sixth engine from forgetting to call it. So there is a test that reads the engine sources and fails, naming the file, if anything conforming to `TranscriptionEngine` returns without the shared step.

Reading source from a test is unusual and I would normally push back on it. Here the invariant is "every conformance calls this", which the type system does not express and which has already been violated once in production. A protocol default would not help, since it still has to be called.

Verified the guard actually guards: removing the call from `RemoteEngine` makes it fail with that filename, restoring it makes it pass. A check that has never failed is not known to work.