### PR TITLE
Post-record hook: add the raw transcription and the app's bundle id

### DIFF
--- a/OpenSuperWhisper/DictationPipeline.swift
+++ b/OpenSuperWhisper/DictationPipeline.swift
@@ -162,6 +162,12 @@ final class DictationPipeline: ObservableObject {
             let modelUsed = transcriptionService.lastUsedModel?.displayName ?? ModelCatalog.activeOption()?.displayName
             let wasFallback = transcriptionService.lastUsedFallback
             var text = AppPreferences.shared.cleanTranscription(rawText)
+            // The engine's own output, before the dictionary rules and any LLM cleanup, kept
+            // for the post-record hook. Tracked alongside `text` rather than read from
+            // `rawText` at the end, because the short-clip fallback below replaces the basis
+            // of the text entirely — handing a hook "No speech detected" for a clip that
+            // produced words would be worse than not telling it at all.
+            var engineText = rawText
 
             // File pass found nothing. Fall back to the live preview if it caught the words (short
             // clip); only with neither is it genuinely "no speech" — then drop it (no empty
@@ -177,6 +183,7 @@ final class DictationPipeline: ObservableObject {
                     return
                 }
                 text = fallback
+                engineText = item.streamedFallback
             }
 
             // Optional LLM cleanup (no-op when disabled; returns the raw text on failure). The
