### PR TITLE
fix(recorder): keep App Nap from suspending a running recording

### DIFF
--- a/OpenSuperWhisper/AudioRecorder.swift
+++ b/OpenSuperWhisper/AudioRecorder.swift
@@ -23,6 +23,25 @@ class AudioRecorder: NSObject, ObservableObject {
     // Keeps audio hardware warm so the first word is never cut off
     private var primedRecorder: AVAudioRecorder?
 
+    /// Holds App Nap off for as long as a recording is running. Nil when nothing is recording.
+    ///
+    /// App Nap throttles timers and defers dispatch work for an app that is not frontmost and has
+    /// no visible window — which describes every dictation, since the point of the app is to record
+    /// while another app has focus. Playing audio holds App Nap off on its own; *recording* audio
+    /// does not, so a recorder without an assertion gets suspended.
+    ///
+    /// That was #98. CoreAudio's I/O threads are real-time and carry on regardless, so the clip
+    /// kept growing while everything meant to react to it stopped: the connection wait never
+    /// ticked, the `isConnecting`/`isRecording` updates sat unapplied on the main queue, and the
+    /// trigger key did nothing. The bubble stayed up with no way to stop it, and force-quitting was
+    /// the only way out. Locking the Mac or opening Sound settings to change input is simply how
+    /// you end up backgrounded and occluded, which is why the bug looked like it was about
+    /// switching devices.
+    ///
+    /// Idle *system* sleep is deliberately left enabled: a recording that somehow never ends should
+    /// not also keep the Mac awake for ever.
+    private var recordingActivity: NSObjectProtocol?
+
     // MARK: - Singleton Instance
 
     static let shared = AudioRecorder()
@@ -125,18 +144,45 @@ class AudioRecorder: NSObject, ObservableObject {
         }
     }
     
