### PR TITLE
Un enregistrement qui meurt ne laisse plus la bulle sur « Connecting »

### DIFF
--- a/OpenSuperWhisper/AudioRecorder.swift
+++ b/OpenSuperWhisper/AudioRecorder.swift
@@ -433,12 +433,25 @@ class AudioRecorder: NSObject, ObservableObject {
 
 extension AudioRecorder: AVAudioRecorderDelegate {
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        // Only the failure is worth a line: it clears `currentRecordingURL`, which is also what the
-        // connection monitor guards on, so a take can end here and leave the wait with nothing to
-        // measure.
-        if !flag {
-            Diag.mark("recorder.didFinishRecording failed — clip discarded")
-            currentRecordingURL = nil
+        guard !flag else { return }
+        Diag.mark("recorder.didFinishRecording failed - clip discarded")
+
+        // Clearing the URL is also what the connection wait guards on, so on its own it left that
+        // timer running at 20Hz with nothing to measure and no way to reach its own timeout. The
+        // bubble then sat on "Connecting" until the app was force-quit. Reported by someone whose
+        // AirPods reconfigure the input route out from under the recorder, which is one reliable
+        // way to get here; the built-in microphone never does it, which is why it only happened
+        // with AirPods.
+        currentRecordingURL = nil
+        stopConnectionMonitoring()
+        endRecordingActivity()
+        updateRecordingState(isRecording: false, isConnecting: false)
+
+        Task { @MainActor in
+            SpectrumAnalyzer.shared.stop()
+            // Said out loud rather than left to be noticed. A take that captured nothing is
+            // otherwise indistinguishable from one the user simply has not finished (#117).
+            IndicatorWindowManager.shared.reportRecordingFailure("Recording stopped: the microphone dropped out")
         }
     }
 

--- a/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
+++ b/OpenSuperWhisper/Indicator/IndicatorWindowManager.swift
@@ -321,6 +321,17 @@ class IndicatorWindowManager: IndicatorViewDelegate {
         }
     }
 
+    /// The recording itself died, so the bubble has to stop waiting for it and say so.
+    ///
+    /// Deliberately not routed through `flash`, which steps aside for a live recording: here the
+    /// live recording is precisely what failed, and stepping aside would leave the bubble waiting
+    /// for audio that is never coming.
+    func reportRecordingFailure(_ message: String) {
+        guard let viewModel else { return }
+        viewModel.cleanup()
+        viewModel.showError(message)
+    }
+
     private func present(_ state: RecordingState, on viewModel: IndicatorViewModel) {
         switch state {
         case .error(let message): viewModel.showError(message)

--- a/OpenSuperWhisperTests/RecordingFailureTests.swift
+++ b/OpenSuperWhisperTests/RecordingFailureTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import OpenSuperWhisper
+
+/// What happens when the recording dies on its own, rather than because somebody stopped it.
+///
+/// Reported by a user whose AirPods leave the bubble on "Connecting" for ever, needing a force
+/// quit, where the built-in microphone is fine. Connecting a Bluetooth microphone reconfigures
+/// the input route under the recorder, `AVAudioRecorder` gives up, and its delegate clears the
+/// recording URL. That URL is also what the connection wait guards on, so the wait was left
+/// spinning with nothing to measure and could not even reach its own timeout.
+final class RecordingFailureTests: XCTestCase {
+
+    /// The wait only ever goes live off observed growth or elapsed time, and it can observe
+    /// neither once the file it was watching is gone. So nothing inside it can rescue a recording
+    /// that already died: the exit has to come from the failure itself.
+    func testTheWaitCannotRescueItself() {
+        // Two sightings of growth is what normally ends it.
+        XCTAssertTrue(AudioRecorder.shouldGoLive(growthObservations: 2, elapsed: 0.2))
+        // And with no growth at all, only the grace period does.
+        XCTAssertFalse(AudioRecorder.shouldGoLive(growthObservations: 0, elapsed: 0.2))
+        XCTAssertTrue(AudioRecorder.shouldGoLive(growthObservations: 0, elapsed: 5))
+    }
+
+    /// The grace period is bounded, which is what makes it a wait rather than a hang. It is also
+    /// why this bug was invisible in testing: reaching it requires the handler to keep running,
+    /// and after the failure the handler returns before ever looking at the clock.
+    func testTheGraceIsBounded() {
+        XCTAssertGreaterThan(AudioRecorder.connectionGracePeriod, 0)
+        XCTAssertLessThanOrEqual(AudioRecorder.connectionGracePeriod, 10)
+    }
+
+    /// An error must be able to take the bubble even while it is showing a live recording. Every
+    /// other message steps aside for one, which is right for a message about an earlier clip and
+    /// wrong here: the live recording is the thing that failed.
+    func testAnErrorMayTakeOverALiveRecording() {
+        // `flash` refuses these two, which is why the failure path does not go through it.
+        XCTAssertFalse(IndicatorWindowManager.messageMayTakeOver(from: .recording))
+        XCTAssertFalse(IndicatorWindowManager.messageMayTakeOver(from: .connecting))
+    }
+}


### PR DESCRIPTION
Signalé par un utilisateur dont les AirPods laissent l'app bloquée sur l'animation « Connecting » jusqu'au forçage de quitter, alors que le micro interne ne pose jamais de problème.

Connecter un micro Bluetooth reconfigure la route d'entrée sous l'enregistreur. `AVAudioRecorder` abandonne, son délégué part avec `successfully: false`, et ça effaçait `currentRecordingURL`. Or cette URL est aussi ce sur quoi la boucle d'attente se garde :

```swift
guard let self = self, let _ = self.audioRecorder, let url = self.currentRecordingURL else { return }
```

Donc la boucle continuait de tourner à 20 Hz en ressortant immédiatement, sans jamais atteindre la ligne qui regarde l'horloge. Son propre délai de grâce de trois secondes était devenu inatteignable, et rien d'autre ne remet cet état à zéro. La bulle attendait un son qui n'arriverait jamais.

Le piège était déjà écrit noir sur blanc dans le commentaire du délégué, ajouté en corrigeant #98 :

> it clears `currentRecordingURL`, which is also what the connection monitor guards on, so a take can end here and leave the wait with nothing to measure

Il n'avait simplement pas de sortie.

L'échec termine maintenant l'attente, relâche l'assertion App Nap, arrête le visualiseur et dit ce qui s'est passé. Il le dit par un chemin dédié plutôt que par `flash`, qui s'efface devant un enregistrement en cours : c'est le bon comportement pour un message concernant un clip précédent, et le mauvais ici, puisque l'enregistrement en cours est précisément ce qui a échoué.

C'est la moitié visible de #117. Une prise qui ne capture rien est sinon indiscernable d'une prise que l'utilisateur n'a pas encore terminée, et il l'apprend en constatant que ses mots manquent.

Ce que ça ne couvre pas : le même rapport mentionne un plantage et une redemande d'autorisation micro après le blocage. Je n'ai pas d'explication pour ceux-là et je ne prétends pas les corriger ici.
