### PR TITLE
Bump the Homebrew tap from the release instead of by hand

### DIFF
--- a/make_release.sh
+++ b/make_release.sh
@@ -151,7 +151,7 @@ if [[ -n "$GITHUB_TOKEN" ]]; then
             "tag_name": "'${TAG}'",
             "target_commitish": "master",
             "name": "Release '${NEW_VERSION}'",
-            "body": "## OpenSuperWhisper '${NEW_VERSION}'\n\nReal-time audio transcription for macOS using Whisper.\n\n## Installation\n\n### Homebrew (Recommended)\n```bash\nbrew update\nbrew install opensuperwhisper\n```\n\n### Manual Installation\n1. Download the `'${APP_NAME}-${ARCH}-${NEW_VERSION}'.dmg` file below\n2. Open the DMG and drag OpenSuperWhisper to Applications\n3. Launch the app and grant necessary permissions\n\n## Requirements\n- macOS 14.0 (Sonoma) or later\n- Apple Silicon (ARM64) Mac",
+            "body": "## OpenSuperWhisper '${NEW_VERSION}'\n\nReal-time audio transcription for macOS using Whisper.\n\n## Installation\n\n### Homebrew (Recommended)\n```bash\nbrew install --cask my-monkeys/tap/opensuperwhisper\n```\nUse the full `my-monkeys/tap/` path: the bare name resolves to the original unmaintained cask, not this fork.\n\n### Manual Installation\n1. Download the `'${APP_NAME}-${ARCH}-${NEW_VERSION}'.dmg` file below\n2. Open the DMG and drag OpenSuperWhisper to Applications\n3. Launch the app and grant necessary permissions\n\n## Requirements\n- macOS 14.0 (Sonoma) or later\n- Apple Silicon or Intel",
             "draft": false,
             "prerelease": false,
             "generate_release_notes": false
@@ -240,27 +240,22 @@ if [[ -f "$DSYM_ZIP_PATH" ]]; then
     echo "   - OpenSuperWhisper.app.dSYM.zip"
 fi
 echo ""
-echo "🍺 Homebrew cask update:"
-echo "-----"
-cat << EOF
-cask "opensuperwhisper" do
-  version "${NEW_VERSION}"
-  sha256 "${SHA256}"
-
-  url "https://github.com/${REPO}/releases/download/v#{version}/${APP_NAME}-${ARCH}-#{version}.dmg"
-  name "OpenSuperWhisper"
-  desc "Whisper dictation/transcription app"
-  homepage "https://github.com/${REPO}"
-
-  depends_on macos: ">= :sonoma"
-  depends_on arch: :arm64
-
-  app "OpenSuperWhisper.app"
-
-  zap trash: [
-    "~/Library/Application Scripts/ru.starmel.OpenSuperWhisper",
-    "~/Library/Application Support/ru.starmel.OpenSuperWhisper",
-  ]
-end
-EOF
-echo "-----" 
+echo "🍺 Homebrew tap:"
+# Not printed for someone to copy by hand any more. What used to be printed here was a
+# single-arch cask that declared `depends_on arch: :arm64` and zapped `ru.starmel.*`, the bundle
+# ID of the project this was forked from — following it produced a cask that was wrong for Intel
+# and cleaned up nothing. So nobody followed it, and the tap sat on 0.9.9 for three releases
+# while Homebrew was the first install route in our own README (#106).
+#
+# The bump reads the checksums off the published release rather than off this build, so it can
+# only run once BOTH architectures are uploaded. Releasing the second one is what completes it;
+# on the first it says so and stops, which is a state to expect rather than a failure.
+if [[ -x "./update_homebrew_tap.sh" ]]; then
+    ./update_homebrew_tap.sh "${NEW_VERSION}" || {
+        echo ""
+        echo "⚠️  The tap was not updated. Run this once the other architecture is published:"
+        echo "    ./update_homebrew_tap.sh ${NEW_VERSION}"
+    }
+else
+    echo "⚠️  update_homebrew_tap.sh not found; the tap still points at whatever it did before."
+fi

