### PR TITLE
Choose how text is inserted, per app

### DIFF
--- a/OpenSuperWhisper/DictationPipeline.swift
+++ b/OpenSuperWhisper/DictationPipeline.swift
@@ -224,7 +224,7 @@ final class DictationPipeline: ObservableObject {
                 try? FileManager.default.removeItem(at: item.tempURL)
             }
 
-            let pasteTargetMissing = hasText ? insertText(text) : false
+            let pasteTargetMissing = hasText ? insertText(text, targetBundleID: item.context.bundleID) : false
             if hasText {
                 PostRecordHook.runIfEnabled(text: text, audioPath: hookAudioPath, timestamp: item.startedAt, duration: 0)
             }
@@ -315,8 +315,9 @@ final class DictationPipeline: ObservableObject {
     /// the text on the clipboard and notify ⌘V. When no target is found, typing is skipped. The
     /// insertion policy itself lives in `TranscriptInserter`, shared with the re-paste shortcut.
     @discardableResult
-    private func insertText(_ text: String) -> Bool {
+    private func insertText(_ text: String, targetBundleID: String?) -> Bool {
         TranscriptInserter.insert(IndicatorViewModel.applyPostProcessing(text),
-                                  honorAutoPastePreference: true)
+                                  honorAutoPastePreference: true,
+                                  targetBundleID: targetBundleID)
     }
 }

