### PR TITLE
La notarisation ne dépend plus d'un trousseau qu'un script ne peut pas lire

### DIFF
--- a/make_release.sh
+++ b/make_release.sh
@@ -45,6 +45,27 @@ else
     echo "✅ Using GitHub token from environment variable"
 fi
 
+# Checked before anything is built, because the failure it catches surfaces at the very end.
+# Notarisation is the last step and takes tens of minutes to reach; on 0.12.4 the credentials
+# turned out to be unreadable and the whole build was wasted discovering it. Two seconds here
+# buys that back.
+echo "🔑 Checking notarisation credentials..."
+if ! ( NOTARY_ENV="${NOTARY_ENV:-$HOME/.osw-notary.env}"; [ -f "${NOTARY_ENV}" ] && . "${NOTARY_ENV}"
+       xcrun notarytool history --keychain-profile "osw-notary" >/dev/null 2>&1 \
+       || { [ -n "${NOTARY_KEY:-}" ] && [ -f "${NOTARY_KEY}" ] \
+            && [ -n "${NOTARY_KEY_ID:-}" ] && [ -n "${NOTARY_ISSUER:-}" ]; } ); then
+    echo "❌ notarytool cannot authenticate, so this release would fail after the build."
+    echo "   Register the profile from a Terminal window:"
+    echo "     xcrun notarytool store-credentials \"osw-notary\" --key <p8> --key-id <id> --issuer <issuer>"
+    echo "   or write NOTARY_KEY / NOTARY_KEY_ID / NOTARY_ISSUER into ~/.osw-notary.env"
+    echo ""
+    echo "   Note: the keychain profile lives in the data-protection keychain and can only be"
+    echo "   read by a process able to show an authorisation prompt, so a release driven from a"
+    echo "   non-interactive shell needs the ~/.osw-notary.env route."
+    exit 1
+fi
+echo "✅ Notarisation credentials usable"
+
 echo ""
 echo "🚀 Making release for OpenSuperWhisper v${NEW_VERSION}"
 echo "   Code signing identity: ${CODE_SIGN_IDENTITY}"

--- a/notarize_app.sh
+++ b/notarize_app.sh
@@ -14,6 +14,49 @@ APP_PATH="./build/Build/Products/Release/OpenSuperWhisper.app"
 ZIP_PATH="./build/OpenSuperWhisper.zip"
 BUNDLE_ID="fr.my-monkey.opensuperwhisper"
 KEYCHAIN_PROFILE="osw-notary"
+
+# How notarytool is authenticated, worked out once and reused for both submissions.
+#
+# The keychain profile is the normal path, but it lives in the data-protection keychain, and an
+# item there can only be read by a process able to put an authorisation prompt on screen. A
+# release driven from a non-interactive shell therefore gets `errSecInteractionNotAllowed` and
+# reports it as "No Keychain password item found", which reads like the profile is missing rather
+# than unreadable. That cost a full build on 0.12.4: ten minutes of compiling before the failure
+# surfaced.
+#
+# So the App Store Connect key is accepted directly as a fallback. Put the three values in
+# ~/.osw-notary.env, outside the repo:
+#
+#   NOTARY_KEY=$HOME/.appstoreconnect/private_keys/AuthKey_XXXXXXXXXX.p8
+#   NOTARY_KEY_ID=XXXXXXXXXX
+#   NOTARY_ISSUER=00000000-0000-0000-0000-000000000000
+#
+# The .p8 is the secret and stays a file with its own permissions; the two identifiers are not
+# secret but live there anyway so nothing about the account is committed to a public repo.
+NOTARY_ENV="${NOTARY_ENV:-$HOME/.osw-notary.env}"
+[ -f "${NOTARY_ENV}" ] && . "${NOTARY_ENV}"
+
+notary_auth_args() {
+    if xcrun notarytool history --keychain-profile "${KEYCHAIN_PROFILE}" >/dev/null 2>&1; then
+        printf '%s' "--keychain-profile ${KEYCHAIN_PROFILE}"
+        return 0
+    fi
+    if [ -n "${NOTARY_KEY:-}" ] && [ -f "${NOTARY_KEY}" ] \
+       && [ -n "${NOTARY_KEY_ID:-}" ] && [ -n "${NOTARY_ISSUER:-}" ]; then
+        printf '%s' "--key ${NOTARY_KEY} --key-id ${NOTARY_KEY_ID} --issuer ${NOTARY_ISSUER}"
+        return 0
+    fi
+    return 1
+}
+
+if ! NOTARY_AUTH=$(notary_auth_args); then
+    echo "❌ notarytool has no usable credentials."
+    echo "   The keychain profile \"${KEYCHAIN_PROFILE}\" is missing or cannot be read from a"
+    echo "   non-interactive shell. Either register it from a Terminal window:"
+    echo "     xcrun notarytool store-credentials \"${KEYCHAIN_PROFILE}\" --key <p8> --key-id <id> --issuer <issuer>"
+    echo "   or write the same three values into ${NOTARY_ENV} (see the comment in this script)."
+    exit 1
+fi
 CODE_SIGN_IDENTITY="${1}"
 ARCH="${2:-arm64}"
 DEVELOPMENT_TEAM="5C67TFSJ2B"
