### PR TITLE
Three ways the release script failed quietly

### DIFF
--- a/OpenSuperWhisper-arm64.dmg.sha256
+++ b/OpenSuperWhisper-arm64.dmg.sha256
@@ -1,0 +1,1 @@
+01275cba037394e28f7ac0d9a3492cdd8d432ef4da7d414bb11a4024e98c2ba3  ./OpenSuperWhisper-arm64.dmg

--- a/OpenSuperWhisper.xcodeproj/project.pbxproj
+++ b/OpenSuperWhisper.xcodeproj/project.pbxproj
@@ -818,7 +818,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"OpenSuperWhisper/Preview Content\"";
@@ -855,7 +855,7 @@
 					/opt/homebrew/opt/libomp/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -885,7 +885,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"OpenSuperWhisper/Preview Content\"";
@@ -924,7 +924,7 @@
 				);
 				LLVM_LTO = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -950,7 +950,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5C67TFSJ2B;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -961,7 +961,7 @@
 					"$(PROJECT_DIR)/vendor/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.my-monkey.opensuperwhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -976,7 +976,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5C67TFSJ2B;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -987,7 +987,7 @@
 					"$(PROJECT_DIR)/vendor/sherpa-onnx.xcframework/macos-arm64_x86_64/Headers",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.my-monkey.opensuperwhisperTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1001,11 +1001,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5C67TFSJ2B;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.my-monkey.opensuperwhisperUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1018,11 +1018,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5C67TFSJ2B;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.12.2;
+				MARKETING_VERSION = 0.12.3;
 				PRODUCT_BUNDLE_IDENTIFIER = fr.my-monkey.opensuperwhisperUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/make_release.sh
+++ b/make_release.sh
@@ -154,11 +154,16 @@ fi
 if [[ -n "$GITHUB_TOKEN" ]]; then
     # The second architecture joins the release the first one made. A tag carries one release,
     # so creating it again just fails.
+    # `|| true` is load-bearing. On the FIRST architecture there is no release yet, the lookup
+    # 404s, `grep` matches nothing and exits 1, and under `set -e` an assignment from a failing
+    # command substitution aborts the script — right after the tag has been pushed and forty
+    # minutes of notarisation have completed. Finding nothing here is the normal case, not an
+    # error.
     RELEASE_ID=$(curl -s -L \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
         "https://api.github.com/repos/${REPO}/releases/tags/${TAG}" \
-        | grep -o '"id": [0-9]*' | head -1 | grep -o '[0-9]*')
+        | grep -o '"id": [0-9]*' | head -1 | grep -o '[0-9]*' || true)
 
     if [[ -n "$RELEASE_ID" ]]; then
         echo "🚀 Release ${TAG} exists (ID: $RELEASE_ID), adding the ${ARCH} build."
@@ -182,7 +187,10 @@ if [[ -n "$GITHUB_TOKEN" ]]; then
             }')
     
         # Extract release ID from response
-        RELEASE_ID=$(echo "$RELEASE_RESPONSE" | grep -o '"id": [0-9]*' | head -1 | grep -o '[0-9]*')
+        # Same reason: a creation that failed has no id to find, and the explicit check just
+        # below is what should report that, with the response body, rather than `set -e`
+        # killing the run one line earlier and saying nothing.
+        RELEASE_ID=$(echo "$RELEASE_RESPONSE" | grep -o '"id": [0-9]*' | head -1 | grep -o '[0-9]*' || true)
     
         if [[ -z "$RELEASE_ID" ]]; then
             echo "❌ Failed to create GitHub release or extract release ID"

--- a/make_release.sh
+++ b/make_release.sh
@@ -98,7 +98,14 @@ fi
 chmod +x ./notarize_app.sh
 # No exit-code check here: `set -e` already aborts on a non-zero return, so a test on $? would
 # only ever see the 0 of a script that succeeded.
-./notarize_app.sh "${CODE_SIGN_IDENTITY}"
+# ARCH has to be passed positionally. `notarize_app.sh` reads it as `${2:-arm64}`, so leaving it
+# off does not inherit it from the environment, it silently builds arm64 — and then also skips
+# the two things that run only for x86_64 in there: stripping the arm64-only onnxruntime, and
+# pointing Sparkle at the x86_64 appcast. An Intel release built this way is an ARM binary under
+# an Intel name, subscribed to the wrong update feed. The DMG filename carries the architecture,
+# so the run dies looking for a file that was never made, which is the only reason this was a
+# failed release rather than a wrong one.
+./notarize_app.sh "${CODE_SIGN_IDENTITY}" "${ARCH}"
 
 echo "✅ Build and notarization successful!"
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -114,15 +114,24 @@ fi
 DSYM_PATH="./build/Build/Products/Release/OpenSuperWhisper.app.dSYM"
 # Named per architecture: the two slices have different symbols, and uploading both under one
 # name left whichever lost the race with none to read a crash report against.