@@ -226,7 +233,10 @@ final class DictationPipeline: ObservableObject {
 
             let pasteTargetMissing = hasText ? insertText(text, targetBundleID: item.context.bundleID) : false
             if hasText {
-                PostRecordHook.runIfEnabled(text: text, audioPath: hookAudioPath, timestamp: item.startedAt, duration: 0)
+                PostRecordHook.runIfEnabled(text: text, rawText: engineText,
+                                            bundleID: item.context.bundleID,
+                                            audioPath: hookAudioPath,
+                                            timestamp: item.startedAt, duration: 0)
             }
 
             // Submit only when auto-paste actually inserted text somewhere. A short settle delay lets

--- a/OpenSuperWhisper/Settings.swift
+++ b/OpenSuperWhisper/Settings.swift
@@ -1328,6 +1328,8 @@ struct SettingsView: View {
     struct HookVariable { let name: String; let description: String }
     static let postRecordHookVariables = [
         HookVariable(name: "$OSW_TEXT", description: "the transcription"),
+        HookVariable(name: "$OSW_RAW_TEXT", description: "before the dictionary rules and AI cleanup"),
+        HookVariable(name: "$OSW_APP_BUNDLE_ID", description: "the app you dictated into"),
         HookVariable(name: "$OSW_AUDIO_PATH", description: "wav file path (when history is on)"),
         HookVariable(name: "$OSW_TIMESTAMP", description: "ISO 8601 date"),
         HookVariable(name: "$OSW_DURATION", description: "length in seconds"),
@@ -2222,7 +2224,7 @@ struct SettingsView: View {
             SSection(title: "Post-record hook") {
                 SRow(title: "Run a command after each transcription", hint: "Launch your own script when a transcription completes.") {
                     HStack(spacing: 8) {
-                        InfoButton(text: "Runs via /bin/sh -c after each successful transcription, in the background. Your command receives the data as environment variables — OSW_TEXT, OSW_AUDIO_PATH (when history is on), OSW_TIMESTAMP, OSW_DURATION — and a JSON object on stdin with the same fields. Example: echo \"$OSW_TEXT\" >> ~/dictations.txt")
+                        InfoButton(text: "Runs via /bin/sh -c after each successful transcription, in the background. Your command receives the data as environment variables — OSW_TEXT, OSW_RAW_TEXT, OSW_APP_BUNDLE_ID, OSW_AUDIO_PATH (when history is on), OSW_TIMESTAMP, OSW_DURATION — and a JSON object on stdin with the same fields. Example: echo \"$OSW_TEXT\" >> ~/dictations.txt")
                         SToggle(isOn: $viewModel.postRecordHookEnabled)
                     }
                 }

--- a/OpenSuperWhisper/Utils/PostRecordHook.swift
+++ b/OpenSuperWhisper/Utils/PostRecordHook.swift
@@ -5,41 +5,78 @@ import Foundation
 ///
 /// The command runs via `/bin/sh -c`, fire-and-forget (never blocks the UI). The transcription
 /// data is exposed two ways so any script can consume it:
-/// - environment variables: `OSW_TEXT`, `OSW_AUDIO_PATH`, `OSW_TIMESTAMP` (ISO 8601), `OSW_DURATION`
-/// - a JSON object on stdin: `{ "text", "audioPath", "timestamp", "duration" }`
+/// - environment variables: `OSW_TEXT`, `OSW_RAW_TEXT`, `OSW_APP_BUNDLE_ID`, `OSW_AUDIO_PATH`,
+///   `OSW_TIMESTAMP` (ISO 8601), `OSW_DURATION`
+/// - a JSON object on stdin: `{ "text", "rawText", "bundleID", "audioPath", "timestamp", "duration" }`
 enum PostRecordHook {
-    static func runIfEnabled(text: String, audioPath: String?, timestamp: Date, duration: Double) {
+
+    /// What the hook is handed, built once and exposed both ways. Pure, so the shape a script
+    /// depends on is unit-tested instead of only being exercised by launching a process.
+    struct Payload {
+        /// The text the user received: after the dictionary rules and any LLM cleanup.
+        let text: String
+        /// The same dictation as the engine produced it, before either of those. Equal to
+        /// `text` when neither changed anything.
+        let rawText: String
+        /// The app that was frontmost when recording started — the one the text was dictated
+        /// into, and the one the app-aware formatting rules were keyed off.
+        let bundleID: String?
+        let audioPath: String?
+        let timestamp: Date
+        let duration: Double
+
+        var isoTimestamp: String { ISO8601DateFormatter().string(from: timestamp) }
+        var durationString: String { String(format: "%.2f", duration) }
+
+        var environment: [String: String] {
+            [
+                "OSW_TEXT": text,
+                "OSW_RAW_TEXT": rawText,
+                "OSW_APP_BUNDLE_ID": bundleID ?? "",
+                "OSW_AUDIO_PATH": audioPath ?? "",
+                "OSW_TIMESTAMP": isoTimestamp,
+                "OSW_DURATION": durationString,
+            ]
+        }
+
+        var json: [String: Any] {
+            [
+                "text": text,
+                "rawText": rawText,
+                "bundleID": bundleID ?? "",
+                "audioPath": audioPath ?? "",
+                "timestamp": isoTimestamp,
+                "duration": duration,
+            ]
+        }
+    }
+
+    static func runIfEnabled(text: String, rawText: String, bundleID: String?,
+                             audioPath: String?, timestamp: Date, duration: Double) {
         let prefs = AppPreferences.shared
         guard prefs.postRecordHookEnabled else { return }
         let command = prefs.postRecordHookCommand.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !command.isEmpty else { return }
 
-        let isoTimestamp = ISO8601DateFormatter().string(from: timestamp)
-        let durationString = String(format: "%.2f", duration)
+        let payload = Payload(text: text, rawText: rawText, bundleID: bundleID,
+                              audioPath: audioPath, timestamp: timestamp, duration: duration)
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", command]
 
         var env = ProcessInfo.processInfo.environment
-        env["OSW_TEXT"] = text
-        env["OSW_AUDIO_PATH"] = audioPath ?? ""
-        env["OSW_TIMESTAMP"] = isoTimestamp
-        env["OSW_DURATION"] = durationString
+        for (key, value) in payload.environment {
+            env[key] = value
+        }
         process.environment = env
 
-        let payload: [String: Any] = [
-            "text": text,
-            "audioPath": audioPath ?? "",
-            "timestamp": isoTimestamp,
-            "duration": duration,
-        ]
         let stdin = Pipe()
         process.standardInput = stdin
 
         do {
             try process.run()
-            if let json = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]) {
+            if let json = try? JSONSerialization.data(withJSONObject: payload.json, options: [.prettyPrinted]) {
                 stdin.fileHandleForWriting.write(json)
             }
             try? stdin.fileHandleForWriting.close()

--- a/OpenSuperWhisperTests/PostRecordHookPayloadTests.swift
+++ b/OpenSuperWhisperTests/PostRecordHookPayloadTests.swift
@@ -1,0 +1,87 @@
+//
+//  PostRecordHookPayloadTests.swift
+//  OpenSuperWhisperTests
+//
+//  Covers the data the post-record hook hands to a user's script. A hook consumer's script
+//  breaks silently if a key is renamed or dropped, so the shape is pinned here rather than
+//  only exercised by launching a process.
+//
+
+import XCTest
+@testable import OpenSuperWhisper
+
+final class PostRecordHookPayloadTests: XCTestCase {
+
+    private let timestamp = Date(timeIntervalSince1970: 1_789_236_556)
+
+    private func payload(text: String = "We should build the harness first.",
+                         rawText: String = "um we should build the harness first",
+                         bundleID: String? = "com.tinyspeck.slackmacgap",
+                         audioPath: String? = "/tmp/clip.wav") -> PostRecordHook.Payload {
+        PostRecordHook.Payload(text: text, rawText: rawText, bundleID: bundleID,
+                               audioPath: audioPath, timestamp: timestamp, duration: 15.38)
+    }
+
+    /// The four fields scripts already depend on keep their names and their meaning.
+    func testExistingFieldsAreUnchanged() {
+        let env = payload().environment
+
+        XCTAssertEqual(env["OSW_TEXT"], "We should build the harness first.")
+        XCTAssertEqual(env["OSW_AUDIO_PATH"], "/tmp/clip.wav")
+        XCTAssertEqual(env["OSW_TIMESTAMP"], ISO8601DateFormatter().string(from: timestamp))
+        XCTAssertEqual(env["OSW_DURATION"], "15.38")
+    }
+
+    func testRawTextIsTheEngineOutputBeforeCleanup() {
+        XCTAssertEqual(payload().environment["OSW_RAW_TEXT"],
+                       "um we should build the harness first")
+    }
+
+    func testBundleIDIsTheAppDictatedInto() {
+        XCTAssertEqual(payload().environment["OSW_APP_BUNDLE_ID"],
+                       "com.tinyspeck.slackmacgap")
+    }
+
+    /// A missing bundle id is an empty variable, matching how `OSW_AUDIO_PATH` already behaves
+    /// — a script reads "" rather than the variable vanishing from the environment.
+    func testAMissingBundleIDIsAnEmptyString() {
+        let env = payload(bundleID: nil, audioPath: nil).environment
+
+        XCTAssertEqual(env["OSW_APP_BUNDLE_ID"], "")
+        XCTAssertEqual(env["OSW_AUDIO_PATH"], "")
+    }
+
+    /// With no dictionary rules and no LLM cleanup the two texts are the same, and a script
+    /// can tell "nothing changed it" from "it was rewritten" by comparing them.
+    func testRawTextEqualsTextWhenNothingRewroteIt() {
+        let same = payload(text: "test paste loop 1 2 3", rawText: "test paste loop 1 2 3")
+
+        XCTAssertEqual(same.environment["OSW_TEXT"], same.environment["OSW_RAW_TEXT"])
+    }
+
+    func testJSONCarriesTheSameSixFields() throws {
+        let data = try JSONSerialization.data(withJSONObject: payload().json)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["text"] as? String, "We should build the harness first.")
+        XCTAssertEqual(object["rawText"] as? String, "um we should build the harness first")
+        XCTAssertEqual(object["bundleID"] as? String, "com.tinyspeck.slackmacgap")
+        XCTAssertEqual(object["audioPath"] as? String, "/tmp/clip.wav")
+        XCTAssertEqual(object["timestamp"] as? String,
+                       ISO8601DateFormatter().string(from: timestamp))
+        XCTAssertEqual(object["duration"] as? Double, 15.38)
+        XCTAssertEqual(object.count, 6)
+    }
+
+    /// The JSON is what a script parses, so it must survive serialization with a nil bundle id.
+    func testJSONSerializesWithNoBundleIDAndNoAudio() throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: payload(bundleID: nil, audioPath: nil).json)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["bundleID"] as? String, "")
+        XCTAssertEqual(object["audioPath"] as? String, "")
+    }
+}


### PR DESCRIPTION
The post-record hook is handed the text after the dictionary rules and the LLM cleanup have
run, and it is not told which app the dictation went into. That leaves a hook consumer unable
to answer two ordinary questions: what did cleanup actually change, and where was this
dictated?

Both values already exist at the call site. This passes them through.

### What changes

Two new fields, in the environment and in the JSON on stdin:

| Variable | JSON key | What it is |
|---|---|---|
| `OSW_RAW_TEXT` | `rawText` | The engine's output, before the dictionary rules and before LLM cleanup. |
| `OSW_APP_BUNDLE_ID` | `bundleID` | The app that was frontmost when recording started. |

### Why a hook consumer wants them

**The raw text makes cleanup visible.** Today a script receives one string and cannot tell
whether anything touched it. With both, comparing them answers it exactly: equal means nothing
changed it, different means the dictionary rules or the model did. That is useful for anyone
tuning an app-context profile or a custom dictionary, because right now the only way to see
the effect is to turn the feature off and dictate the same sentence again.

**The bundle id is the one the app itself used.** A script can already ask the system which app
is frontmost, but that answer is taken *after* the text has been inserted, while the formatting
rules are keyed off the app that was frontmost when recording *started*
(`DictationPipeline.swift`). Those differ whenever the user switches app while a clip is still
being transcribed — and then the script records the wrong app and, if it infers anything from
it, the wrong profile. Passing the value the app already decided with removes the guess.

### What does not change

Nothing for existing hooks. `OSW_TEXT`, `OSW_AUDIO_PATH`, `OSW_TIMESTAMP` and `OSW_DURATION`
keep their names and their meaning, and a missing bundle id is an empty string, matching how
`OSW_AUDIO_PATH` already behaves when history is off. A script that ignores the new fields
carries on exactly as before.

### Two implementation notes

**The short-clip fallback.** When the file pass finds nothing and the live preview rescued the
words, the basis of the text is replaced. So the raw value is tracked alongside `text` rather
than read from `rawText` at the end — handing a hook `No speech detected` for a clip that
produced words would be worse than not telling it at all.

**A small refactor for testability.** The payload moved into a pure `Payload` struct so its
shape can be unit-tested without launching a process, following the pure-logic pattern already
used in `LLMPostProcessor`. A renamed or dropped key breaks a user's script silently, which
seemed worth pinning down. `PostRecordHookPayloadTests` covers the six fields, the empty-string
cases, and that raw equals text when nothing rewrote it.

The new variables are listed in `SettingsView.postRecordHookVariables` and in the hook's info
text, so they appear in the app's own help.

### Testing

Unit tests added for the payload shape. I have not built or run the app locally, so the Swift
tests here have not been executed — I would rather say that than imply a green run. The change
is confined to the hook payload and one call site.