+    /// Tells the system this app is doing work the user asked for, so App Nap leaves it alone.
+    /// See `recordingActivity`. Ending any assertion already held keeps them from stacking: a
+    /// start that never saw a matching stop would otherwise leak one and hold App Nap off for good.
+    /// Internal rather than private so a test can check the pair stays balanced.
+    func beginRecordingActivity() {
+        endRecordingActivity()
+        recordingActivity = ProcessInfo.processInfo.beginActivity(
+            options: .userInitiatedAllowingIdleSystemSleep,
+            reason: "Recording audio for dictation")
+    }
+
+    /// Releases the assertion. Safe to call when none is held, which is what makes it usable both
+    /// on every exit path and as the guard against stacking in `beginRecordingActivity`.
+    func endRecordingActivity() {
+        guard let activity = recordingActivity else { return }
+        ProcessInfo.processInfo.endActivity(activity)
+        recordingActivity = nil
+    }
+
+    /// Whether an assertion is currently held. Exists so a test can check that starting and
+    /// stopping a recording leaves none behind.
+    var isHoldingRecordingActivity: Bool { recordingActivity != nil }
+
     func startRecording() {
         Diag.mark("recorder.startRecording (canRecord=\(canRecord))")
         guard canRecord else {
             print("Cannot start recording - no audio input available")
             return
         }
-        
+
         if isRecording || isConnecting {
             print("stop recording while recording")
             _ = stopRecording()
         }
-        
+
+        // Before any of the audio setup, so the connection wait and the state updates that follow
+        // are already protected from being throttled. (#98)
+        beginRecordingActivity()
+
         if AppPreferences.shared.pauseMediaOnRecord {
             MediaPlaybackController.shared.pauseMedia()
         }
@@ -175,6 +221,10 @@ class AudioRecorder: NSObject, ObservableObject {
         let requiresConnection = Diag.measure("isActiveMicrophoneRequiresConnection") {
             MicrophoneService.shared.isActiveMicrophoneRequiresConnection()
         }
+        // Which device a take ran on and whether it has to connect first: the two facts that pick
+        // the start path, and the first two worth knowing from a report of a take going wrong.
+        Diag.mark("recorder.device=\(MicrophoneService.shared.getActiveMicrophone()?.displayName ?? "none") "
+            + "requiresConnection=\(requiresConnection)")
         updateRecordingState(isRecording: false, isConnecting: requiresConnection)
         startRecordingWithRecorder(fileURL: fileURL, monitorConnection: requiresConnection)
     }
@@ -212,12 +262,20 @@ class AudioRecorder: NSObject, ObservableObject {
         } catch {
             print("Failed to start recording: \(error)")
             currentRecordingURL = nil
+            // No recording to protect, and nothing will call `stopRecording` for a start that
+            // never happened — so release the assertion here or it is held for ever.
+            endRecordingActivity()
             updateRecordingState(isRecording: false, isConnecting: false)
         }
     }
     
     func stopRecording() -> URL? {
-        audioRecorder?.stop()
+        // Runs on the main thread (IndicatorViewModel is @MainActor). AudioQueueStop waits for the
+        // queue to drain, so an input device pulled out from under it could stall the app here —
+        // timed so a `▶` with no `◀` would name it rather than leaving a silent freeze.
+        Diag.measure("AVAudioRecorder.stop") { audioRecorder?.stop() }
+        endRecordingActivity()
+
         updateRecordingState(isRecording: false, isConnecting: false)
         Task { @MainActor in SpectrumAnalyzer.shared.stop() }
         stopConnectionMonitoring()
@@ -231,7 +289,7 @@ class AudioRecorder: NSObject, ObservableObject {
         if AppPreferences.shared.reduceVolumeOnRecord {
             SystemVolumeController.shared.restore()
         }
-        
+
         if let url = currentRecordingURL,
            let duration = try? AVAudioPlayer(contentsOf: url).duration,
            duration < 1.0
@@ -240,14 +298,16 @@ class AudioRecorder: NSObject, ObservableObject {
             currentRecordingURL = nil
             return nil
         }
-        
+
         let url = currentRecordingURL
         currentRecordingURL = nil
         return url
     }
-    
+
     func cancelRecording() {
-        audioRecorder?.stop()
+        // Same blocking AudioQueueStop as `stopRecording`, timed for the same reason.
+        Diag.measure("AVAudioRecorder.stop (cancel)") { audioRecorder?.stop() }
+        endRecordingActivity()
         updateRecordingState(isRecording: false, isConnecting: false)
         Task { @MainActor in SpectrumAnalyzer.shared.stop() }
         stopConnectionMonitoring()
@@ -364,7 +424,7 @@ class AudioRecorder: NSObject, ObservableObject {
         connectionCheckTimer = timer
         timer.resume()
     }
-    
+
     private func stopConnectionMonitoring() {
         connectionCheckTimer?.cancel()
         connectionCheckTimer = nil
@@ -373,9 +433,17 @@ class AudioRecorder: NSObject, ObservableObject {
 
 extension AudioRecorder: AVAudioRecorderDelegate {
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        // Only the failure is worth a line: it clears `currentRecordingURL`, which is also what the
+        // connection monitor guards on, so a take can end here and leave the wait with nothing to
+        // measure.
         if !flag {
+            Diag.mark("recorder.didFinishRecording failed — clip discarded")
             currentRecordingURL = nil
         }
+    }
+
+    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: Error?) {
+        Diag.mark("recorder.encodeError \(error?.localizedDescription ?? "unknown")")
     }
 }
 

--- a/OpenSuperWhisper/Indicator/IndicatorWindow.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindow.swift
@@ -231,6 +231,7 @@ class IndicatorViewModel: ObservableObject {
 
         guard let tempURL = recorder.stopRecording() else {
             print("!!! Not found record url !!!")
+            Diag.mark("vm.startDecoding — no clip returned, nothing to transcribe")
             delegate?.didFinishDecoding()
             return
         }

--- a/OpenSuperWhisper/ShortcutManager.swift
+++ b/OpenSuperWhisper/ShortcutManager.swift
@@ -325,6 +325,10 @@ class ShortcutManager {
                 // trigger key.
                 self.enterLatch()
             } else if !self.holdMode {
+                // Paired with "keyDown → start recording": a stop that is missing from the log
+                // never reached the app, which is a different bug from one that reached it and
+                // did nothing.
+                Diag.mark("keyDown → stop recording")
                 IndicatorWindowManager.shared.stopRecording()
                 self.activeVm = nil
                 LatchKeyMonitor.shared.stop()
@@ -350,6 +354,7 @@ class ShortcutManager {
             // A latched recording ignores the trigger key coming back up — that is the whole point
             // — and waits for Space (or the trigger) to stop it.
             if holdToRecordEnabled && self.holdMode && !self.latched {
+                Diag.mark("keyUp → stop recording (hold)")
                 IndicatorWindowManager.shared.stopRecording()
                 self.activeVm = nil
                 LatchKeyMonitor.shared.stop()

--- a/OpenSuperWhisperTests/AppNapActivityTests.swift
+++ b/OpenSuperWhisperTests/AppNapActivityTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Holding App Nap off for the duration of a recording.
+///
+/// Reported in #98 as a freeze after switching audio input: the recording bubble stayed up, no
+/// state ever changed, the trigger key did nothing, and force-quitting was the only way out.
+/// Nothing was actually stuck. App Nap had suspended the app's timers and deferred its main-queue
+/// work, because it only suppresses App Nap for audio *output* — a recorder has to say so itself.
+/// CoreAudio's I/O threads are real-time and unaffected, so the clip kept growing the whole time,
+/// which is what made it look like a hang rather than a throttle.
+///
+/// What is worth testing here is not App Nap itself — that is the system's behaviour, and the fix
+/// was verified against the real bug — but that the assertion is always balanced. A leaked
+/// assertion holds App Nap off for the rest of the process's life, which is invisible until
+/// something else needs the power.
+final class AppNapActivityTests: XCTestCase {
+
+    private var recorder: AudioRecorder { AudioRecorder.shared }
+
+    override func tearDown() {
+        recorder.endRecordingActivity()
+        super.tearDown()
+    }
+
+    func testNoActivityIsHeldWhileIdle() {
+        recorder.endRecordingActivity()
+        XCTAssertFalse(recorder.isHoldingRecordingActivity)
+    }
+
+    func testBeginningHoldsAnActivity() {
+        recorder.beginRecordingActivity()
+        XCTAssertTrue(recorder.isHoldingRecordingActivity)
+    }
+
+    func testEndingReleasesIt() {
+        recorder.beginRecordingActivity()
+        recorder.endRecordingActivity()
+        XCTAssertFalse(recorder.isHoldingRecordingActivity)
+    }
+
+    /// The leak that matters. Two starts without a stop between them must not stack, or the second
+    /// assertion outlives every `endRecordingActivity` and App Nap stays off for good.
+    func testTwoStartsDoNotStackAssertions() {
+        recorder.beginRecordingActivity()
+        recorder.beginRecordingActivity()
+        recorder.endRecordingActivity()
+        XCTAssertFalse(recorder.isHoldingRecordingActivity)
+    }
+
+    /// Ending is used both on every exit path and as the guard inside `beginRecordingActivity`,
+    /// so it has to tolerate being called with nothing held.
+    func testEndingWithNothingHeldIsHarmless() {
+        recorder.endRecordingActivity()
+        recorder.endRecordingActivity()
+        XCTAssertFalse(recorder.isHoldingRecordingActivity)
+    }
+
+    /// Cancelling a recording releases the assertion, the same as stopping one. Esc used to be the
+    /// only way out of the state in #98, so it must not be the path that leaks.
+    func testCancellingARecordingReleasesTheActivity() {
+        recorder.beginRecordingActivity()
+        recorder.cancelRecording()
+        XCTAssertFalse(recorder.isHoldingRecordingActivity)
+    }
+}


### PR DESCRIPTION
Closes #98.

#98 was closed by #103, but the freeze still reproduces on 0.12.2 (build 51). The cause turns out not to be the connection wait — it is App Nap.

## Reproduction (no lock/unlock needed)

The original report described locking and unlocking the Mac and switching input, which is hard to set up. It is simpler than that:

1. Start a recording while OpenSuperWhisper is **not frontmost** and its windows are occluded (e.g. right after changing input in Sound settings, or after a lock/unlock).
2. Speak.
3. Try to stop it.

The bubble stays up, nothing is transcribed, and the recording cannot be stopped or cancelled. Force-quitting is the only way out.

This is deterministic on my machine. The lock/unlock in the original report is not the trigger — it is just a reliable way to end up backgrounded and occluded.

## Root cause

Nothing is actually stuck. **App Nap suspends the app mid-recording.**

App Nap throttles timers and defers main-queue work for an app that is not frontmost and has no visible window — which describes every dictation, since the point of the app is to record while another app has focus. macOS suppresses App Nap automatically for audio **output**, but not for audio **input**, so a recorder has to declare the activity itself. There is currently no `beginActivity` call anywhere in the codebase.

CoreAudio's I/O threads are real-time and unaffected, so the clip keeps growing at 64KB/s throughout. That is what makes a throttle look like a hang: the recording is fine, and everything meant to *react* to it has stopped.

Instrumented log at the moment of the hang:

```
recorder.updateRecordingState(isRecording: true, isConnecting: false) queued
   ← no matching "applied on main", for over two minutes
```

The identical call 55ms earlier applied in under 1ms. At the same time, `sample` showed the main thread idle in `mach_msg2_trap` (parked, not blocked), idle workqueue threads available, and the AudioQueue still writing packets. The menu bar stayed responsive throughout, because direct user input wakes the app briefly.

Both observed variants have the same cause:

- **`requiresConnection == true`** — the connection wait never ticks, so `isConnecting` never clears and the bubble sits on "Connecting…".
- **`requiresConnection == false`** — the `isRecording: true` update never reaches the main queue, so the bubble sits on "Recording…" from the optimistic local set in `IndicatorViewModel.startRecording()` while the recorder's own state is never updated.

## Why #103 could not have fixed it

#103 added a 3-second timeout to escape the connection wait, but placed it **inside the connection timer's own event handler**:

```swift
timer.setEventHandler { ...
    let elapsed = Date().timeIntervalSince(startedAt)
    guard Self.shouldGoLive(growthObservations: growthCount, elapsed: elapsed) else { return }
```

App Nap had suspended that timer, so `shouldGoLive` was never called. The arithmetic in it is correct — it is simply unreachable in this state.

`ConnectionWaitTests` passes and always would have: it tests `shouldGoLive` in isolation, which was never the broken part. Nothing exercised the loop that calls it.

This also explains the honest note in that commit that it could not be reproduced locally — **with the app frontmost, App Nap never engages.** Testing it interactively hides the bug.

## The fix

An activity assertion held for the life of a recording, in `AudioRecorder`:

```swift
recordingActivity = ProcessInfo.processInfo.beginActivity(
    options: .userInitiatedAllowingIdleSystemSleep,
    reason: "Recording audio for dictation")
```

Released in `stopRecording`, `cancelRecording`, and the start-failure path. `beginRecordingActivity` ends any assertion already held before taking a new one, so a start without a matching stop cannot leak one and pin App Nap off for the life of the process.

Idle **system** sleep is deliberately left enabled. `.idleSystemSleepDisabled` would mean a recording that somehow never ends also keeps the Mac awake indefinitely — trading this bug for a worse one.

## Verification

Confirmed in two stages against the reproduction above:

1. Disabled App Nap externally via `NSAppSleepDisabled`, with **no code change** — bug gone. This established the diagnosis.
2. Removed that key and applied **only this change** — bug gone. This established the fix.

`AppNapActivityTests` adds 6 tests; all 11 across it and `ConnectionWaitTests` pass. The tests deliberately do not attempt to test App Nap itself — that is system behaviour, and it was verified against the real bug. They cover the invariant that can regress silently: assertions must never stack and must always be released, because a leaked one holds App Nap off for the rest of the process's life and is invisible until something else needs the power.

## Diagnostics

Eight `Diag` markers are added or kept — one line per recording (which device, and whether it needs connecting), the timed `AudioQueueStop`, three failure-only markers, and two hotkey stop markers pairing with the existing `keyDown → start recording`. A stop that is missing from the log is a different bug from a stop that arrived and did nothing, and that distinction is what made this findable. `startConnectionMonitoring` is left byte-identical to master.

Most of the diff is the doc comment explaining why the assertion exists; the mechanism is about 15 lines.

## Related issues left out of scope

Happy to open separate PRs for any of these — they are not the cause, but they are why the bug was unrecoverable rather than merely annoying:

1. **The escape hatch is nested inside the thing it guards.** A timeout that rescues a stalled timer cannot live inside that timer. It needs an independent deadline armed at record start.
2. **`handleKeyDown` has states that silently do nothing.** Three branches and no `else`: with `activeVm != nil` and `holdMode == true`, pressing the trigger does nothing and logs nothing. A stuck recording should always be stoppable by the key that started it.
3. **`MainThreadWatchdog` clock race.** `check()` reads the clock before taking its lock, so `beat()` can update `lastBeatNs` in between and `now &- lastBeatNs` underflows, reporting stalls of `≥18446744073s`. False stall reports are worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
