### PR TITLE
A microphone that never connects no longer freezes the recording

### DIFF
--- a/OpenSuperWhisper/AudioRecorder.swift
+++ b/OpenSuperWhisper/AudioRecorder.swift
@@ -310,28 +310,56 @@ class AudioRecorder: NSObject, ObservableObject {
         }
     }
     
+    /// How long to wait for a microphone that needs to connect before showing the recording as
+    /// live anyway.
+    ///
+    /// Bluetooth headsets take a moment to actually start delivering audio, which is what the
+    /// wait is for. Three seconds is far longer than that and short enough that nobody sits
+    /// through it wondering whether the app heard them.
+    static let connectionGracePeriod: TimeInterval = 3.0
+
+    /// Whether to stop waiting and treat the recording as live.
+    ///
+    /// The growth check alone had no way out. If the file never grew — a device that went away
+    /// while the Mac was locked, an input that delivers nothing — the app waited forever: the
+    /// bubble was up, `isRecording` stayed false, and only force-quitting recovered it (#98).
+    ///
+    /// Timing out into "live" rather than into a failure is deliberate. The recorder is running
+    /// either way and the person is already talking, so giving up would throw their words away
+    /// to fix a state problem. The worst case here is a silent recording they can stop, look at,
+    /// and try again — which is what every microphone that does not need connecting already does.
+    static func shouldGoLive(growthObservations: Int, elapsed: TimeInterval) -> Bool {
+        growthObservations >= 2 || elapsed >= connectionGracePeriod
+    }
+
     private func startConnectionMonitoring() {
         stopConnectionMonitoring()
-        
+
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
         timer.schedule(deadline: .now() + 0.05, repeating: 0.05)
         let initialFileSize: Int64 = 4096
+        let startedAt = Date()
         var growthCount = 0
-        
+
         timer.setEventHandler { [weak self] in
             guard let self = self, let _ = self.audioRecorder, let url = self.currentRecordingURL else { return }
-            
+
             let currentFileSize = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64) ?? 0
             let totalGrowth = currentFileSize - initialFileSize
-            
+
             if totalGrowth > 8000 {
                 growthCount += 1
             }
-            
-            if growthCount >= 2 {
-                self.stopConnectionMonitoring()
-                self.updateRecordingState(isRecording: true, isConnecting: false)
+
+            let elapsed = Date().timeIntervalSince(startedAt)
+            guard Self.shouldGoLive(growthObservations: growthCount, elapsed: elapsed) else { return }
+
+            if growthCount < 2 {
+                Diag.mark("recorder.connectionWait timed out after \(Int(elapsed * 1000))ms "
+                    + "with \(totalGrowth) bytes written; going live anyway")
             }
+            self.stopConnectionMonitoring()
+            self.updateRecordingState(isRecording: true, isConnecting: false)
         }
         connectionCheckTimer = timer
         timer.resume()

--- a/OpenSuperWhisperTests/ConnectionWaitTests.swift
+++ b/OpenSuperWhisperTests/ConnectionWaitTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Deciding when to stop waiting for a microphone that has to connect first.
+///
+/// Reported in #98: after locking the Mac and switching from headphones to the built-in
+/// microphone, the bubble appeared and the recording never completed or could be stopped, and
+/// only force-quitting recovered it. The wait had no way out, so a file that never grew meant
+/// waiting forever.
+final class ConnectionWaitTests: XCTestCase {
+
+    func testTwoSightingsOfGrowthGoLiveImmediately() {
+        XCTAssertTrue(AudioRecorder.shouldGoLive(growthObservations: 2, elapsed: 0.1))
+    }
+
+    func testOneSightingIsNotEnoughYet() {
+        XCTAssertFalse(AudioRecorder.shouldGoLive(growthObservations: 1, elapsed: 0.1))
+    }
+
+    /// The bug. Audio never arriving used to mean waiting for ever, with the bubble up and the
+    /// recording unstoppable.
+    func testAWaitThatLearnsNothingStillEnds() {
+        XCTAssertTrue(AudioRecorder.shouldGoLive(
+            growthObservations: 0, elapsed: AudioRecorder.connectionGracePeriod))
+        XCTAssertTrue(AudioRecorder.shouldGoLive(growthObservations: 0, elapsed: 30))
+    }
+
+    func testItStillWaitsWhileThereIsTimeLeft() {
+        let almost = AudioRecorder.connectionGracePeriod - 0.05
+        XCTAssertFalse(AudioRecorder.shouldGoLive(growthObservations: 0, elapsed: almost))
+    }
+
+    /// Long enough for a Bluetooth headset to wake up, short enough that nobody sits through it
+    /// wondering whether the app heard them.
+    func testTheGraceIsLongEnoughToBeUsefulAndShortEnoughToBeBearable() {
+        XCTAssertGreaterThanOrEqual(AudioRecorder.connectionGracePeriod, 1)
+        XCTAssertLessThanOrEqual(AudioRecorder.connectionGracePeriod, 5)
+    }
+}


### PR DESCRIPTION
Closes #98.

@carlotxra's report has the two halves that matter: the recording never completes and cannot be stopped, and a process sample showing the CoreAudio thread still running and still writing packets. Nothing had crashed and nothing had stalled, which is what pointed at a wait rather than a hang.

## What happens

A microphone that has to connect first gets a grace period before the recording counts as live. `startConnectionMonitoring` polls the file size every 50ms and flips `isRecording` after seeing it grow twice.

There was no other exit from that loop. No timeout, no failure path. If the file never grew, the app waited for ever: bubble up, `isRecording` false, and only force-quitting recovered it. A device that went away while the Mac was locked is exactly the shape of input that delivers nothing.

## The fix, and the choice inside it

The wait is bounded at three seconds. Long enough for a Bluetooth headset to wake up, short enough that nobody sits through it wondering whether the app heard them.

Timing out into "live" rather than into a failure is the deliberate part. The recorder is running either way and the person is already talking, so failing the recording would throw their words away in order to fix a state problem. The worst case now is a silent recording they can stop, look at and retry, which is already the risk for every microphone that does not need connecting.

## What I have not done

Reproduced it. The trigger needs @carlotxra's hardware and a lock/unlock cycle. So this fixes an unbounded wait that explains every part of the report, rather than one I have watched happen, and I would rather say that than imply otherwise.

If it recurs, the timeout now logs how much audio had actually arrived, which distinguishes a device delivering nothing from a growth check that was measuring the wrong thing.