### PR TITLE
fix(whisper): stop losing whole 30-second windows to no_timestamps

### DIFF
--- a/OpenSuperWhisper/Engines/WhisperEngine.swift
+++ b/OpenSuperWhisper/Engines/WhisperEngine.swift
@@ -166,7 +166,9 @@ class WhisperEngine: TranscriptionEngine {
         var params = WhisperFullParams()
         params.strategy = settings.useBeamSearch ? .beamSearch : .greedy
         params.nThreads = Int32(nThreads)
-        params.noTimestamps = !settings.showTimestamps
+        // Timestamp tokens are what advance whisper's sliding window: without them a window whose
+        // decode ends early is neither retried nor rewound, and seek skips the rest of it (#115).
+        params.noTimestamps = false
         params.suppressBlank = settings.suppressBlankAudio
         params.translate = settings.translateToEnglish
         let isAutoDetect = settings.selectedLanguage == "auto"
@@ -250,7 +252,7 @@ class WhisperEngine: TranscriptionEngine {
                 let t1 = context.fullGetSegmentT1(iSegment: i)
                 text += String(format: "[%.1f->%.1f] ", Float(t0) / 100.0, Float(t1) / 100.0)
             }
-            text += segmentText + "\n"
+            text += segmentText + (settings.showTimestamps ? "\n" : "")
         }
         
         let cleanedText = text


### PR DESCRIPTION
Fixes #115.

**The problem.** Every dictation with the timestamps toggle off — the default — ran whisper with `no_timestamps = true`. That flag is not a formatting switch: timestamp tokens are what advance whisper.cpp's sliding window. Without them, a window whose decode ends early is neither retried nor rewound, and `seek` jumps a full 30 s however many tokens actually came out. Three words into a thirty-second window, those three words *are* the window and the other 27 seconds are dropped — no error, no log line, and the temperature fallback does not fire because a short output is a confident one. On my machine it cost about one window in twenty. #115 has the measurements and the whisper.cpp line numbers.

**The change**, both in `WhisperEngine.transcribeAudio`:

1. `params.noTimestamps = false`, always.
2. Segments are joined with `"\n"` only when the user asked to see timestamps. Whisper used to return one segment per 30 s window because that is all `no_timestamps` ever returned; it now returns one per sentence, and a line break between each would chop dictated text into fragments. Whisper's segment text already opens with a space, so joining directly reads as prose.

**Scope.** The `showTimestamps == true` path is untouched — it already decoded with `no_timestamps = false` and still gets a line per segment. Only the default path changes, and only in that it now receives the text it was already supposed to. `speechOnlySamples`, the VAD trim and the #87 padding are not touched.

**What I checked.** With the app's exact parameters (greedy, `best_of` 1, no context, the same initial prompt with `carry_initial_prompt`) the two clips that lost windows in the app come back whole and stay whole across repeated runs once timestamps are on. `swiftc -parse` is clean and the file's diagnostics are unchanged. I have **not** built the app locally — cmake ≥ 3.30 plus both submodules was more setup than this two-line change seemed to warrant — and `SpeechTrimmingTests` / `VadIntegrationTests` cover `speechOnlySamples`, which this does not touch. Happy to build and run the suite if you would rather see that before merging.

One measurement that did not make it into this PR: with timestamps on, `speechOnlySamples`' digital-silence joins cost sentence breaks (7 punctuation marks against 12 for the raw clip and 14 for whisper.cpp's own VAD stitching, deterministic over three runs each). It is a separate change and I left it alone — details in the "Aside" at the bottom of #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
