### PR TITLE
Log what an insertion was up against

### DIFF
--- a/OpenSuperWhisper/Utils/FocusUtils.swift
+++ b/OpenSuperWhisper/Utils/FocusUtils.swift
@@ -236,6 +236,45 @@ class FocusUtils {
                                    role: role)
     }
 
+
+    /// How much text is already in the focused field, and where the caret sits in it.
+    ///
+    /// Sizes and offsets only, never the text itself: this exists to be written to a diagnostic
+    /// log, and the numbers are what the diagnosis needs. Read from the frontmost application's
+    /// own element rather than the system-wide one, which answers `cannotComplete` in cases where
+    /// asking the application directly works. nil when accessibility cannot say, which is a real
+    /// answer here rather than a failure: an app that reports nothing is itself a finding.
+    static func focusedTextMetrics() -> (length: Int, caret: Int?)? {
+        guard AXIsProcessTrusted(),
+              let front = NSWorkspace.shared.frontmostApplication else { return nil }
+
+        let app = AXUIElementCreateApplication(front.processIdentifier)
+        AXUIElementSetMessagingTimeout(app, axMessagingTimeout)
+
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            app, kAXFocusedUIElementAttribute as CFString, &focused
+        ) == .success, let focused else { return nil }
+
+        let element = focused as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, axMessagingTimeout)
+
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXValueAttribute as CFString, &value
+        ) == .success, let text = value as? String else { return nil }
+
+        var caret: Int?
+        var rangeRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(
+            element, kAXSelectedTextRangeAttribute as CFString, &rangeRef
+        ) == .success, let rangeRef {
+            var range = CFRange()
+            if AXValueGetValue(rangeRef as! AXValue, .cfRange, &range) { caret = range.location }
+        }
+
+        return (text.count, caret)
+    }
 }
 
 private extension AXValue {

--- a/OpenSuperWhisper/Utils/TextInserter.swift
+++ b/OpenSuperWhisper/Utils/TextInserter.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Foundation
 
@@ -53,11 +54,47 @@ enum TextInserter {
     /// Types `text` into the focused app as Unicode keyboard events. Each chunk
     /// is sent as one key-down/key-up pair carrying the Unicode string; modifier
     /// flags are cleared so a still-held hotkey can't combine with the input.
+
+    /// One line describing an insertion, for diagnosing corruption that only happens in the wild.
+    ///
+    /// Asked for on #85 by the person reporting it, and it is the right ask: the fault fires about
+    /// twice in twelve hours, so turning a pacing dial by feel costs days per setting and invites
+    /// reading noise as signal. The numbers at the moment it breaks answer directly what the pause
+    /// should scale with. Written as one flat line so it can be pasted into an issue.
+    ///
+    /// `targetLength` nil is itself a finding rather than a gap: an app that will not say how much
+    /// it is holding is an app where pacing derived from that number cannot work, and the report
+    /// came from an Electron terminal.
+    static func insertionLogLine(app: String, targetLength: Int?, caret: Int?,
+                                 payload: Int, chunks: Int, pause: useconds_t) -> String {
+        let gaps = max(chunks - 1, 0)
+        let target = targetLength.map(String.init) ?? "unavailable"
+        let caretText = caret.map(String.init) ?? "unavailable"
+        return "insert app=\(app) target=\(target) caret=\(caretText) payload=\(payload) "
+            + "chunks=\(chunks) pause=\(pause)us/gap total=\(UInt(pause) * UInt(gaps))us"
+    }
+
+    /// Reads the target's state and logs the line. Skipped entirely when diagnostics are off: the
+    /// accessibility read costs up to 32ms, and the insertion path should not pay that to log
+    /// nothing.
+    private static func logInsertion(payload: String, chunks: Int, pause: useconds_t) {
+        guard Diag.isEnabled else { return }
+        let metrics = FocusUtils.focusedTextMetrics()
+        Diag.mark(insertionLogLine(
+            app: NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown",
+            targetLength: metrics?.length,
+            caret: metrics?.caret,
+            payload: payload.count,
+            chunks: chunks,
+            pause: pause))
+    }
+
     static func type(_ text: String) {
         guard let source = CGEventSource(stateID: .combinedSessionState) else { return }
 
         let allChunks = chunks(of: text)
         let pause = chunkPause(forChunkCount: allChunks.count)
+        logInsertion(payload: text, chunks: allChunks.count, pause: pause)
 
         for (index, chunk) in allChunks.enumerated() {
             guard

--- a/OpenSuperWhisperTests/InsertionDiagnosticsTests.swift
+++ b/OpenSuperWhisperTests/InsertionDiagnosticsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// The line an insertion writes to the log. Its whole job is to be pasted into an issue by
+/// somebody who reproduced a fault we cannot, so the shape of it is the deliverable.
+final class InsertionDiagnosticsTests: XCTestCase {
+
+    func testTheLineCarriesEveryNumberTheDiagnosisNeeds() {
+        let line = TextInserter.insertionLogLine(
+            app: "com.microsoft.VSCode", targetLength: 396, caret: 386,
+            payload: 107, chunks: 6, pause: 2_000)
+
+        XCTAssertEqual(line,
+            "insert app=com.microsoft.VSCode target=396 caret=386 payload=107 "
+            + "chunks=6 pause=2000us/gap total=10000us")
+    }
+
+    /// An app that will not say how much it holds is the finding, not a hole in the log: pacing
+    /// derived from that number cannot work there, and the report came from such an app.
+    func testAnUnreadableTargetSaysSoRatherThanReportingZero() {
+        let line = TextInserter.insertionLogLine(
+            app: "com.example.electron", targetLength: nil, caret: nil,
+            payload: 78, chunks: 4, pause: 2_000)
+
+        XCTAssertTrue(line.contains("target=unavailable"))
+        XCTAssertTrue(line.contains("caret=unavailable"))
+        XCTAssertFalse(line.contains("target=0"))
+    }
+
+    /// The caret is what distinguishes the two failure modes reported: text truncated partway,
+    /// versus the whole burst landing at a stale position. It can be missing while the length is
+    /// readable, so the two are reported independently.
+    func testALengthWithoutACaretIsReportable() {
+        let line = TextInserter.insertionLogLine(
+            app: "dev.warp.Warp-Stable", targetLength: 5_371, caret: nil,
+            payload: 40, chunks: 2, pause: 2_000)
+
+        XCTAssertTrue(line.contains("target=5371"))
+        XCTAssertTrue(line.contains("caret=unavailable"))
+    }
+
+    /// One chunk means no gaps, so the total pause is zero however large the per-gap pause is.
+    func testASingleChunkHasNoTotalPause() {
+        let line = TextInserter.insertionLogLine(
+            app: "x", targetLength: 0, caret: 0, payload: 5, chunks: 1, pause: 2_000)
+
+        XCTAssertTrue(line.contains("chunks=1"))
+        XCTAssertTrue(line.contains("total=0us"))
+    }
+
+    /// The totals in the log have to match what the insertion actually waits, or the numbers sent
+    /// back would describe a build nobody is running.
+    func testTheTotalMatchesWhatThePacingActuallyProduces() {
+        let payload = String(repeating: "a", count: 107)
+        let chunkCount = TextInserter.chunks(of: payload).count
+        let pause = TextInserter.chunkPause(forChunkCount: chunkCount)
+        let line = TextInserter.insertionLogLine(
+            app: "x", targetLength: 396, caret: 386,
+            payload: payload.count, chunks: chunkCount, pause: pause)
+
+        XCTAssertTrue(line.contains("chunks=\(chunkCount)"))
+        XCTAssertTrue(line.contains("total=\(UInt(pause) * UInt(chunkCount - 1))us"))
+    }
+}


### PR DESCRIPTION
Asked for on #85 by the person reporting the corruption, and it is a better plan than the one I had.

The fault fires about twice in twelve hours, so turning a pacing dial by feel costs days per setting and invites reading noise as signal. The numbers at the moment it breaks answer directly what the pause should scale with.

## What it writes

One line per insertion, behind the existing `diagnosticLogging` switch:

```
insert app=com.microsoft.VSCode target=396 caret=386 payload=107 chunks=6 pause=2000us/gap total=10000us
```

`target` is the length already in the field, which is the quantity his analysis says the cost actually depends on and the one my pacing ignored.

The caret is there because his second report has a different shape from the first: the whole burst arrived intact but landed ten characters before the end of the existing text, splitting a word around it. So "did all the text arrive" is not a sufficient test, and truncation is only one of two failure modes.

## An unreadable target is the finding, not a gap

Recorded as `unavailable` rather than as `0`. An app that will not say how much it holds is an app where pacing derived from that number cannot work, and the report came from an Electron terminal. Whether that read works in Electron is the open question this exists to answer, and it is not one I could settle on my own machine: no VS Code here, and my one Electron sample had nothing focused at the time.

## Cost

The accessibility read is 0.1 ms median and 32 ms worst, measured. It only happens when diagnostics are on, so the insertion path pays nothing to log nothing.

This fixes nothing. It measures, so that the fix is not guessed a third time.