--- a/OpenSuperWhisper/InsertionByAppSection.swift
+++ b/OpenSuperWhisper/InsertionByAppSection.swift
@@ -34,9 +34,17 @@ struct InsertionByAppSection: View {
             }
 
             VStack(alignment: .leading, spacing: 10) {
-                Text("Apps listed here ignore the global “Paste instead of typing” switch.")
-                    .scaledFont(size: 11)
-                    .foregroundColor(STheme.hint)
+                // Both sides of the choice, together. The trade is the whole reason this section
+                // exists, and putting it only in a tooltip on the segmented control showed one
+                // option at a time: you could not learn what the mode you were not on would do
+                // without switching to it first.
+                HStack(alignment: .top, spacing: 6) {
+                    Text("Apps listed here ignore the global “Paste instead of typing” switch.")
+                        .scaledFont(size: 11)
+                        .foregroundColor(STheme.hint)
+                    InfoButton(text: "**Type** sends synthetic keystrokes and leaves the clipboard alone. An app that redraws its whole input area on every keystroke can fall behind, and the text arrives cut short or lands where the cursor used to be. Raising the pace for that app gives it time to keep up.\n\n**Paste** sends a single ⌘V, so there is nothing to fall behind. It needs the clipboard: when transcriptions are not kept there, your previous contents are borrowed and put back around each dictation.")
+                    Spacer()
+                }
 
                 if viewModel.appInsertionRules.isEmpty {
                     Text("No apps yet. Add one below.")

--- a/OpenSuperWhisper/InsertionByAppSection.swift
+++ b/OpenSuperWhisper/InsertionByAppSection.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+/// Per-app choice of how a transcription is put into the app you dictated into.
+///
+/// Typing and pasting fail in opposite places and a single global switch cannot serve both.
+/// Typing posts a keyboard event per twenty characters, and an app that redraws its whole input
+/// area on every keystroke falls behind: the text arrives cut off at a chunk boundary, or arrives
+/// whole at a caret that has moved (#85). Pasting sends one event and is immune, but it needs the
+/// clipboard, and someone who keeps things there on purpose is worse off with it.
+///
+/// A list rather than a built-in check on terminals, because the two reports we have are a
+/// terminal and a text editor, and we only know about those two because two people looked closely
+/// at text they had just dictated. Anyone else can now fix their own app without filing a report
+/// that is hard to place.
+struct InsertionByAppSection: View {
+    @ObservedObject var viewModel: SettingsViewModel
+
+    @State private var showingAppPicker = false
+    @State private var pickerTargetID: UUID?
+
+    var body: some View {
+        SSection(title: "Insertion by app") {
+            SRow(title: "Typing pace",
+                 hint: "Milliseconds between keystroke bursts. Raise it if dictating into a busy input box duplicates or misplaces text; the cost is a slower insertion.") {
+                HStack(spacing: 6) {
+                    Stepper(value: $viewModel.typingPaceMilliseconds,
+                            in: 0...TextInserter.maxChunkPauseMilliseconds) {
+                        Text("\(viewModel.typingPaceMilliseconds) ms")
+                            .scaledFont(size: 12)
+                            .monospacedDigit()
+                    }
+                    .controlSize(.small)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Apps listed here ignore the global “Paste instead of typing” switch.")
+                    .scaledFont(size: 11)
+                    .foregroundColor(STheme.hint)
+
+                if viewModel.appInsertionRules.isEmpty {
+                    Text("No apps yet. Add one below.")
+                        .scaledFont(size: 11)
+                        .foregroundColor(STheme.hint)
+                        .padding(.vertical, 4)
+                }
+
+                ForEach($viewModel.appInsertionRules) { $rule in
+                    ruleRow($rule)
+                }
+
+                Button {
+                    pickerTargetID = nil
+                    showingAppPicker = true
+                } label: {
+                    Label("Add App", systemImage: "plus")
+                        .scaledFont(size: 11.5, weight: .medium)
+                }
+                .controlSize(.small)
+            }
+            .padding(.leading, 16)
+        }
+        .sheet(isPresented: $showingAppPicker) {
+            AppPickerSheet { applyPickedApp($0) }
+        }
+    }
+
+    @ViewBuilder private func ruleRow(_ rule: Binding<AppInsertionRule>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                Button {
+                    pickerTargetID = rule.wrappedValue.id
+                    showingAppPicker = true
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(nsImage: InstalledApps.icon(
+                            forBundleIdentifier: rule.wrappedValue.bundleIdentifier))
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(rule.wrappedValue.appName.isEmpty
+                                 ? "Choose an app…" : rule.wrappedValue.appName)
+                                .scaledFont(size: 12)
+                                .foregroundColor(rule.wrappedValue.appName.isEmpty
+                                                 ? STheme.hint : STheme.text)
+                            if !rule.wrappedValue.bundleIdentifier.isEmpty {
+                                Text(rule.wrappedValue.bundleIdentifier)
+                                    .scaledFont(size: 10)
+                                    .foregroundColor(STheme.hint)
+                            }
+                        }
+                        Image(systemName: "chevron.up.chevron.down")
+                            .scaledFont(size: 9)
+                            .foregroundColor(STheme.hint)
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Change the app")
+
+                Picker("", selection: rule.mode) {
+                    ForEach(AppInsertionMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 120)
+                .help(rule.wrappedValue.mode.subtitle)
+
+                Button {
+                    let id = rule.wrappedValue.id
+                    viewModel.appInsertionRules.removeAll { $0.id == id }
+                } label: {
+                    Image(systemName: "trash")
+                        .scaledFont(size: 11)
+                        .foregroundColor(STheme.hint)
+                }
+                .buttonStyle(.plain)
+                .help("Remove this app")
+                .frame(width: 24)
+            }
+
+            // Only typing has a pace to set, and only here is it worth setting: the global dial
+            // slows every app, and the apps that need it are the exception.
+            if rule.wrappedValue.mode == .type {
+                HStack(spacing: 8) {
+                    Toggle("Custom pace", isOn: Binding(
+                        get: { rule.wrappedValue.typingPaceMilliseconds != nil },
+                        set: { on in
+                            rule.wrappedValue.typingPaceMilliseconds =
+                                on ? viewModel.typingPaceMilliseconds : nil
+                        }))
+                        .scaledFont(size: 11)
+                        .toggleStyle(.checkbox)
+
+                    if let pace = rule.wrappedValue.typingPaceMilliseconds {
+                        Stepper(value: Binding(
+                            get: { pace },
+                            set: { rule.wrappedValue.typingPaceMilliseconds = $0 }),
+                                in: 0...TextInserter.maxChunkPauseMilliseconds) {
+                            Text("\(pace) ms")
+                                .scaledFont(size: 11)
+                                .monospacedDigit()
+                        }
+                        .controlSize(.small)
+                    }
+                }
+                .padding(.leading, 30)
+            }
+        }
+        .padding(.bottom, 2)
+    }
+
+    /// Reassigns the app on the targeted rule, or appends a new one.
+    ///
+    /// A new rule starts on Paste, because that is the mode that fixes the reported problem
+    /// outright. Someone who cannot spare the clipboard switches it to Type and raises the pace,
+    /// which is the reason both controls are here.
+    private func applyPickedApp(_ app: InstalledApp) {
+        if let targetID = pickerTargetID,
+           let index = viewModel.appInsertionRules.firstIndex(where: { $0.id == targetID }) {
+            viewModel.appInsertionRules[index].appName = app.name
+            viewModel.appInsertionRules[index].bundleIdentifier = app.bundleIdentifier
+        } else {
+            viewModel.appInsertionRules.append(
+                AppInsertionRule(bundleIdentifier: app.bundleIdentifier,
+                                 appName: app.name,
+                                 mode: .paste))
+        }
+        pickerTargetID = nil
+    }
+}

--- a/OpenSuperWhisper/Models/AppInsertionRule.swift
+++ b/OpenSuperWhisper/Models/AppInsertionRule.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// How a transcription should reach one particular app.
+///
+/// Typing and pasting fail in opposite places, and which one hurts is a property of the app you
+/// are dictating into rather than something a single global switch can settle.
+///
+/// Typing posts one keyboard event per twenty characters. An app that redraws its whole input
+/// area on every keystroke falls behind, and its buffer and caret drift apart: the text arrives
+/// truncated at a chunk boundary, or arrives whole at a caret that has moved (#85). Pasting sends
+/// one event instead of forty and is immune, but it needs the clipboard, and for someone who
+/// keeps things on the clipboard on purpose that is the worse trade.
+///
+/// So this is a list rather than a terminal check. The two reports we have are a terminal and a
+/// text editor, and we only know about those two because two people looked closely.
+enum AppInsertionMode: String, Codable, CaseIterable, Identifiable {
+    /// Synthetic keystrokes. Leaves the clipboard alone.
+    case type
+    /// A synthetic ⌘V. One event, so a heavy redraw cannot fall behind, at the cost of borrowing
+    /// the clipboard when transcriptions are not kept on it.
+    case paste
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .type: return "Type"
+        case .paste: return "Paste"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .type: return "Synthetic keystrokes. Leaves the clipboard alone."
+        case .paste: return "One ⌘V. Immune to redraw-heavy apps, but uses the clipboard."
+        }
+    }
+}
+
+/// One app, and how text should be put into it.
+struct AppInsertionRule: Codable, Identifiable, Equatable {
+    var id = UUID()
+    var bundleIdentifier: String
+    var appName: String
+    var mode: AppInsertionMode
+
+    /// Milliseconds between keystroke chunks in this app, or nil to use the global pace.
+    ///
+    /// Only meaningful for `.type`. It exists because paste is not the safe side for everyone:
+    /// the person who reported #85 keeps the clipboard in active use, so the answer for a
+    /// difficult app has to be able to be "type, but slower here" rather than only "paste".
+    var typingPaceMilliseconds: Int?
+
+    init(id: UUID = UUID(), bundleIdentifier: String = "", appName: String = "",
+         mode: AppInsertionMode = .paste, typingPaceMilliseconds: Int? = nil) {
+        self.id = id
+        self.bundleIdentifier = bundleIdentifier
+        self.appName = appName
+        self.mode = mode
+        self.typingPaceMilliseconds = typingPaceMilliseconds
+    }
+}
+
+extension AppInsertionRule {
+
+    /// The rule that applies to `bundleID`, or nil when nothing matches and the global settings
+    /// should decide.
+    ///
+    /// Matched case-insensitively, because a bundle identifier typed by hand rarely comes out
+    /// with the same capitalisation as the one the system reports. The first match wins, so a
+    /// duplicated identifier behaves like the list reads rather than unpredictably.
+    static func rule(for bundleID: String?, in rules: [AppInsertionRule]) -> AppInsertionRule? {
+        guard let bundleID, !bundleID.isEmpty else { return nil }
+        return rules.first {
+            !$0.bundleIdentifier.isEmpty
+                && $0.bundleIdentifier.compare(bundleID, options: .caseInsensitive) == .orderedSame
+        }
+    }
+}