--- a/update_homebrew_tap.sh
+++ b/update_homebrew_tap.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Points the Homebrew cask at a published release.
+#
+# This exists because the tap spent three releases stuck on 0.9.9 (#106). Bumping it was a manual
+# step outside the release, so it only happened when somebody noticed, and between July and
+# September nobody did. `brew install opensuperwhisper` is the first line of our own install
+# instructions, so for two months that line handed people a version from before half the app was
+# written.
+#
+# The checksums are taken from what GitHub actually serves, never from the local build. Those are
+# not the same bytes by definition, only by assumption, and the assumption has been wrong here
+# before: a stale DMG from the previous version once survived a failed cleanup and was very nearly
+# shipped under a new number. Downloading is also the only way to be sure the asset a user will be
+# handed exists at all.
+#
+#   ./update_homebrew_tap.sh 0.12.2
+#
+# Safe to run twice: it stops without pushing when the cask already says what it would write.
+
+set -e -o pipefail
+
+VERSION="${1}"
+REPO="${REPO:-my-monkeys/OpenSuperWhisper}"
+TAP="${TAP:-my-monkeys/homebrew-tap}"
+CASK_PATH="Casks/opensuperwhisper.rb"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>            e.g. $0 0.12.2"
+    exit 1
+fi
+
+echo "Pointing the ${TAP} cask at ${REPO} v${VERSION}"
+
+# Both slices, and both are required. A one-armed bump is worse than none: Homebrew picks the
+# stanza matching the machine it is running on, so a missing Intel checksum is invisible on the
+# Apple Silicon Mac doing the release and breaks every Intel install.
+#
+# Plain variables rather than an associative array: macOS ships bash 3.2, where `declare -A` is a
+# syntax error. Written with one and it failed on the only machine that runs it.
+checksum_of() {
+    local arch="$1"
+    local url="https://github.com/${REPO}/releases/download/v${VERSION}/OpenSuperWhisper-${arch}-${VERSION}.dmg"
+
+    # -f so a 404 is a failure rather than an HTML error page quietly hashed into the cask.
+    # `pipefail` is what carries curl's exit code past shasum, which succeeds on anything.
+    curl -sfL "$url" | shasum -a 256 | cut -d' ' -f1
+}
+
+for ARCH in arm64 x86_64; do
+    echo "  fetching ${ARCH}..."
+    if ! DIGEST=$(checksum_of "$ARCH") || [[ -z "$DIGEST" ]]; then
+        echo "No ${ARCH} DMG published for v${VERSION}."
+        echo "Both architectures have to be uploaded before the tap can be bumped."
+        exit 1
+    fi
+    echo "  ${ARCH}  ${DIGEST}"
+    if [[ "$ARCH" == "arm64" ]]; then SHA_ARM="$DIGEST"; else SHA_INTEL="$DIGEST"; fi
+done
+
+WORKTREE=$(mktemp -d)
+trap 'rm -rf "$WORKTREE"' EXIT
+gh repo clone "$TAP" "$WORKTREE" -- --quiet --depth 1
+
+cat > "${WORKTREE}/${CASK_PATH}" <<CASK
+cask "opensuperwhisper" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "${VERSION}"
+
+  on_arm do
+    sha256 "${SHA_ARM}"
+  end
+  on_intel do
+    sha256 "${SHA_INTEL}"
+  end
+
+  url "https://github.com/${REPO}/releases/download/v#{version}/OpenSuperWhisper-#{arch}-#{version}.dmg"
+  name "OpenSuperWhisper"
+  desc "macOS dictation with local Whisper/Parakeet transcription"
+  homepage "https://github.com/${REPO}"
+
+  depends_on macos: :sonoma
+
+  app "OpenSuperWhisper.app"
+  binary "#{appdir}/OpenSuperWhisper.app/Contents/MacOS/OpenSuperWhisper", target: "opensuperwhisper"
+
+  zap trash: [
+    "~/Library/Application Support/fr.my-monkey.opensuperwhisper",
+    "~/Library/Preferences/fr.my-monkey.opensuperwhisper.plist",
+    "~/Library/Caches/fr.my-monkey.opensuperwhisper",
+    "~/Library/Application Support/FluidAudio",
+  ]
+end
+CASK
+
+cd "$WORKTREE"
+if git diff --quiet; then
+    echo "The cask already says this. Nothing to push."
+    exit 0
+fi
+
+git diff --stat
+git add "$CASK_PATH"
+git commit -q -m "opensuperwhisper ${VERSION}"
+git push -q origin HEAD
+echo "Tap updated: https://github.com/${TAP}/blob/main/${CASK_PATH}"


### PR DESCRIPTION
Closes the process side of #106. The cask itself is already fixed and live at 0.12.2, thanks to my-monkeys/homebrew-tap#1; this stops it happening again.

## What went wrong

The tap sat on 0.9.9 from July to September while three versions shipped. Homebrew is the first install route in our own README, so for two months that route handed people a build from before half the app existed.

Bumping it was a manual step outside the release, which is why it only happened when somebody noticed. Nobody had since 0.10.0.

It also could not be done correctly by following our own instructions. `make_release.sh` ended by printing a cask to copy into the tap, and that cask was wrong in three ways:

- single-arch, with one `sha256`, against a project that has shipped an Intel build since 0.5.0
- `depends_on arch: :arm64`, which would have refused to install on Intel outright
- `zap trash:` pointing at `ru.starmel.OpenSuperWhisper`, the bundle identifier of the project this was forked from, so it cleaned up nothing

Anyone who followed it produced a broken cask, so the instruction was worse than no instruction.

## What replaces it

`update_homebrew_tap.sh <version>`, called at the end of the release.

It takes the checksums from the release **GitHub actually serves**, not from the local build. Those are the same bytes only by assumption, and that assumption has been wrong here before: a stale DMG from the previous version once survived a failed cleanup and was very nearly shipped under a new number. Downloading is also the only way to know the asset a user will be handed exists at all.

Both architectures are required before it writes anything. Homebrew picks the stanza matching the machine it is running on, so a missing Intel checksum is invisible on the Apple Silicon Mac doing the release and breaks every Intel install. Each arch is released in its own run, so the first stops and prints the command to finish with, and the second completes the bump.

Running it when the cask already matches pushes nothing, so a re-run costs two downloads and no noise.

## Also fixed

The generated release notes told people to run `brew install opensuperwhisper`. That is the bare name the README explicitly warns against, because it resolves to the original unmaintained cask rather than this fork. They also claimed Apple Silicon was required. Both corrected.

## Verified

- idempotence: run against 0.12.2, reports the cask already says this, pushes nothing
- unpublished version: refuses, exit 1
- half-published release: with the Intel URL pointed at a name that does not exist, it fetches arm64, then refuses on x86_64 and exits 1 rather than writing a one-armed cask
- `bash -n` on both scripts

The first version used `declare -A`, which is a syntax error on the bash 3.2 macOS ships, so it failed on the only machine that runs it. Caught by running it rather than reading it. Plain variables now, with a note saying why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)