### PR TITLE
L'éditeur de règle était rogné, et annuler laissait un badge vide

### DIFF
--- a/OpenSuperWhisper/Models/CustomDictionary.swift
+++ b/OpenSuperWhisper/Models/CustomDictionary.swift
@@ -72,6 +72,16 @@ struct CustomDictionaryEntry: Codable, Identifiable, Equatable, Hashable {
             .filter { !$0.isEmpty }
     }
 
+    /// Whether the rule says anything at all.
+    ///
+    /// A rule needs both halves to do anything: something to hear and something to write. One
+    /// without the other is a half-finished thought, not a rule, and it is what someone leaves
+    /// behind when they open the editor and change their mind.
+    var isBlank: Bool {
+        triggers.isEmpty
+            && replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Drops one phrasing, counting from the primary at 0.
     ///
     /// Removing the primary promotes the next one instead of blanking it: an entry with no

--- a/OpenSuperWhisper/Settings/DictionaryBadgeEditor.swift
+++ b/OpenSuperWhisper/Settings/DictionaryBadgeEditor.swift
@@ -71,11 +71,16 @@ struct DictionaryBadgeEditor: View {
         }
     }
 
+    /// The rule being written, before it exists.
+    ///
+    /// Adding it up front and editing it in place meant anyone who opened the editor and thought
+    /// better of it left an "empty" badge sitting in the row, which then has to be noticed and
+    /// deleted. A rule now comes into being when it says something.
+    @State private var pending: CustomDictionaryEntry?
+
     private var addBadge: some View {
         Button {
-            let entry = CustomDictionaryEntry()
-            entries.append(entry)
-            editing = entry.id
+            pending = CustomDictionaryEntry()
         } label: {
             Image(systemName: "plus")
                 .scaledFont(size: 11, weight: .semibold)
@@ -91,6 +96,24 @@ struct DictionaryBadgeEditor: View {
         }
         .buttonStyle(.plain)
         .help("Add a rule")
+        // `popover(item:)` rather than `isPresented` plus an `if let` inside. Wrapping the editor
+        // in a conditional means clearing the state removes the content before the popover
+        // dismisses it, and the editor's `onDisappear` never runs, so the rule it was holding is
+        // silently dropped. Tested: a fully filled rule vanished on close. With `item:` the
+        // editor is unconditional, exactly as it is for an existing badge, where saving has
+        // always worked.
+        .popover(item: $pending, arrowEdge: .bottom) { draft in
+            DictionaryRuleEditor(
+                initial: draft,
+                onChange: { written in
+                    // Fired as the editor goes away, so this is the finished rule rather than a
+                    // keystroke. A rule that says nothing is one somebody started and thought
+                    // better of, and it is not worth a badge.
+                    guard !written.isBlank else { return }
+                    entries.append(written)
+                },
+                onDelete: { pending = nil })
+        }
     }
 }
 
@@ -223,7 +246,11 @@ private struct DictionaryRuleEditor: View {
             .foregroundColor(STheme.hint)
         }
         .padding(14)
-        .frame(width: 280)
+        // A floor, not a fixed size. The spacing picker is a segmented control carrying three
+        // words, and its intrinsic width is more than 280 minus the padding: forced into a fixed
+        // frame the content was centred and clipped at both edges, which is why the labels on the
+        // left arrived cut in half.
+        .frame(minWidth: 280)
         // Committed when the editor goes away, not per keystroke.
         //
         // Writing on every change fed a second update pass back into the badge row: the row


### PR DESCRIPTION
Deux choses signalées sur le dictionnaire personnalisé, toutes deux vérifiées sur une build en marche.

L'éditeur arrivait coupé sur la gauche, les libellés amputés de leurs premières lettres. Le contenu a 14pt de marge et était ensuite forcé dans un cadre fixe de 280pt, mais le sélecteur d'espacement est un contrôle segmenté portant trois mots et sa largeur intrinsèque dépasse ce qu'il restait. Un contenu plus large qu'un cadre fixe se fait centrer, donc rogner des deux côtés. La largeur est un plancher maintenant, le popover s'élargit pour tenir.

Le bouton + créait aussi la règle avant que quiconque l'ait écrite, donc ouvrir l'éditeur puis se raviser laissait un badge « empty » dans la rangée, à repérer et supprimer. La règle naît maintenant quand elle dit quelque chose : l'éditeur ouvre sur un brouillon, et il n'est ajouté que s'il a un déclencheur et un remplacement.

Vérifié à l'écran : annuler n'ajoute rien, une règle remplie apparaît, et le popover n'est plus rogné. Un détail découvert en me trompant d'abord, le badge n'apparaît qu'une fois le popover complètement refermé, pas à la frappe : j'avais conclu trop vite que ça ne marchait pas en mesurant trop tôt.

Une chose que le premier essai a ratée et qui vaut d'être notée : envelopper l'éditeur dans un `if let` à l'intérieur du popover fait disparaître le contenu avant que le popover ne le congédie, donc son `onDisappear` ne part jamais et la règle qu'il tenait est perdue en silence. `popover(item:)` le garde inconditionnel, exactement comme pour un badge existant, où l'enregistrement a toujours marché.