--- a/OpenSuperWhisper/PasteLastTranscript.swift
+++ b/OpenSuperWhisper/PasteLastTranscript.swift
@@ -53,8 +53,14 @@ enum PasteLastTranscript {
 
         // `honorAutoPastePreference: false` — asking for this insertion *is* the request, so a
         // user who dictates to the clipboard only still gets text where the cursor is.
-        let targetMissing = TranscriptInserter.insert(IndicatorViewModel.applyPostProcessing(text),
-                                                      honorAutoPastePreference: false)
+        //
+        // The target here is whatever is frontmost right now, unlike the pipeline, which uses the
+        // app that was frontmost when the clip was recorded. This insertion has no earlier moment
+        // to refer back to: the request is being made now, at this window.
+        let targetMissing = TranscriptInserter.insert(
+            IndicatorViewModel.applyPostProcessing(text),
+            honorAutoPastePreference: false,
+            targetBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
         if targetMissing {
             IndicatorWindowManager.shared.flash(.info("Copied — press ⌘V"))
         }

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -582,6 +582,14 @@ class SettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var typingPaceMilliseconds: Int {
+        didSet { AppPreferences.shared.typingPaceMilliseconds = typingPaceMilliseconds }
+    }
+
+    @Published var appInsertionRules: [AppInsertionRule] {
+        didSet { AppPreferences.shared.appInsertionRules = appInsertionRules }
+    }
+
     @Published var appContextProfiles: [AppContextProfile] {
         didSet {
             AppPreferences.shared.appContextProfiles = appContextProfiles
@@ -744,6 +752,8 @@ class SettingsViewModel: ObservableObject {
         self.notifyWhenNoPasteTarget = prefs.notifyWhenNoPasteTarget
         self.submitOnVoiceCommand = prefs.submitOnVoiceCommand
         self.appContextFormattingEnabled = prefs.appContextFormattingEnabled
+        self.typingPaceMilliseconds = prefs.typingPaceMilliseconds
+        self.appInsertionRules = prefs.appInsertionRules
         self.appContextProfiles = prefs.appContextProfiles
         self.pauseMediaOnRecord = prefs.pauseMediaOnRecord
         self.reduceVolumeOnRecord = prefs.reduceVolumeOnRecord
@@ -2022,7 +2032,7 @@ struct SettingsView: View {
                     SToggle(isOn: $viewModel.autoPasteTranscription)
                 }
                 SRow(title: "Paste instead of typing",
-                     hint: "⌘V instead of synthetic keystrokes — helps in Electron apps and Messages") {
+                     hint: "⌘V instead of synthetic keystrokes — helps in Electron apps and Messages. Apps listed under Insertion by app override this.") {
                     SToggle(isOn: $viewModel.pasteInsteadOfTyping)
                 }
                 SRow(title: "Notify when no paste target",
@@ -2043,6 +2053,8 @@ struct SettingsView: View {
                     SToggle(isOn: $viewModel.addSpaceAfterSentence)
                 }
             }
+
+            InsertionByAppSection(viewModel: viewModel)
         }
     }
 

--- a/OpenSuperWhisper/Utils/AppPreferences.swift
+++ b/OpenSuperWhisper/Utils/AppPreferences.swift
@@ -478,6 +478,33 @@ final class AppPreferences {
     @UserDefault(key: "appContextFormattingEnabled", defaultValue: false)
     var appContextFormattingEnabled: Bool
 
+    /// Milliseconds between keystroke chunks while typing. See `TextInserter`.
+    ///
+    /// A dial rather than a constant because the quantity it has to cover, the target's redraw
+    /// cost, is not something we can read in every app: the accessibility read comes back empty
+    /// in several, including the Electron terminal that produced #85. Handing the number to the
+    /// person who hits the bug beats another constant chosen by reasoning, which is how the
+    /// first attempt came to scale on the wrong thing.
+    @UserDefault(key: "typingPaceMilliseconds", defaultValue: 2)
+    var typingPaceMilliseconds: Int
+
+    @OptionalUserDefault(key: "appInsertionRulesData")
+    private var appInsertionRulesData: Data?
+
+    /// Per-app overrides of how text is inserted. Empty by default: no rule means the global
+    /// paste-or-type setting decides, exactly as before.
+    var appInsertionRules: [AppInsertionRule] {
+        get {
+            guard let data = appInsertionRulesData,
+                  let rules = try? JSONDecoder().decode([AppInsertionRule].self, from: data)
+            else { return [] }
+            return rules
+        }
+        set {
+            appInsertionRulesData = try? JSONEncoder().encode(newValue)
+        }
+    }
+
     @OptionalUserDefault(key: "appContextProfilesData")
     private var appContextProfilesData: Data?
 

--- a/OpenSuperWhisper/Utils/TextInserter.swift
+++ b/OpenSuperWhisper/Utils/TextInserter.swift
@@ -29,14 +29,33 @@ enum TextInserter {
         return result
     }
 
-    /// Pause between chunks, so the receiving app gets a chance to process each one.
+    /// Default pause between chunks, so the receiving app gets a chance to process each one.
     ///
     /// Unpaced, a 400-character dictation is ~40 key events posted inside a millisecond. An app
     /// that re-renders its whole input area per keystroke falls behind, and its buffer and caret
     /// drift apart: reported as existing text duplicated two or three times with the new speech
     /// wedged inside, in a terminal TUI, and it got likelier the fuller the input box already was
     /// (#85). Paste mode was unaffected, which is one event instead of forty.
-    static let chunkPauseMicroseconds: useconds_t = 2_000
+    ///
+    /// Two milliseconds is not enough for the app that produced the report, and the reason is that
+    /// the cost this has to cover is the target's redraw, which scales with what the box already
+    /// holds rather than with what we are sending. A short dictation into a long message therefore
+    /// gets the least pacing exactly where it needs the most, and no single constant fixes that.
+    /// Measured there at 10ms of total pacing into a 400-character box, still corrupt. So this is
+    /// a default that can be raised, globally and per app, rather than the answer.
+    static let defaultChunkPauseMilliseconds = 2
+
+    /// Anything above this is almost certainly a mistake rather than a preference: at 50ms a
+    /// 400-character dictation would take two seconds of blocked main thread.
+    static let maxChunkPauseMilliseconds = 50
+
+    static var chunkPauseMicroseconds: useconds_t {
+        microseconds(fromMilliseconds: AppPreferences.shared.typingPaceMilliseconds)
+    }
+
+    static func microseconds(fromMilliseconds milliseconds: Int) -> useconds_t {
+        useconds_t(min(max(milliseconds, 0), maxChunkPauseMilliseconds)) * 1_000
+    }
 
     /// Ceiling on the delay this adds in total. Typing runs on the main thread, and it has to:
     /// the caller presses Return after it returns, so going async would race the submit key
@@ -44,11 +63,12 @@ enum TextInserter {
     /// than freezing the app.
     static let maxTotalPauseMicroseconds: useconds_t = 500_000
 
-    /// How long to wait between chunks for a text of `chunkCount` chunks.
-    static func chunkPause(forChunkCount chunkCount: Int) -> useconds_t {
-        guard chunkCount > 1 else { return 0 }
+    /// How long to wait between chunks for a text of `chunkCount` chunks, given a requested pace.
+    static func chunkPause(forChunkCount chunkCount: Int,
+                           requested: useconds_t = TextInserter.chunkPauseMicroseconds) -> useconds_t {
+        guard chunkCount > 1, requested > 0 else { return 0 }
         let gaps = useconds_t(chunkCount - 1)
-        return min(chunkPauseMicroseconds, maxTotalPauseMicroseconds / gaps)
+        return min(requested, maxTotalPauseMicroseconds / gaps)
     }
 
     /// Types `text` into the focused app as Unicode keyboard events. Each chunk
@@ -89,11 +109,15 @@ enum TextInserter {
             pause: pause))
     }
 
-    static func type(_ text: String) {
+    /// - Parameter paceMilliseconds: gap between chunks. Defaults to the global setting; a
+    ///   per-app rule passes its own, because the app being dictated into is what decides how
+    ///   much pacing is needed.
+    static func type(_ text: String, paceMilliseconds: Int? = nil) {
         guard let source = CGEventSource(stateID: .combinedSessionState) else { return }
 
         let allChunks = chunks(of: text)
-        let pause = chunkPause(forChunkCount: allChunks.count)
+        let requested = paceMilliseconds.map(microseconds(fromMilliseconds:)) ?? chunkPauseMicroseconds
+        let pause = chunkPause(forChunkCount: allChunks.count, requested: requested)
         logInsertion(payload: text, chunks: allChunks.count, pause: pause)
 
         for (index, chunk) in allChunks.enumerated() {

--- a/OpenSuperWhisper/Utils/TextInserter.swift
+++ b/OpenSuperWhisper/Utils/TextInserter.swift
@@ -85,23 +85,51 @@ enum TextInserter {
     /// `targetLength` nil is itself a finding rather than a gap: an app that will not say how much
     /// it is holding is an app where pacing derived from that number cannot work, and the report
     /// came from an Electron terminal.
-    static func insertionLogLine(app: String, targetLength: Int?, caret: Int?,
+    /// - Parameters:
+    ///   - app: the app actually receiving the events, read now.
+    ///   - dictatedInto: the app the clip was recorded in, which is what the per-app rule was
+    ///     resolved from. The two differ whenever the user switches apps while transcription
+    ///     runs, and their disagreement is itself worth seeing: the pace on this line came from
+    ///     the second, so a line that named only the first would attribute one app's rule to
+    ///     another and send triage into the settings code.
+    ///   - rule: what the rule lookup decided, so a rule that matched can be told apart from one
+    ///     that silently did not. A typo in a bundle identifier and no rule at all otherwise
+    ///     produce the same line, and that is the first question anyone reading #85 now asks.
+    static func insertionLogLine(app: String, dictatedInto: String?, rule: String,
+                                 mechanism: String, targetLength: Int?, caret: Int?,
                                  payload: Int, chunks: Int, pause: useconds_t) -> String {
         let gaps = max(chunks - 1, 0)
         let target = targetLength.map(String.init) ?? "unavailable"
         let caretText = caret.map(String.init) ?? "unavailable"
-        return "insert app=\(app) target=\(target) caret=\(caretText) payload=\(payload) "
+        return "insert via=\(mechanism) app=\(app) dictated-into=\(dictatedInto ?? "unknown") "
+            + "rule=\(rule) target=\(target) caret=\(caretText) payload=\(payload) "
             + "chunks=\(chunks) pause=\(pause)us/gap total=\(UInt(pause) * UInt(gaps))us"
+    }
+
+    /// How a rule reads on the diagnostic line.
+    static func ruleDescription(_ rule: AppInsertionRule?) -> String {
+        guard let rule else { return "none" }
+        guard rule.mode == .type, let pace = rule.typingPaceMilliseconds else {
+            return rule.mode.rawValue
+        }
+        return "\(rule.mode.rawValue)@\(pace)ms"
     }
 
     /// Reads the target's state and logs the line. Skipped entirely when diagnostics are off: the
     /// accessibility read costs up to 32ms, and the insertion path should not pay that to log
     /// nothing.
-    private static func logInsertion(payload: String, chunks: Int, pause: useconds_t) {
+    /// Called by `TranscriptInserter`, which is where the rule and the recorded app are known.
+    /// Logging from inside `type()` could only see the app in front right now, which is not the
+    /// one the decision was made for.
+    static func logInsertion(payload: String, mechanism: String, dictatedInto: String?,
+                             rule: AppInsertionRule?, chunks: Int, pause: useconds_t) {
         guard Diag.isEnabled else { return }
         let metrics = FocusUtils.focusedTextMetrics()
         Diag.mark(insertionLogLine(
             app: NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown",
+            dictatedInto: dictatedInto,
+            rule: ruleDescription(rule),
+            mechanism: mechanism,
             targetLength: metrics?.length,
             caret: metrics?.caret,
             payload: payload.count,
@@ -118,7 +146,6 @@ enum TextInserter {
         let allChunks = chunks(of: text)
         let requested = paceMilliseconds.map(microseconds(fromMilliseconds:)) ?? chunkPauseMicroseconds
         let pause = chunkPause(forChunkCount: allChunks.count, requested: requested)
-        logInsertion(payload: text, chunks: allChunks.count, pause: pause)
 
         for (index, chunk) in allChunks.enumerated() {
             guard

--- a/OpenSuperWhisper/Utils/TranscriptInserter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptInserter.swift
@@ -15,12 +15,18 @@ enum TranscriptInserter {
     ///     "Auto-paste transcription" preference decides whether anything is inserted at all.
     ///     `false` when the user explicitly asked for this insertion — the request itself is the
     ///     intent, so a clipboard-only workflow still gets text where the cursor is.
+    ///   - targetBundleID: the app being dictated into, for the per-app insertion rules. Passed by
+    ///     the pipeline from the snapshot taken at record start rather than read here: transcription
+    ///     runs in the background, so by the time this executes the frontmost app may be a different
+    ///     one, and the rule has to be the one for the app the text is going to.
     /// - Returns: `true` when insertion was skipped because no editable field was focused, so the
     ///   caller can leave the text on the clipboard and notify ⌘V.
     @MainActor
     @discardableResult
-    static func insert(_ text: String, honorAutoPastePreference: Bool) -> Bool {
+    static func insert(_ text: String, honorAutoPastePreference: Bool,
+                       targetBundleID: String? = nil) -> Bool {
         let prefs = AppPreferences.shared
+        let rule = AppInsertionRule.rule(for: targetBundleID, in: prefs.appInsertionRules)
 
         // Optional, independent clipboard stash (never the insertion mechanism).
         if prefs.autoCopyToClipboard {
@@ -29,7 +35,9 @@ enum TranscriptInserter {
 
         guard prefs.autoPasteTranscription || !honorAutoPastePreference else { return false }
 
-        if prefs.pasteInsteadOfTyping {
+        // A rule for this app wins over the global switch, which is the whole point of having one.
+        let pasting = rule.map { $0.mode == .paste } ?? prefs.pasteInsteadOfTyping
+        if pasting {
             // Paste is universal: ⌘V lands in any text field, including apps the accessibility check
             // can't read (Messages, Electron), and is a harmless no-op otherwise. So no editable-
             // target gate — it only ever produces false negatives (#paste-messages).
@@ -55,7 +63,9 @@ enum TranscriptInserter {
             }
             return true
         }
-        Diag.measure("TextInserter.type") { TextInserter.type(text) }
+        Diag.measure("TextInserter.type") {
+            TextInserter.type(text, paceMilliseconds: rule?.typingPaceMilliseconds)
+        }
         return false
     }
 }

--- a/OpenSuperWhisper/Utils/TranscriptInserter.swift
+++ b/OpenSuperWhisper/Utils/TranscriptInserter.swift
@@ -37,10 +37,25 @@ enum TranscriptInserter {
 
         // A rule for this app wins over the global switch, which is the whole point of having one.
         let pasting = rule.map { $0.mode == .paste } ?? prefs.pasteInsteadOfTyping
+
+        // Logged from here rather than from inside `TextInserter`, because this is where the
+        // decision is made: which rule matched, which app it was resolved from, and which of the
+        // two mechanisms ran. Logging it one layer down could only report the app in front right
+        // now, which is not the one the rule came from once transcription has run in between.
+        func log(mechanism: String, chunks: Int, pause: useconds_t) {
+            TextInserter.logInsertion(payload: text, mechanism: mechanism,
+                                      dictatedInto: targetBundleID, rule: rule,
+                                      chunks: chunks, pause: pause)
+        }
+
         if pasting {
             // Paste is universal: ⌘V lands in any text field, including apps the accessibility check
             // can't read (Messages, Electron), and is a harmless no-op otherwise. So no editable-
             // target gate — it only ever produces false negatives (#paste-messages).
+            // One event, so there is nothing to pace and nothing to chunk. Logged all the same:
+            // a report has to be able to say which mechanism ran, and a paste that logged
+            // nothing looked exactly like an insertion that never happened.
+            log(mechanism: "paste", chunks: 1, pause: 0)
             if prefs.autoCopyToClipboard {
                 Diag.measure("TextInserter.paste") { TextInserter.paste() }
             } else {
@@ -63,8 +78,15 @@ enum TranscriptInserter {
             }
             return true
         }
+        let pace = rule?.typingPaceMilliseconds
+        let chunkCount = TextInserter.chunks(of: text).count
+        let requested = pace.map(TextInserter.microseconds(fromMilliseconds:))
+            ?? TextInserter.chunkPauseMicroseconds
+        log(mechanism: "type", chunks: chunkCount,
+            pause: TextInserter.chunkPause(forChunkCount: chunkCount, requested: requested))
+
         Diag.measure("TextInserter.type") {
-            TextInserter.type(text, paceMilliseconds: rule?.typingPaceMilliseconds)
+            TextInserter.type(text, paceMilliseconds: pace)
         }
         return false
     }

--- a/OpenSuperWhisperTests/AppInsertionRuleTests.swift
+++ b/OpenSuperWhisperTests/AppInsertionRuleTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// Choosing how text reaches one particular app, and how fast.
+///
+/// From #85: typing posts a keyboard event per twenty characters, and an app that redraws its
+/// whole input area per keystroke falls behind, losing part of the text or landing all of it at a
+/// caret that has moved. Pasting is immune and costs the clipboard. Which of those is the worse
+/// trade depends on the app and on the person, so it is a list.
+final class AppInsertionRuleTests: XCTestCase {
+
+    private let vsCode = AppInsertionRule(
+        bundleIdentifier: "com.microsoft.VSCode", appName: "Visual Studio Code",
+        mode: .type, typingPaceMilliseconds: 12)
+    private let terminal = AppInsertionRule(
+        bundleIdentifier: "com.apple.Terminal", appName: "Terminal", mode: .paste)
+
+    private var rules: [AppInsertionRule] { [vsCode, terminal] }
+
+    // MARK: - Matching
+
+    func testTheRuleForAnAppIsFound() {
+        XCTAssertEqual(AppInsertionRule.rule(for: "com.apple.Terminal", in: rules), terminal)
+    }
+
+    /// A bundle identifier typed by hand rarely comes out capitalised the way the system reports
+    /// it, and a rule that silently does not apply is worse than no rule at all.
+    func testMatchingIgnoresCase() {
+        XCTAssertEqual(AppInsertionRule.rule(for: "com.microsoft.vscode", in: rules), vsCode)
+        XCTAssertEqual(AppInsertionRule.rule(for: "COM.APPLE.TERMINAL", in: rules), terminal)
+    }
+
+    /// No rule means the global setting decides, which is what every existing install gets.
+    func testAnAppWithNoRuleMatchesNothing() {
+        XCTAssertNil(AppInsertionRule.rule(for: "com.apple.Notes", in: rules))
+        XCTAssertNil(AppInsertionRule.rule(for: nil, in: rules))
+        XCTAssertNil(AppInsertionRule.rule(for: "", in: rules))
+    }
+
+    /// A half-filled row in the editor must not swallow every app that comes past it.
+    func testARuleWithNoIdentifierNeverMatches() {
+        let blank = AppInsertionRule(bundleIdentifier: "", appName: "", mode: .paste)
+
+        XCTAssertNil(AppInsertionRule.rule(for: "com.apple.Notes", in: [blank]))
+        XCTAssertEqual(AppInsertionRule.rule(for: "com.apple.Terminal", in: [blank, terminal]),
+                       terminal)
+    }
+
+    /// Duplicates are the user's business, but the behaviour has to be the one the list reads.
+    func testTheFirstMatchWins() {
+        let second = AppInsertionRule(bundleIdentifier: "com.apple.Terminal",
+                                      appName: "Terminal again", mode: .type)
+
+        XCTAssertEqual(AppInsertionRule.rule(for: "com.apple.Terminal", in: [terminal, second]),
+                       terminal)
+    }
+
+    // MARK: - Round trip
+
+    /// The list lives in UserDefaults as JSON, so a rule has to survive encoding unchanged,
+    /// including the optional pace that is the whole point of the typing case.
+    func testARuleSurvivesEncoding() throws {
+        let data = try JSONEncoder().encode(rules)
+        let decoded = try JSONDecoder().decode([AppInsertionRule].self, from: data)
+
+        XCTAssertEqual(decoded, rules)
+        XCTAssertEqual(decoded.first?.typingPaceMilliseconds, 12)
+        XCTAssertNil(decoded.last?.typingPaceMilliseconds)
+    }
+
+    // MARK: - The pace
+
+    func testMillisecondsBecomeMicroseconds() {
+        XCTAssertEqual(TextInserter.microseconds(fromMilliseconds: 2), 2_000)
+        XCTAssertEqual(TextInserter.microseconds(fromMilliseconds: 12), 12_000)
+    }
+
+    /// Typing blocks the main thread, because the caller presses Return after it returns and going
+    /// async would race the submit key against its own text. So a number typed into a settings
+    /// field cannot be allowed to freeze the app.
+    func testThePaceIsClamped() {
+        XCTAssertEqual(TextInserter.microseconds(fromMilliseconds: -5), 0)
+        XCTAssertEqual(TextInserter.microseconds(fromMilliseconds: 9_999),
+                       useconds_t(TextInserter.maxChunkPauseMilliseconds) * 1_000)
+    }
+
+    /// A normal dictation gets the pace it asked for.
+    func testAShortTextGetsTheFullPace() {
+        XCTAssertEqual(TextInserter.chunkPause(forChunkCount: 6, requested: 12_000), 12_000)
+    }
+
+    /// And a very long one trades pacing for responsiveness rather than stalling the app, since
+    /// the total is what blocks the main thread.
+    func testAVeryLongTextIsCappedInTotal() {
+        let chunks = 500
+        let pause = TextInserter.chunkPause(forChunkCount: chunks, requested: 12_000)
+
+        XCTAssertLessThan(pause, 12_000)
+        XCTAssertLessThanOrEqual(UInt(pause) * UInt(chunks - 1),
+                                 UInt(TextInserter.maxTotalPauseMicroseconds))
+    }
+
+    /// The higher the pace, the sooner the cap starts biting. Worth pinning: raising the dial must
+    /// shorten the text at which it takes effect, not silently do nothing.
+    func testARaisedPaceReachesTheCapSooner() {
+        let chunks = 100
+        let slow = TextInserter.chunkPause(forChunkCount: chunks, requested: 20_000)
+        let quick = TextInserter.chunkPause(forChunkCount: chunks, requested: 2_000)
+
+        XCTAssertEqual(quick, 2_000, "2ms over 100 chunks is well inside the total budget")
+        XCTAssertLessThan(slow, 20_000, "20ms over 100 chunks is not")
+    }
+
+    func testNoPaceMeansNoWait() {
+        XCTAssertEqual(TextInserter.chunkPause(forChunkCount: 10, requested: 0), 0)
+        XCTAssertEqual(TextInserter.chunkPause(forChunkCount: 1, requested: 12_000), 0)
+    }
+}

--- a/OpenSuperWhisperTests/InsertionDiagnosticsTests.swift
+++ b/OpenSuperWhisperTests/InsertionDiagnosticsTests.swift
@@ -8,11 +8,13 @@ final class InsertionDiagnosticsTests: XCTestCase {
 
     func testTheLineCarriesEveryNumberTheDiagnosisNeeds() {
         let line = TextInserter.insertionLogLine(
-            app: "com.microsoft.VSCode", targetLength: 396, caret: 386,
+            app: "com.microsoft.VSCode", dictatedInto: "com.microsoft.VSCode", rule: "none",
+            mechanism: "type", targetLength: 396, caret: 386,
             payload: 107, chunks: 6, pause: 2_000)
 
         XCTAssertEqual(line,
-            "insert app=com.microsoft.VSCode target=396 caret=386 payload=107 "
+            "insert via=type app=com.microsoft.VSCode dictated-into=com.microsoft.VSCode "
+            + "rule=none target=396 caret=386 payload=107 "
             + "chunks=6 pause=2000us/gap total=10000us")
     }
 
@@ -20,7 +22,8 @@ final class InsertionDiagnosticsTests: XCTestCase {
     /// derived from that number cannot work there, and the report came from such an app.
     func testAnUnreadableTargetSaysSoRatherThanReportingZero() {
         let line = TextInserter.insertionLogLine(
-            app: "com.example.electron", targetLength: nil, caret: nil,
+            app: "com.example.electron", dictatedInto: "com.example.electron", rule: "none",
+            mechanism: "type", targetLength: nil, caret: nil,
             payload: 78, chunks: 4, pause: 2_000)
 
         XCTAssertTrue(line.contains("target=unavailable"))
@@ -33,7 +36,8 @@ final class InsertionDiagnosticsTests: XCTestCase {
     /// readable, so the two are reported independently.
     func testALengthWithoutACaretIsReportable() {
         let line = TextInserter.insertionLogLine(
-            app: "dev.warp.Warp-Stable", targetLength: 5_371, caret: nil,
+            app: "dev.warp.Warp-Stable", dictatedInto: "dev.warp.Warp-Stable", rule: "none",
+            mechanism: "type", targetLength: 5_371, caret: nil,
             payload: 40, chunks: 2, pause: 2_000)
 
         XCTAssertTrue(line.contains("target=5371"))
@@ -43,7 +47,8 @@ final class InsertionDiagnosticsTests: XCTestCase {
     /// One chunk means no gaps, so the total pause is zero however large the per-gap pause is.
     func testASingleChunkHasNoTotalPause() {
         let line = TextInserter.insertionLogLine(
-            app: "x", targetLength: 0, caret: 0, payload: 5, chunks: 1, pause: 2_000)
+            app: "x", dictatedInto: "x", rule: "none", mechanism: "type",
+            targetLength: 0, caret: 0, payload: 5, chunks: 1, pause: 2_000)
 
         XCTAssertTrue(line.contains("chunks=1"))
         XCTAssertTrue(line.contains("total=0us"))
@@ -56,10 +61,69 @@ final class InsertionDiagnosticsTests: XCTestCase {
         let chunkCount = TextInserter.chunks(of: payload).count
         let pause = TextInserter.chunkPause(forChunkCount: chunkCount)
         let line = TextInserter.insertionLogLine(
-            app: "x", targetLength: 396, caret: 386,
+            app: "x", dictatedInto: "x", rule: "none", mechanism: "type",
+            targetLength: 396, caret: 386,
             payload: payload.count, chunks: chunkCount, pause: pause)
 
         XCTAssertTrue(line.contains("chunks=\(chunkCount)"))
         XCTAssertTrue(line.contains("total=\(UInt(pause) * UInt(chunkCount - 1))us"))
+    }
+
+    // MARK: - Which app, and which rule
+
+    /// The app receiving the keystrokes and the app the rule came from are different questions,
+    /// and they have different answers whenever someone switches app while transcription runs.
+    /// A line naming only the first would attribute one app's pace to another and send whoever
+    /// reads it into the settings code.
+    func testTheReceivingAppAndTheDictatedAppAreBothNamed() {
+        let line = TextInserter.insertionLogLine(
+            app: "com.apple.Safari", dictatedInto: "com.apple.Terminal", rule: "type@12ms",
+            mechanism: "type", targetLength: 396, caret: 386,
+            payload: 107, chunks: 6, pause: 12_000)
+
+        XCTAssertTrue(line.contains("app=com.apple.Safari"))
+        XCTAssertTrue(line.contains("dictated-into=com.apple.Terminal"))
+    }
+
+    /// A rule that matched and a rule that silently did not produce the same pause when the pace
+    /// is left at the default, so the line has to say which happened. A typo in a bundle
+    /// identifier is the likeliest way to get the second.
+    func testAMatchedRuleIsDistinguishableFromNoRule() {
+        let matched = TextInserter.ruleDescription(
+            AppInsertionRule(bundleIdentifier: "com.apple.Terminal", appName: "Terminal",
+                             mode: .type, typingPaceMilliseconds: 12))
+        let matchedAtGlobalPace = TextInserter.ruleDescription(
+            AppInsertionRule(bundleIdentifier: "com.apple.Terminal", appName: "Terminal",
+                             mode: .type))
+        let pasting = TextInserter.ruleDescription(
+            AppInsertionRule(bundleIdentifier: "com.apple.Terminal", appName: "Terminal",
+                             mode: .paste))
+
+        XCTAssertEqual(matched, "type@12ms")
+        XCTAssertEqual(matchedAtGlobalPace, "type")
+        XCTAssertEqual(pasting, "paste")
+        XCTAssertEqual(TextInserter.ruleDescription(nil), "none")
+    }
+
+    /// Pasting logs too. It has nothing to pace, but a report has to be able to say which of the
+    /// two mechanisms ran, and a paste that logged nothing read exactly like an insertion that
+    /// never happened.
+    func testPastingIsReportedAsItsOwnMechanism() {
+        let line = TextInserter.insertionLogLine(
+            app: "com.apple.Terminal", dictatedInto: "com.apple.Terminal", rule: "paste",
+            mechanism: "paste", targetLength: 396, caret: nil,
+            payload: 107, chunks: 1, pause: 0)
+
+        XCTAssertTrue(line.contains("via=paste"))
+        XCTAssertTrue(line.contains("total=0us"))
+    }
+
+    /// A clip recorded before the app was known still logs, rather than dropping the line.
+    func testAnUnknownDictatedAppSaysSo() {
+        let line = TextInserter.insertionLogLine(
+            app: "com.apple.Terminal", dictatedInto: nil, rule: "none", mechanism: "type",
+            targetLength: nil, caret: nil, payload: 10, chunks: 1, pause: 0)
+
+        XCTAssertTrue(line.contains("dictated-into=unknown"))
     }
 }


### PR DESCRIPTION
For #85, and it is the thing I said I would build there rather than a new idea. @alchemicwebstudio proposed it, and the order of business we agreed was this first and the pacing derived from the target size once his numbers say what the relationship is.

## Why a per-app choice rather than a better default

Typing posts one keyboard event per twenty characters. An app that redraws its whole input area on every keystroke cannot keep up: the text arrives cut off at exactly a chunk boundary, or arrives whole at a caret that has since moved, wedging the new speech inside what was already there.

Pasting sends one event and is immune. It is not the safe side though, which is the part that shapes this. The person who reported it screenshots constantly, so his clipboard is genuinely in use, and routing every dictation through it is the worse trade for him. There is no default that serves both him and someone who never touches the clipboard.

A list rather than a check on terminals, and that was his argument, not mine: the first report of this was somebody dictating fiction into an editor. We know about two apps because two people happened to look closely at text they had just dictated. A hardcoded check would have covered neither of them without a release.

## Why the pace is a dial

My first attempt derived the pause from the length of what was being inserted. He showed why that could not work: the cost it has to cover is the target redraw, which scales with what the box already holds. A short dictation into a long message therefore gets the least pacing exactly where it needs the most, and no constant fixes an inversion.

The obvious next move is to derive it from the target length instead, and that is still the plan. It is not this PR because the read comes back empty in a fair number of apps, including the Electron terminal that produced the report, so the fallback would be the main path in the one app we actually know about. Measured there at 10 ms of total pacing into a 400-character box, still corrupt.

So the number goes to the person who hits the bug, globally and per app. Handing him another constant chosen by my reasoning is exactly how the first version came to scale on the wrong quantity.

## Which app the rule is resolved from

The recorded one, not the current one. Transcription runs in the background, so by insertion time the front app may be a different one, and the rule has to be the one for the app the text is going to. The re-paste shortcut is the exception and uses the current front app, because that request has no earlier moment to refer back to.

That distinction also fixed the diagnostic line, which named the receiving app while reporting a pace chosen for the recorded one. Since that line exists to be pasted into the issue, a user who switched apps mid-transcription would have sent Terminal pace under Safari name. It now carries both, plus what the rule lookup decided, because a rule that matched and a rule that silently did not through a typo in a bundle identifier otherwise print the same thing. Pasting logs too, so a report can say which mechanism ran.

## Nothing changes without a rule

An install with an empty list takes the same branch it always did, decided by the global switch.

## Review

Ran five review dimensions over the diff with adversarial verification: 28 findings, 26 refuted. Two were never adjudicated because their verifiers errored out, so I judged those myself rather than counting them clean, and both held. They are the second commit: the diagnostic attribution above, and the fact that the trade between the two modes was written down and then only reachable as a tooltip showing whichever mode you were already on.

## Tests

12 on rule resolution and the pacing arithmetic, 5 more on the log line. Case-insensitive matching, a blank row never swallowing every app, first match wins on duplicates, the clamp at both ends, the total cap, and that raising the pace makes the cap bite sooner rather than silently doing nothing. Full suite green.

## Not verified

I have not seen the section rendered. It compiles, it is wired into Output → Delivery, and it follows the editor in `AppContextSettingsView` closely, but three attempts to screenshot it were defeated by window activation and I stopped rather than spend more on it. Worth a look before merge.