-DSYM_ZIP_PATH="./OpenSuperWhisper-${ARCH}-${NEW_VERSION}.app.dSYM.zip"
+#
+# Absolute, because the zip is made from inside the build directory. Relative, the `mv` that
+# was meant to bring it back to the repo root renamed it onto itself and left it in the build
+# directory, so the `-f` test below found nothing and the upload was skipped without a word.
+# No release has ever carried a dSYM: not 0.12.2, not 0.12.1, not 0.12.0. Which means every
+# crash report we have been sent had no symbols to read it against.
+DSYM_ZIP_PATH="$(pwd)/OpenSuperWhisper-${ARCH}-${NEW_VERSION}.app.dSYM.zip"
 
 if [[ -d "$DSYM_PATH" ]]; then
     echo "📦 Creating dSYM zip..."
-    cd $(dirname "$DSYM_PATH")
-    zip -r "$(basename "$DSYM_ZIP_PATH")" "$(basename "$DSYM_PATH")" > /dev/null
-    mv "$(basename "$DSYM_ZIP_PATH")" "$DSYM_ZIP_PATH"
-    cd - > /dev/null
-    echo "✅ dSYM zip created: $DSYM_ZIP_PATH"
+    rm -f "$DSYM_ZIP_PATH"
+    # A subshell, so a failure here cannot leave the rest of the script in the build directory.
+    (cd "$(dirname "$DSYM_PATH")" && zip -r -q "$DSYM_ZIP_PATH" "$(basename "$DSYM_PATH")")
+    if [[ ! -f "$DSYM_ZIP_PATH" ]]; then
+        echo "❌ dSYM zip was not written to $DSYM_ZIP_PATH"
+        exit 1
+    fi
+    echo "✅ dSYM zip created: $DSYM_ZIP_PATH ($(du -h "$DSYM_ZIP_PATH" | cut -f1))"
 else
     echo "⚠️ dSYM not found at $DSYM_PATH - skipping dSYM upload"
     DSYM_ZIP_PATH=""


### PR DESCRIPTION
Found by running the 0.12.3 release for real. Four hand-driven two-architecture releases had not shown any of them, because each one either failed silently or drifted without saying so.

## 1. The release lookup killed the first architecture

Mine, from #111, which added the lookup so the second architecture joins the release the first one made.

On the first run there is no release yet. The lookup 404s, `grep` matches nothing and exits 1, and under `set -e` an assignment from a failing command substitution aborts the script. It aborts **after** the tag is pushed and **after** notarisation, and the log just stops at `Pushing tag to origin`.

Reproduced in isolation rather than assumed:

```
$ bash -c 'set -e
X=$(echo "no id here" | grep -o "\"id\": [0-9]*" | head -1 | grep -o "[0-9]*")
echo "unreachable"'
exit code: 1
```

The same guard goes on the id parsed from a creation response, where the explicit `if [[ -z "$RELEASE_ID" ]]` below it is what should report the failure with the body.

## 2. The dSYM never reached a single release

Not new, and worse than the first.

The zip is made from inside the build directory and its path was relative, so the `mv` meant to bring it back to the repo root renamed it onto itself. The `-f` test that follows found nothing at the root and the upload was skipped in silence.

Checked against the published assets: **no release of this project has ever carried a dSYM.** Not 0.12.2, not 0.12.1, not 0.12.0. Every crash report ever sent to us arrived with nothing to symbolicate it against, which is exactly where #107 sits right now.

Absolute path, a subshell so a failure cannot strand the rest of the script in the build directory, and a check that the file exists rather than an assumption.

## 3. The architecture was never passed to the notarisation script

Not new, and the one that could have shipped something wrong.

`make_release.sh` called `./notarize_app.sh "${CODE_SIGN_IDENTITY}"` with no second argument. That script reads `ARCH="${2:-arm64}"`, a positional parameter, so an `ARCH` in the environment is not inherited. Every run built arm64.

Building the wrong slice is the smaller half. The two steps gated on x86_64 live inside that script: stripping the arm64-only onnxruntime, and repointing Sparkle at `appcast-x86_64.xml`. An Intel release made this way is an ARM binary under an Intel name, subscribed to the wrong update feed, and nothing in the run says so.

It failed instead of shipping only because the DMG filename carries the architecture, so the run died looking for a file that was never made. That is luck, not a guard.

## Verified by finishing the release

0.12.3 went out on both architectures with these in place. Each DMG downloaded from GitHub and mounted:

| | arm64 | x86_64 |
|---|---|---|
| checksum matches what was signed and what the cask says | yes | yes |
| version / build | 0.12.3 / 52 | 0.12.3 / **52** |
| real architecture | `arm64` | `x86_64` |
| Sparkle feed | `appcast.xml` | `appcast-x86_64.xml` |
| arm64 onnxruntime stripped | n/a | yes, 0 files |
| Gatekeeper | Notarized Developer ID | Notarized Developer ID |

Same build number on both, which is what #111 was for. Correct Intel feed, which is what defect 3 would have broken. Four assets on the release: two DMGs and, for the first time, two dSYMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)