@@ -139,7 +182,7 @@ current_dir=$(pwd)
 cd $(dirname "${APP_PATH}") && zip -r -y "${current_dir}/${ZIP_PATH}" $(basename "${APP_PATH}")
 cd "${current_dir}"
 
-xcrun notarytool submit "${ZIP_PATH}" --wait --keychain-profile "${KEYCHAIN_PROFILE}"
+xcrun notarytool submit "${ZIP_PATH}" --wait ${NOTARY_AUTH}
 xcrun stapler staple "${APP_PATH}"
 
 # Build the DMG with hdiutil (no extra tooling): the .app + an Applications symlink.
@@ -151,7 +194,7 @@ hdiutil create -volname "${APP_NAME}" -srcfolder "${DMG_STAGE}" -ov -format UDZO
 rm -rf "${DMG_STAGE}"
 
 codesign --sign "${CODE_SIGN_IDENTITY}" "${DMG_NAME}.dmg"
-xcrun notarytool submit "${DMG_NAME}.dmg" --wait --keychain-profile "${KEYCHAIN_PROFILE}"
+xcrun notarytool submit "${DMG_NAME}.dmg" --wait ${NOTARY_AUTH}
 xcrun stapler staple "${DMG_NAME}.dmg"
 
 echo "Successfully notarized ${APP_NAME} (${ARCH}) → ${DMG_NAME}.dmg"


### PR DESCRIPTION
Le profil trousseau qu'utilise `notarytool` vit dans le trousseau à protection de données, et un item de là ne peut être lu que par un processus capable d'afficher une invite d'autorisation. Une release pilotée depuis un shell non interactif reçoit donc `errSecInteractionNotAllowed`, que `notarytool` rapporte ainsi :

```
Error: No Keychain password item found for profile: osw-notary
```

Ce qui se lit comme « le profil a disparu » alors qu'il est seulement illisible. Et le réenregistrer échoue pour la même raison, avec un message différent : `An error occurred while accessing the keychain. User interaction is not allowed.`

Ça a coûté une build complète sur la 0.12.4. La notarisation est la dernière étape, donc l'échec est apparu après dix minutes de compilation. Ce qui a mis sur la piste est que `security find-generic-password -s com.apple.gke.notary.tool` ne voit pas l'item **du tout** : il n'est pas dans le trousseau fichier, donc il n'a jamais pu être « supprimé » comme je le croyais.

## Deux changements

La clé App Store Connect est acceptée directement, lue depuis `~/.osw-notary.env`, hors du dépôt. Le `.p8` reste un fichier avec ses propres permissions ; l'identifiant de clé et l'issuer ne sont pas des secrets mais vivent là quand même, pour que rien du compte ne finisse commité sur un dépôt public. Le profil trousseau reste préféré quand il fonctionne.

Et les identifiants sont vérifiés **avant** de construire quoi que ce soit, donc une release qui ne pourra pas notariser échoue en deux secondes au lieu de la fin.

## Vérifié

Les trois chemins, exécutés :

| situation | résultat |
|---|---|
| profil trousseau lisible | `--keychain-profile osw-notary`, préflight passe |
| profil absent, clé API présente | `--key … --key-id … --issuer …`, et `notarytool history` répond vraiment à Apple par ce chemin |
| ni l'un ni l'autre | refus immédiat, code 1, avec les deux marches à suivre |
